### PR TITLE
Use bin/minio for starting up minio

### DIFF
--- a/bin/minio
+++ b/bin/minio
@@ -1,0 +1,36 @@
+#!/usr/bin/env ruby
+require 'fileutils'
+require 'figaro'
+
+APP_ROOT = File.expand_path('..', __dir__)
+
+# Use Figaro to load our environment variables
+Figaro.application = Figaro::Application.new(
+  environment: ENV.fetch('RAILS_ENV', 'development'),
+  path: Pathname.new(APP_ROOT).join('config').join('application.yml')
+)
+Figaro.load
+
+MINIO_ACCESS_KEY = ENV.fetch('MINIO_ACCESS_KEY', 'asdf')
+MINIO_SECRET_KEY = ENV.fetch('MINIO_SECRET_KEY', 'asdfasdf')
+MINIO_PORT = ENV.fetch('MINIO_PORT', '9000')
+
+def system!(*args)
+  command = args.join(" ")
+  system(command) || abort("\n== Command #{command} failed ==")
+end
+
+FileUtils.chdir APP_ROOT do
+  # Starts up minio for testing
+  system! %W{
+    echo 
+      "Starting up minio on port #{MINIO_PORT} with key #{MINIO_ACCESS_KEY} and secret key #{MINIO_SECRET_KEY}"
+  }
+  system! %W{
+    docker run
+      -e MINIO_ACCESS_KEY=#{MINIO_ACCESS_KEY}
+      -e MINIO_SECRET_KEY=#{MINIO_SECRET_KEY}
+      -p #{MINIO_PORT}:#{MINIO_PORT}
+      minio/minio:latest server --compat /data
+  }
+end

--- a/config/samples/application.yml
+++ b/config/samples/application.yml
@@ -11,19 +11,16 @@
 # To enable uploading via Minio, ensure that minio is installed. See:
 #   https://github.com/minio/minio
 #
-# Startup the service locally with:
-#   docker run
-#     -e MINIO_ACCESS_KEY=asdf
-#     -e MINIO_SECRET_KEY=asdfasdf
-#     -p 9000:9000 
-#     minio/minio:latest server --compat /data
+# You can optionally set a MINIO_ACCESS_KEY, MINIO_SECRET_KEY, and MINIO_PORT, or omit them and it will use defaults.
+# Start up minio with:
+#   bin/minio
 #
 # The corresponding environment configuation would look like:
 #
-#   S3_ENDPOINT:           "http://127.0.0.1:9000"
+#   S3_ENDPOINT:           "http://127.0.0.1:9000" # Port should be the same as MINIO_PORT
 #   AWS_BUCKET:            "scholarsphere"
-#   AWS_ACCESS_KEY_ID:     "asdf"     # this is MINIO_ACCESS_KEY
-#   AWS_SECRET_ACCESS_KEY: "asdfasdf" # this is MINIO_SECRET_KEY
+#   AWS_ACCESS_KEY_ID:     "asdf"     # this should be the same as MINIO_ACCESS_KEY
+#   AWS_SECRET_ACCESS_KEY: "asdfasdf" # this should be the same as MINIO_SECRET_KEY
 #   AWS_REGION:            "us-east-1"
 #
 # You will need to create a "scholarsphere" bucket in your Minio instance. This can be done via the web interface.
@@ -36,6 +33,9 @@ SOLR_COLLECTION: scholarsphere
 SOLR_PORT: 8983
 # SOLR_CONFIG_DIR: solr/conf
 # SOLR_NUM_SHARDS: 1
+# MINIO_ACCESS_KEY: "asdf"
+# MINIO_SECRET_KEY: "asdfasdf"
+# MINIO_PORT: "9000"
 
 # If the oauth servers authorize path differs from /oauth/authorize, you can set that value here
 # Under normal circumstances, this shouldn't need changing


### PR DESCRIPTION
Creates a minio executable to start the minio server and hooks into our application.yml file for the config options.