### PR TITLE
[WIP] Start dependencies

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,12 +1,41 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true.
 require 'fileutils'
+require 'figaro'
+require 'net/http'
+require 'uri'
 
 # path to your application root.
 APP_ROOT = File.expand_path('..', __dir__)
 
-def system!(*args)
-  system(*args) || abort("\n== Command #{args} failed ==")
+def wait_for_solr(solr_host, solr_port)
+  uri = URI.parse("http://#{solr_host}:#{solr_port}/")
+  begin
+    retries ||= 0
+    Net::HTTP.get(uri)
+  rescue Errno::ECONNREFUSED, EOFError => e
+    sleep(1)
+    print '.'
+    retry if (retries += 1) < 12
+    raise e
+  end
+  puts '.'
 end
+
+def system!(*args)
+  command = args.join(' ')
+  system(command) || abort("\n== Command #{args} failed ==")
+end
+
+Figaro.application = Figaro::Application.new(
+  environment: ENV.fetch('RAILS_ENV', 'development'),
+  path: Pathname.new(APP_ROOT).join('config').join('application.yml')
+)
+fig = Figaro.load
+
+# Populate an array of environment variables to pass to docker-compose
+env_vars = []
+fig.each { |k, v| env_vars.push("#{k}=#{v}") }
 
 FileUtils.chdir APP_ROOT do
   # This script is a way to setup or update your development environment automatically.
@@ -17,6 +46,25 @@ FileUtils.chdir APP_ROOT do
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
 
+  puts '== Starting up Minio, and Solr =='
+  system! env_vars + %w{
+    docker-compose up -d minio solr
+  }
+
+  puts '== Waiting for Solr =='
+  solr_host = fig.fetch('SOLR_HOST', 'localhost')
+  solr_port = fig.fetch('SOLR_PORT', '8983')
+  wait_for_solr(solr_host, solr_port)
+
+  puts '== Initalizing Solr =='
+
+  system! %w{
+    bundle exec rake solr:init
+  }
+  system! %w{
+    RAILS_ENV=test bundle exec rake solr:init
+  }
+
   # Install JavaScript dependencies
   # system('bin/yarn')
 
@@ -25,12 +73,12 @@ FileUtils.chdir APP_ROOT do
   #   FileUtils.cp 'config/database.yml.sample', 'config/database.yml'
   # end
 
-  puts "\n== Preparing database =="
-  system! 'bin/rails db:prepare'
+  # puts "\n== Preparing database =="
+  # system! 'bin/rails db:prepare'
 
-  puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  # puts "\n== Removing old logs and tempfiles =="
+  # system! 'bin/rails log:clear tmp:clear'
 
-  puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
+  # puts "\n== Restarting application server =="
+  # system! 'bin/rails restart'
 end

--- a/bin/setup
+++ b/bin/setup
@@ -73,12 +73,12 @@ FileUtils.chdir APP_ROOT do
   #   FileUtils.cp 'config/database.yml.sample', 'config/database.yml'
   # end
 
-  # puts "\n== Preparing database =="
-  # system! 'bin/rails db:prepare'
+  puts "\n== Preparing database =="
+  system! 'bin/rails db:prepare'
 
-  # puts "\n== Removing old logs and tempfiles =="
-  # system! 'bin/rails log:clear tmp:clear'
+  puts "\n== Removing old logs and tempfiles =="
+  system! 'bin/rails log:clear tmp:clear'
 
-  # puts "\n== Restarting application server =="
-  # system! 'bin/rails restart'
-end
+  puts "\n== Restarting application server =="
+  system! 'bin/rails restart'
+en

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,14 +26,14 @@ services:
     volumes:
     - minio-data:/data
     environment: 
-      MINIO_ACCESS_KEY: scholarsphere
-      MINIO_SECRET_KEY: scholarsphere
+      MINIO_ACCESS_KEY: ${AWS_ACCESS_KEY_ID-:scholarsphere}
+      MINIO_SECRET_KEY: ${AWS_SECRET_ACCESS_KEY:-scholarsphere}
     ports:
-    - 9002:9002
+    - ${MINIO_PORT:-9000}:9000
     entrypoint:
     - /bin/sh
     - -c 
-    - mkdir -p /data/scholarsphere; minio --compat server --address ':9002' /data
+    - mkdir -p /data/scholarsphere; minio --compat server --address ':9000' /data
   solr:
     image: solr:8.2.0-slim
     restart: always


### PR DESCRIPTION
This is a work in progress, a small wrapper around `docker-compose` that pulls in config from `figaro` and then runs the docker compose up phase for _only_ minio and solr. 

TODO:

- a developer has to run `docker-compose down` in `APP_ROOT` when they are done working. I don't think or know if this should be another binstub or not

- if a developer wants to run database or rails server within docker this script isn't very useful to them. they can, however, run the commands by hand

- we don't check if docker or docker-compose is installed. I don't know how clever this script should be, with cleverness comes complexity and what not.

