### PR TITLE
Removing profile option

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,3 @@
 --color
 --format documentation
---profile
 --require spec_helper


### PR DESCRIPTION
The profile option was added to our config back when we were having really slow test problems. Now that it isn't an issue anymore, the tag is generating a lot of extra output each time tests are run. This creates unnecessary background "noise" so let's turn it off and add it when we need to really profile the test suite.