### PR TITLE
Removing solr wrapper

### DIFF
--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -1,7 +1,0 @@
-# Place any default configuration for solr_wrapper here
-# port: 8983
-instance_dir: tmp/solr-development
-download_dir: tmp
-collection:
-  dir: solr/conf/
-  name: blacklight-core

--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,6 @@ group :development, :test do
   gem 'niftany'
   gem 'pry-byebug'
   gem 'pry-rails'
-  gem 'solr_wrapper', '>= 0.3'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,7 +309,6 @@ GEM
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
-    retriable (3.1.2)
     roda (3.25.0)
       rack
     rsolr (2.2.1)
@@ -394,11 +393,6 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
     smart_properties (1.15.0)
-    solr_wrapper (2.1.0)
-      faraday
-      retriable
-      ruby-progressbar
-      rubyzip
     spring (2.1.0)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -489,7 +483,6 @@ DEPENDENCIES
   shoulda-matchers (~> 3.1)
   shrine (~> 3.0)
   simplecov
-  solr_wrapper (>= 0.3)
   spring
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)

--- a/Rakefile
+++ b/Rakefile
@@ -6,5 +6,3 @@
 require_relative 'config/application'
 
 Rails.application.load_tasks
-
-require 'solr_wrapper/rake_task' unless Rails.env.production?


### PR DESCRIPTION
Solr is now managed as a docker install, so we don't this gem anymore.