### PR TITLE
Uses right option for authorize_url, defaults it to /oauth/authorize

### DIFF
--- a/config/samples/application.yml
+++ b/config/samples/application.yml
@@ -37,6 +37,10 @@ SOLR_PORT: 8983
 # SOLR_CONFIG_DIR: solr/conf
 # SOLR_NUM_SHARDS: 1
 
+# If the oauth servers authorize path differs from /oauth/authorize, you can set that value here
+# Under normal circumstances, this shouldn't need changing
+# OAUTH_AUTHORIZE_URL: "/oauth/authorize"
+
 development:
   POSTGRES_DB: "scholarsphere_4_development"
   OAUTH_APP_ID: ""

--- a/lib/omniauth/strategies/psu.rb
+++ b/lib/omniauth/strategies/psu.rb
@@ -9,7 +9,7 @@ module OmniAuth
 
       option :client_options,
              site: ENV['OAUTH_APP_URL'],
-             authorize_path: '/oauth/authorize'
+             authorize_url: ENV.fetch('OAUTH_AUTHORIZE_URL', 'oauth/authorize')
 
       uid do
         raw_info['uid']


### PR DESCRIPTION
Fixes #64 

Documents `OAUTH_AUTHORIZE_URL` and defaults the option in Psu:OmniAuth::Strategies::OAuth2