### PR TITLE
Refactor JS feature specs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -70,27 +70,26 @@ steps:
   <<: *test_common
   commands:
     - export DOCKER_HOST=unix:///var/run/host.sock
-    - apk add bind-tools
-    - export POSTGRES_HOST=$(dig +short postgres)
-    - export MINIO_HOST=$(dig +short minio)
-    - export SOLR_HOST=$(dig +short solr)
-    - docker run
-        --net host
-        -e S3_ENDPOINT=http://$MINIO_HOST:9000
+    - docker create --name test-$DRONE_BUILD_NUMBER --network drone
+        -e S3_ENDPOINT=http://minio:9000
         -e AWS_BUCKET=scholarsphere
         -e AWS_ACCESS_KEY_ID=scholarsphere
         -e AWS_SECRET_ACCESS_KEY=scholarsphere
         -e AWS_REGION=us-east-1
+        -e APP_HOST=test-$DRONE_BUILD_NUMBER
         -e POSTGRES_USER=scholarsphere
+        -e SELENIUM_URL=http://selenium:4444/wd/hub
         -e POSTGRES_PASSWORD=scholarsphere
         -e POSTGRES_DB=scholarsphere
-        -e POSTGRES_HOST=$POSTGRES_HOST
-        -e SOLR_HOST=$SOLR_HOST
+        -e POSTGRES_HOST=postgres
+        -e SOLR_HOST=solr
         -e CC_TEST_REPORTER_ID=$CC_TEST_REPORTER_ID
         -e DRONE_COMMIT_SHA=$DRONE_COMMIT_SHA
         -e DRONE_BRANCH=$DRONE_BRANCH
         -e DRONE_BUILD_STARTED=$DRONE_BUILD_STARTED
         harbor.dsrd.libraries.psu.edu/library/scholarsphere:$DRONE_BUILD_NUMBER-rspec
+    - docker network connect $DOCKER_NETWORK_ID test-$DRONE_BUILD_NUMBER
+    - docker start test-$DRONE_BUILD_NUMBER -a
 
 - name: push
   image: docker
@@ -160,6 +159,8 @@ steps:
       - tag
 
 services:
+- name: selenium
+  image: selenium/standalone-chrome:3.141.59-xenon
 - name: solr
   image: solr:8.2.0-slim
   entrypoint:
@@ -188,6 +189,6 @@ volumes:
     path: /var/run/docker.sock
 ---
 kind: signature
-hmac: f75878a49f4ed82f22e4892a246b2ca3d8ad48716fdbf54b9f0d7cf8ded85a0c
+hmac: d630d78dc587fbcd7da5a2b0247b3a280c709ae1d9b05f5a5cc67a053e4dabc3
 
 ...

--- a/spec/features/dashboard/file_management_spec.rb
+++ b/spec/features/dashboard/file_management_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Dashboard File Management', with_user: :user do
     end
   end
 
-  it 'renames a file inline with JavaScript', with_driver: :selenium_chrome_headless, unless: ci_build? do
+  it 'renames a file inline with JavaScript', js: true do
     visit(dashboard_work_version_file_list_path(work_version))
 
     edited_filename = "EDITED#{File.extname(file_membership.title)}"

--- a/spec/features/publish_new_work_spec.rb
+++ b/spec/features/publish_new_work_spec.rb
@@ -2,12 +2,12 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Publishing a new work', unless: ci_build? do
+RSpec.describe 'Publishing a new work' do
   let(:user) { create(:user) }
   let(:metadata) { MetadataFactory.new.work_version }
   let(:updated_metadata) { MetadataFactory.new.work_version }
 
-  it 'routes the user through the workflow', with_user: :user, with_driver: :selenium_chrome_headless do
+  it 'routes the user through the workflow', with_user: :user, js: true do
     visit(new_dashboard_work_path)
     fill_in('Title', with: metadata[:title])
     click_button('Create Work')

--- a/spec/support/capybara_drivers.rb
+++ b/spec/support/capybara_drivers.rb
@@ -1,46 +1,29 @@
 # frozen_string_literal: true
 
-module CapybaraDrivers
-  def sign_in(user: nil, driver:)
-    assign_current_driver(driver)
-    OmniAuth.config.test_mode = true
-    OmniAuth.config.mock_auth[:psu] = mock_auth_hash(user) if user.present?
-  end
-
-  private
-
-    def assign_current_driver(driver)
-      register_driver(driver) unless Capybara.drivers.include?(driver)
-      Capybara.current_driver = driver
-    end
-
-    def register_driver(driver)
-      Capybara.register_driver driver do |app|
-        capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(chromeOptions: chrome_options)
-        Capybara::Selenium::Driver.new(app, browser: :chrome, desired_capabilities: capabilities)
-      end
-    end
-
-    def chrome_options
-      { args: ['no-sandbox', 'disable-gpu', 'window-size=1024,768', 'single-process'] }
-    end
-
-    def mock_auth_hash(user)
-      build :psu_oauth_response, access_id: user.access_id
-    end
+RSpec.configure do |_config|
+  Capybara.javascript_driver = if ci_build?
+                                 :selenium_remote
+                               else
+                                 :selenium_chrome_headless
+                                 # :selenium_chrome # For debugging in dev
+                               end
 end
 
-RSpec.configure do |config|
-  config.before(type: :feature) do |example|
-    driver = example.metadata.fetch(:with_driver, Capybara.current_driver)
-
-    if example.metadata.key?(:with_user)
-      sign_in(user: send(example.metadata.fetch(:with_user)), driver: driver)
-    else
-      sign_in(driver: driver)
-    end
-  end
-
-  config.include CapybaraDrivers, type: :feature
-  config.include ActionView::RecordIdentifier, type: :feature
+Capybara.register_driver :selenium_remote do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: { args: [
+      'headless',
+      'no-sandbox',
+      'disable-gpu',
+      'window-size=1024,768',
+      'single-process'
+    ] }
+  )
+  Capybara.server_port = '3002'
+  Capybara.server_host = '0.0.0.0'
+  Capybara.app_host = "http://#{ENV['APP_HOST']}:#{Capybara.server_port}"
+  Capybara::Selenium::Driver.new(app,
+                                 browser: :remote,
+                                 desired_capabilities: capabilities,
+                                 url: ENV['SELENIUM_URL'].to_s)
 end

--- a/spec/support/cleaner.rb
+++ b/spec/support/cleaner.rb
@@ -16,8 +16,11 @@ RSpec.configure do |config|
     DatabaseCleaner.clean_with(:truncation)
   end
 
-  config.before do
-    DatabaseCleaner.strategy = :truncation
+  config.before do |example|
+    # Use transaction strategy by default because it's so much faster. However,
+    # it's not compatible with in-browser javascript testing, so fall back to
+    # truncation if the spec that we're about to run is tagged with :js.
+    DatabaseCleaner.strategy = example.metadata[:js] ? :truncation : :transaction
     DatabaseCleaner.start
   end
 

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module FeatureHelpers
+  def sign_in(user: nil)
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:psu] = mock_auth_hash(user) if user.present?
+  end
+
+  private
+
+    def mock_auth_hash(user)
+      build :psu_oauth_response, access_id: user.access_id
+    end
+end
+
+RSpec.configure do |config|
+  config.before(type: :feature) do |example|
+    if example.metadata.key?(:with_user)
+      sign_in(user: send(example.metadata.fetch(:with_user)))
+    else
+      sign_in
+    end
+  end
+
+  config.include FeatureHelpers, type: :feature
+  config.include ActionView::RecordIdentifier, type: :feature
+end


### PR DESCRIPTION
Capybara has the notion of a javascript driver, and it's possible to set the default one to whatever you want. By registering our selenium_chrome_headless driver as the default one, then you can tag your specs with `js: true` as opposed to `with_driver: :selenium_chrome_headless` which is a heck of a lot easier to remember.

This also allowed me to conditionally switch between the `transaction` and `truncation` DatabaseCleaner strategy. Transaction is way faster but doesn't play nice with headless chrome; truncation is way slower but does play nice with headless chrome. By Swapping the two of them out, we get a big speed boost in the spec runtimes (_especially_ for non-feature specs, which comprise most of our tests!). See the lengthy commit message for more deets

Fixes #67 