### PR TITLE
Diff model

### DIFF
--- a/app/services/metadata_diff.rb
+++ b/app/services/metadata_diff.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# @abstract Returns a hash with the differences between two classes that contain a `metadata` json accessors.
+# @example Given two objects with two different titles
+#   >  MetadataDiff(obj1, obj2)
+#   => { title: ["Object 1 Title", "Object 2 Title"] }
+#
+# Accessors that have the same values will be omitted from the diff hash
+class MetadataDiff
+  attr_reader :opts
+
+  # @param [WorkVersion, Object]
+  # @param [WorkVersion, Object]
+  # @param [Hash] opts
+  # @example opts[:separator] will concatenate multiple values together. Default is ", "
+  def self.call(*args)
+    new(*args).hash
+  end
+
+  def initialize(*args)
+    @opts = args[2] || {}
+    (args[0].metadata.keys + args[1].metadata.keys).uniq.map do |key|
+      first_value = stringify(args[0].metadata[key])
+      second_value = stringify(args[1].metadata[key])
+      hash[key] = [first_value, second_value] unless first_value == second_value
+    end
+  end
+
+  def hash
+    @hash ||= ActiveSupport::HashWithIndifferentAccess.new
+  end
+
+  private
+
+    def stringify(terms)
+      Array.wrap(terms).join(separator)
+    end
+
+    def separator
+      @separator ||= opts.fetch(:separator, ', ')
+    end
+end

--- a/spec/services/metadata_diff_spec.rb
+++ b/spec/services/metadata_diff_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MetadataDiff do
+  subject(:diff) { described_class.call(first, second) }
+
+  let(:work) { build(:work, versions_count: 2, has_draft: false) }
+  let(:first) { work.versions[0] }
+  let(:second) { work.versions[1] }
+
+  it { is_expected.to be_a(HashWithIndifferentAccess) }
+
+  context 'when the titles are different' do
+    its(:keys) { is_expected.to contain_exactly('title') }
+
+    it 'returns a diff of the titles' do
+      expect(diff[:title]).to eq([first.title, second.title])
+    end
+  end
+
+  context 'with the same titles and different keywords' do
+    let(:first) { build(:work_version, title: 'The Same Title', keywords: ['foo', 'bar']) }
+    let(:second) { build(:work_version, title: 'The Same Title', keywords: ['foo', 'baz']) }
+
+    its(:keys) { is_expected.to contain_exactly('keywords') }
+
+    it 'returns only the terms that are different' do
+      expect(diff[:title]).to be_nil
+      expect(diff[:keywords]).to eq(['foo, bar', 'foo, baz'])
+    end
+  end
+
+  context 'with a different number of values for the same term' do
+    let(:first) { build(:work_version, title: 'The Same Title', keywords: ['foo', 'bar']) }
+    let(:second) { build(:work_version, title: 'The Same Title', keywords: ['baz']) }
+
+    its(:keys) { is_expected.to contain_exactly('keywords') }
+
+    it 'returns diffs that include the deleted term' do
+      expect(diff[:title]).to be_nil
+      expect(diff[:keywords]).to eq(['foo, bar', 'baz'])
+    end
+  end
+
+  context 'with a custom separator' do
+    subject(:diff) { described_class.call(first, second, separator: '; ') }
+
+    let(:first) { build(:work_version, title: 'The Same Title', keywords: ['foo', 'bar']) }
+    let(:second) { build(:work_version, title: 'The Same Title', keywords: ['foo', 'baz']) }
+
+    it 'shows the diff with the separator' do
+      expect(diff[:keywords]).to eq(['foo; bar', 'foo; baz'])
+    end
+  end
+end


### PR DESCRIPTION
Model diffs of two different objects, according to their metadata.

ping @rschenk Is this what you had in mind? It's tied to `metadata` so attributes outside of that wouldn't get diffed.