### PR TITLE
Feature test uses abiguous search for a link

### DIFF
--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -45,9 +45,7 @@ RSpec.describe 'Blacklight catalog page' do
     end
 
     # Show a random record
-    within(page.all('h3', text: record[:title]).first) do
-      click_link(record[:title])
-    end
+    visit(solr_document_path(record[:uuid]))
     expect(page).to have_blacklight_label('title_tesim')
     expect(page).to have_blacklight_label('aasm_state_tesim')
     expect(page).to have_blacklight_label('keywords_tesim')

--- a/spec/support/faker.rb
+++ b/spec/support/faker.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.before :suite do
+    if ENV.key?('FAKER_SEED')
+      puts "Running tests with Faker seed #{ENV['FAKER_SEED']}"
+      Faker::Config.random = Random.new(ENV['FAKER_SEED'].to_i)
+    end
+  end
+
+  config.after :suite do
+    puts "Test ran with Faker seed #{Faker::Config.random.seed}"
+  end
+end


### PR DESCRIPTION
The catalog feature test was failing at random times. What appears to be the problem was finding the link to click on in the search results. Instead of searching for the link, we'll visit the page directly.

This also includes an added feature to setting up Faker. We can specify an specific seed in case the randomized results of the Faker gem are affecting test results. After each test run, Faker's own randomized seed will be reported. If we want to re-run the same test using the exact same random output, we can provide the seed as follows:

    FAKER_SEED=1234 bundle exec rspec test_spec.rb