### PR TITLE
Single-value fields can be blanked-out

### DIFF
--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -86,7 +86,7 @@ class WorkVersion < ApplicationRecord
 
   %i[subtitle version_name rights].each do |field|
     define_method "#{field}=" do |val|
-      super(val) unless val.empty?
+      super(val.presence)
     end
   end
 

--- a/spec/support/shared/a_singlevalued_json_field.rb
+++ b/spec/support/shared/a_singlevalued_json_field.rb
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'a singlevalued json field' do |field|
-  subject { described_class.new(field => '') }
+  it 'converts "" to nil' do
+    record = described_class.new(field => '')
+    expect(record[field]).to be_nil
+  end
 
-  its(field) { is_expected.to be_nil }
+  it 'allows the field to be cleared when it already has a value' do
+    record = described_class.new(field => '123')
+    record.update(field => '')
+    expect(record[field]).to be_nil
+  end
 end


### PR DESCRIPTION
5ba8260 had created a bug that you can't "blank out" single-valued
fields because we've prevented fields from being empty strings.

Fixes #85 