### PR TITLE
Move version_name from db column into metadata jsonb

### DIFF
--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -7,6 +7,7 @@ class WorkVersion < ApplicationRecord
   jsonb_accessor :metadata,
                  title: :string,
                  subtitle: :string,
+                 version_name: :string,
                  keywords: [:string, array: true, default: []],
                  rights: :string,
                  description: [:string, array: true, default: []],

--- a/app/presenters/work_version_change_presenter.rb
+++ b/app/presenters/work_version_change_presenter.rb
@@ -39,7 +39,9 @@ class WorkVersionChangePresenter
   def changed_attributes
     return [] unless update?
 
-    diff.keys
+    diff.keys.map do |attr|
+      WorkVersion.human_attribute_name(attr)
+    end
   end
 
   def changed_attributes_truncated(count = 3)

--- a/app/views/dashboard/work_versions/_form.html.erb
+++ b/app/views/dashboard/work_versions/_form.html.erb
@@ -12,8 +12,8 @@
   <% end %>
 
   <%= render 'form_fields/text', form: form, attribute: :title %>
-  <%= render 'form_fields/text', form: form, attribute: :version_name %>
   <%= render 'form_fields/text', form: form, attribute: :subtitle %>
+  <%= render 'form_fields/text', form: form, attribute: :version_name %>
   <%= render 'form_fields/multi_text', form: form, attribute: :keywords %>
   <%= render 'form_fields/text', form: form, attribute: :rights %>
   <%= render 'form_fields/multi_text_area', form: form, attribute: :description %>

--- a/db/migrate/20191122162529_remove_version_name_from_work_versions.rb
+++ b/db/migrate/20191122162529_remove_version_name_from_work_versions.rb
@@ -1,0 +1,5 @@
+class RemoveVersionNameFromWorkVersions < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :work_versions, :version_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_19_194237) do
+ActiveRecord::Schema.define(version: 2019_11_22_162529) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -122,7 +122,6 @@ ActiveRecord::Schema.define(version: 2019_11_19_194237) do
 
   create_table "work_versions", force: :cascade do |t|
     t.bigint "work_id"
-    t.string "version_name"
     t.string "aasm_state"
     t.jsonb "metadata"
     t.datetime "created_at", precision: 6, null: false

--- a/spec/features/dashboard/work_history_spec.rb
+++ b/spec/features/dashboard/work_history_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Dashboard Work History', with_user: :user, versioning: true do
   let(:work) { create :work, versions_count: 2, has_draft: true, depositor: user }
 
   before do
-    # This is usuall done in the controller, but we need to do it here to get
+    # This is usually done in the controller, but we need to do it here to get
     # our user on the changes both made in the factory and below
     PaperTrail.request.whodunnit = user.id
 
@@ -32,7 +32,7 @@ RSpec.describe 'Dashboard Work History', with_user: :user, versioning: true do
     within "#work_version_changes_#{work.draft_version.id}" do
       expect(page).to have_content 'Created'
       expect(page).to have_content 'Updated'
-      expect(page).to have_content 'title, subtitle' # changed attributes
+      expect(page).to have_content 'Title, Subtitle' # changed attributes
       expect(page).to have_content 'MY UPDATED TITLE' # diff
       expect(page).to have_content user.access_id
     end

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 RSpec.describe WorkVersion, type: :model do
   describe 'table' do
     it { is_expected.to have_db_column(:work_id) }
-    it { is_expected.to have_db_column(:version_name) }
     it { is_expected.to have_db_index(:work_id) }
     it { is_expected.to have_db_column(:aasm_state) }
     it { is_expected.to have_db_column(:metadata).of_type(:jsonb) }
@@ -13,6 +12,7 @@ RSpec.describe WorkVersion, type: :model do
     it { is_expected.to have_db_column(:version_number).of_type(:integer) }
     it { is_expected.to have_jsonb_accessor(:title).of_type(:string) }
     it { is_expected.to have_jsonb_accessor(:subtitle).of_type(:string) }
+    it { is_expected.to have_jsonb_accessor(:version_name).of_type(:string) }
     it { is_expected.to have_jsonb_accessor(:keywords).of_type(:string).is_array.with_default([]) }
     it { is_expected.to have_jsonb_accessor(:rights).of_type(:string) }
     it { is_expected.to have_jsonb_accessor(:description).of_type(:string).is_array.with_default([]) }

--- a/spec/presenters/work_version_change_presenter_spec.rb
+++ b/spec/presenters/work_version_change_presenter_spec.rb
@@ -68,14 +68,14 @@ RSpec.describe WorkVersionChangePresenter do
         allow(paper_trail_version).to receive(:event).and_return('update')
         allow(paper_trail_version).to receive(:object_changes).and_return(
           'metadata' => [
-            { 'title' => 'old', 'subtitle' => 'old' },
-            { 'title' => 'new', 'subtitle' => 'new' }
+            { 'title' => 'old', 'version_name' => 'old' },
+            { 'title' => 'new', 'version_name' => 'new' }
           ]
         )
       end
 
-      it 'returns an array of all metadata attributes that have changed' do
-        expect(presenter.changed_attributes).to contain_exactly('title', 'subtitle')
+      it 'returns an array of humanized metadata attributes that have changed' do
+        expect(presenter.changed_attributes).to contain_exactly('Title', 'Version Name')
       end
     end
 
@@ -102,7 +102,7 @@ RSpec.describe WorkVersionChangePresenter do
 
       it 'returns an abbreviated list of them' do
         expect(presenter.changed_attributes_truncated).to contain_exactly(
-          'title', 'subtitle', 'description', 'and 2 more'
+          'Title', 'Subtitle', 'Description', 'and 2 more'
         )
       end
     end


### PR DESCRIPTION
There's no need for it to be its own database column, plus by doing so, it was being excluded from our diffs, which only operate on the metadata column.

Also while I was at it, I noticed that I should...
* humanize the changed attributes in the version history (I didn't notice this until testing `version_name`)
* Swap the order of the version name and subtitle fields on the edit form. It makes no sense to have the version name sitting between title and subtitle

Please note that this PR does _not_ build on top of my previous PR, which fixes the bug that prevents the version_name (and other single-value fields) to be nulled-out