### PR TITLE
Work indexing

### DIFF
--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class WorkIndexer
+  def self.call(work, commit: false)
+    work.versions.published.map do |version|
+      IndexingService.add_document(version.to_solr, commit: false)
+    end
+    IndexingService.add_document(work.to_solr, commit: commit)
+  end
+end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -3,11 +3,10 @@
 class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
 
-  ##
-  # @example Adding a new step to the processor chain
-  #   self.default_processor_chain += [:add_custom_data_to_query]
-  #
-  #   def add_custom_data_to_query(solr_parameters)
-  #     solr_parameters[:custom] = blacklight_params[:user_value]
-  #   end
+  self.default_processor_chain += [:show_works_only]
+
+  def show_works_only(solr_parameters)
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] << 'model_ssi:Work'
+  end
 end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -56,6 +56,11 @@ class Work < ApplicationRecord
     work
   end
 
+  def self.reindex_all
+    find_each { |work| WorkIndexer.call(work, commit: false) }
+    IndexingService.commit
+  end
+
   def latest_version
     versions.last
   end
@@ -66,5 +71,11 @@ class Work < ApplicationRecord
 
   def draft_version
     versions.draft.last
+  end
+
+  def to_solr
+    SolrDocumentBuilder.call(resource: latest_published_version)
+      .merge(SolrDocumentBuilder.call(resource: self))
+      .except(:latest_version_bsi)
   end
 end

--- a/app/services/indexing_service.rb
+++ b/app/services/indexing_service.rb
@@ -1,49 +1,15 @@
 # frozen_string_literal: true
 
 class IndexingService
-  class Error < StandardError; end
-
-  # @param [ActiveRecord::Base]
-  # @param [Schema, Hash, nil]
+  # @param [Hash]
   # @param [Boolean]
-  def self.call(resource:, schema: nil, commit: false)
-    new(resource, schema, commit).index
+  def self.add_document(document, commit: false)
+    connection = Blacklight.default_index.connection
+    connection.add(document)
+    connection.commit if commit
   end
 
-  attr_reader :resource, :schema
-
-  def initialize(resource, schema, commit)
-    @resource = resource
-    @schema = schema || DefaultSchema.new(resource.class).schema
-    @commit = commit
+  def self.commit
+    Blacklight.default_index.connection.commit
   end
-
-  def index
-    raise Error, "#{resource.class} has no uuid defined" unless resource.respond_to?(:uuid)
-
-    connection.add(document.merge(id: resource.uuid, model_ssi: resource.class.to_s))
-    connection.commit if commit?
-  end
-
-  def document
-    schema.keys.map do |solr_field|
-      [solr_field.to_s, document_values(solr_field)]
-    end.to_h
-  end
-
-  private
-
-    def document_values(field)
-      schema[field].map do |attribute|
-        resource.send(attribute) if resource.respond_to?(attribute)
-      end
-    end
-
-    def commit?
-      @commit
-    end
-
-    def connection
-      @connection ||= Blacklight.default_index.connection
-    end
 end

--- a/app/services/solr_document_builder.rb
+++ b/app/services/solr_document_builder.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class SolrDocumentBuilder
+  class Error < StandardError; end
+
+  def self.call(resource:, schema: nil)
+    return {} if resource.nil?
+
+    new(resource, schema).document
+  end
+
+  attr_reader :schema, :resource
+
+  def initialize(resource, schema)
+    raise Error, "#{resource.class} has no uuid defined" unless resource.respond_to?(:uuid)
+
+    @resource = resource
+    @schema = schema || DefaultSchema.new(resource.class).schema
+  end
+
+  def document
+    HashWithIndifferentAccess.new(
+      resource_document.merge(id: resource.uuid, model_ssi: resource.class.to_s)
+    )
+  end
+
+  private
+
+    def resource_document
+      schema.keys.map do |solr_field|
+        [solr_field.to_sym, document_values(solr_field)]
+      end.to_h
+    end
+
+    def document_values(field)
+      schema[field].map do |attribute|
+        resource.send(attribute) if resource.respond_to?(attribute)
+      end
+    end
+end

--- a/db/migrate/20191121195458_add_uuid_to_work.rb
+++ b/db/migrate/20191121195458_add_uuid_to_work.rb
@@ -1,0 +1,6 @@
+class AddUuidToWork < ActiveRecord::Migration[6.0]
+  def change
+    enable_extension 'uuid-ossp'
+    add_column :works, :uuid, :uuid, default: 'uuid_generate_v4()'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -136,6 +136,7 @@ ActiveRecord::Schema.define(version: 2019_11_22_162529) do
     t.integer "depositor_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.uuid "uuid", default: -> { "uuid_generate_v4()" }
     t.index ["depositor_id"], name: "index_works_on_depositor_id"
   end
 

--- a/lib/tasks/solr.rake
+++ b/lib/tasks/solr.rake
@@ -17,9 +17,8 @@ namespace :solr do
     conf.modify_collection
   end
 
-  desc 'Reindexes all our resources into Solr'
-  task reindex: :environment do
-    WorkVersion.all.map { |version| IndexingService.call(resource: version) }
-    Blacklight.default_index.connection.commit
+  desc 'Reindexes all the works (as well as their versions) into Solr'
+  task reindex_works: :environment do
+    Work.reindex_all
   end
 end

--- a/spec/factories/work_versions.rb
+++ b/spec/factories/work_versions.rb
@@ -7,6 +7,9 @@ FactoryBot.define do
     title { generate(:work_title) }
     sequence(:version_number) { |n| work.present? ? work.versions.length + 1 : n }
 
+    # Postgres does this for us, but for testing, we can do it here to save having to call create/reload.
+    uuid { SecureRandom.uuid }
+
     trait :with_files do
       transient do
         file_count { 1 }

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -5,6 +5,9 @@ FactoryBot.define do
     association :depositor, factory: :user
     work_type { Work::Types.all.first }
 
+    # Postgres does this for us, but for testing, we can do it here to save having to call create/reload.
+    uuid { SecureRandom.uuid }
+
     transient do
       has_draft { true }
       versions_count { 1 }

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WorkIndexer do
+  describe '::call' do
+    before { described_class.call(work) }
+
+    context 'when the work has one published version' do
+      let(:work) { create(:work, has_draft: false) }
+      let(:current_published) { work.versions[0] }
+
+      it 'indexes the published version and the work' do
+        expect(SolrDocument.find(current_published.uuid)[:latest_version_bsi]).to be(true)
+        expect(SolrDocument.find(work.uuid)[:title_tesim]).to eq([current_published.title])
+      end
+    end
+  end
+
+  context 'when the work has a draft and several published versions' do
+    let(:work) { create(:work, versions_count: 3, has_draft: true) }
+    let(:previous_published) { work.versions[0] }
+    let(:current_published) { work.versions[1] }
+    let(:draft) { work.versions[2] }
+
+    it 'indexes only the published versions and work, marking the latest version' do
+      expect(SolrDocument.find(current_published.uuid)[:latest_version_bsi]).to be(true)
+      expect(SolrDocument.find(previous_published.uuid)[:latest_version_bsi]).to be(false)
+      expect { SolrDocument.find(draft.uuid) }.to raise_error(Blacklight::Exceptions::RecordNotFound)
+      expect(SolrDocument.find(work.uuid)[:title_tesim]).to eq([current_published.title])
+    end
+  end
+end

--- a/spec/services/indexing_service_spec.rb
+++ b/spec/services/indexing_service_spec.rb
@@ -3,79 +3,28 @@
 require 'rails_helper'
 
 RSpec.describe IndexingService, type: :service do
-  let(:resource) { build(:work_version) }
+  before { allow(Blacklight.default_index.connection).to receive(:commit) }
 
-  describe '.call' do
-    subject(:service) { described_class.call(resource: resource, schema: {}) }
-
-    context 'with a supported resource' do
-      let(:resource) { instance_spy('IndexedResource', uuid: SecureRandom.uuid, class: 'IndexedResource') }
-
-      it 'indexes a minimal amount of metadata in Solr but does not automatically commit the results' do
-        service
-        expect(Blacklight.default_index.connection.get('select', q: '*:*')['response']['docs'])
-          .to be_empty
-        document = SolrDocument.find(resource.uuid)
-        expect(document.id).to eq(resource.uuid)
-        expect(document['model_ssi']).to eq('IndexedResource')
+  describe '.add_document' do
+    context 'without calling commit' do
+      it 'indexes a document into Solr and does NOT commit' do
+        described_class.add_document(id: SecureRandom.uuid)
+        expect(Blacklight.default_index.connection).not_to have_received(:commit)
       end
     end
 
-    context 'with an improperly identified resource' do
-      let(:resource) { Struct.new('UnsupportedResource').new }
-
-      it 'raises an error' do
-        expect { service }.to raise_error(IndexingService::Error, 'Struct::UnsupportedResource has no uuid defined')
-      end
-    end
-
-    context 'when commit is set to true' do
-      subject(:service) { described_class.call(resource: resource, schema: {}, commit: true) }
-
-      let(:resource) { instance_spy('CommittedResource', uuid: SecureRandom.uuid, class: 'CommittedResource') }
-
-      it 'commits the changes to the index immediately' do
-        service
-        expect(Blacklight.default_index.connection.get('select', q: '*:*')['response']['docs'].first['id'])
-          .to eq(resource.uuid)
-        document = SolrDocument.find(resource.uuid)
-        expect(document.id).to eq(resource.uuid)
-        expect(document['model_ssi']).to eq('CommittedResource')
-      end
-    end
-
-    context 'when no schema is specified' do
-      subject(:service) { described_class.call(resource: resource) }
-
-      let(:resource) { instance_spy('SchemalessResource', uuid: SecureRandom.uuid, class: 'SchemalessResource') }
-
-      it 'uses the default schema on the resource' do
-        service
-        document = SolrDocument.find(resource.uuid)
-        expect(document.id).to eq(resource.uuid)
-        expect(document['model_ssi']).to eq('SchemalessResource')
+    context 'when calling commit' do
+      it 'indexes the document into Solr and calls commit' do
+        described_class.add_document({ id: SecureRandom.uuid }, commit: true)
+        expect(Blacklight.default_index.connection).to have_received(:commit)
       end
     end
   end
 
-  describe '#document' do
-    subject { described_class.new(resource, schema, false) }
-
-    context 'with a simple schema' do
-      let(:schema) { { title_tesim: ['title'], foo_text: ['title', 'description'] } }
-
-      its(:document) do
-        is_expected.to eq(
-          'title_tesim' => [resource.title],
-          'foo_text' => [resource.title, resource.description]
-        )
-      end
-    end
-
-    context 'when the schema contains undefined attributes' do
-      let(:schema) { { title_tesim: ['title', 'bad_attribute'] } }
-
-      its(:document) { is_expected.to eq('title_tesim' => [resource.title, nil]) }
+  describe '.commit' do
+    it 'calls commit on the Solr index' do
+      described_class.commit
+      expect(Blacklight.default_index.connection).to have_received(:commit)
     end
   end
 end

--- a/spec/services/solr_document_builder_spec.rb
+++ b/spec/services/solr_document_builder_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SolrDocumentBuilder do
+  subject(:document) { described_class.call(resource: resource) }
+
+  describe '::call' do
+    context 'with a WorkVersion' do
+      let(:resource) { build(:work_version) }
+
+      it 'returns a hash' do
+        expect(document).to include(
+          title_tesim: [resource.title],
+          model_ssi: 'WorkVersion',
+          id: resource.uuid
+        )
+      end
+    end
+
+    context 'with a custom schema' do
+      subject(:document) { described_class.call(resource: resource, schema: schema) }
+
+      let(:resource) { build(:work_version) }
+      let(:schema) { { title_ssim: ['title'] } }
+
+      it 'returns a hash using the schema' do
+        expect(document).to include(
+          title_ssim: [resource.title],
+          model_ssi: 'WorkVersion',
+          id: resource.uuid
+        )
+      end
+    end
+
+    context 'when the resource has no uuid' do
+      let(:resource) { Struct.new('UnsupportedResource').new }
+
+      it 'raises an error' do
+        expect { described_class.call(resource: resource) }.to raise_error(SolrDocumentBuilder::Error)
+      end
+    end
+
+    context 'when the resource is nil' do
+      it 'returns an empty hash' do
+        expect(described_class.call(resource: nil)).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
Changes the work and work version indexing process so that only works will be searched when searching the catalog. Work versions are still indexed in Solr so that they can be rendered by the CatalogController. However, a new boolean field is added to their documents indicating if the particular version is the latest published version or not. Also, draft versions are _not_ indexed.

A work is indexed into solr by copying the metadata fields from the latest published version and adding it to its own. This has the side-effect of creating two, almost identical, records for a given latest published version.

Fixes #81 