### PR TITLE
Add files to a Work's change history

### DIFF
--- a/app/models/file_version_membership.rb
+++ b/app/models/file_version_membership.rb
@@ -16,6 +16,17 @@ class FileVersionMembership < ApplicationRecord
 
   delegate :size, :mime_type, :original_filename, to: :uploader
 
+  attr_accessor :changed_by_system
+
+  has_paper_trail(
+    unless: ->(record) { record.changed_by_system },
+    meta: {
+      # Explicitly store the work_version_id to the PaperTrail::Version to allow
+      # easy access in the work history
+      work_version_id: :work_version_id
+    }
+  )
+
   private
 
     def uploader

--- a/app/presenters/file_membership_change_presenter.rb
+++ b/app/presenters/file_membership_change_presenter.rb
@@ -27,11 +27,7 @@ class FileMembershipChangePresenter
   def action
     return t('rename') if rename?
 
-    case event
-    when 'create' then t('create')
-    when 'destroy' then t('destroy')
-    else "#{event}d".titleize
-    end
+    t(event)
   end
 
   def timestamp
@@ -39,8 +35,8 @@ class FileMembershipChangePresenter
   end
 
   def current_filename
-    return paper_trail_object['title'] if event == 'destroy'
-    return paper_trail_object_changes['title'].last if event == 'create'
+    return paper_trail_object['title'] if destroy?
+    return paper_trail_object_changes['title'].last if create?
 
     paper_trail_object_changes.fetch('title', []).last ||
       paper_trail_object['title']
@@ -52,14 +48,26 @@ class FileMembershipChangePresenter
     paper_trail_object_changes.fetch('title', []).first
   end
 
+  def create?
+    event == 'create'
+  end
+
+  def update?
+    event == 'update' && !rename?
+  end
+
   def rename?
     event == 'update' && paper_trail_object_changes.key?('title')
   end
 
+  def destroy?
+    event == 'destroy'
+  end
+
   private
 
-    def t(key)
-      I18n.t("dashboard.work_history.file_membership.#{key}")
+    def t(key, options = {})
+      I18n.t("dashboard.work_history.file_membership.#{key}", options)
     end
 
     def paper_trail_object

--- a/app/presenters/file_membership_change_presenter.rb
+++ b/app/presenters/file_membership_change_presenter.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+class FileMembershipChangePresenter
+  attr_reader :paper_trail_version,
+              :user
+
+  # @param PaperTrail::Version representing a change to a FileVersionMembership
+  # @param User
+  def initialize(paper_trail_version:, user:)
+    if paper_trail_version.item_type != 'FileVersionMembership'
+      raise ArgumentError, 'paper_trail_version must apply to a FileVersionMembership'
+    end
+
+    @paper_trail_version = paper_trail_version
+    @user = user
+  end
+
+  delegate :created_at,
+           :event,
+           :id,
+           to: :paper_trail_version
+
+  def to_partial_path
+    'file_membership_change'
+  end
+
+  def action
+    return t('rename') if rename?
+
+    case event
+    when 'create' then t('create')
+    when 'destroy' then t('destroy')
+    else "#{event}d".titleize
+    end
+  end
+
+  def timestamp
+    created_at.to_s(:long)
+  end
+
+  def current_filename
+    return paper_trail_object['title'] if event == 'destroy'
+    return paper_trail_object_changes['title'].last if event == 'create'
+
+    paper_trail_object_changes.fetch('title', []).last ||
+      paper_trail_object['title']
+  end
+
+  def previous_filename
+    return nil unless rename?
+
+    paper_trail_object_changes.fetch('title', []).first
+  end
+
+  def rename?
+    event == 'update' && paper_trail_object_changes.key?('title')
+  end
+
+  private
+
+    def t(key)
+      I18n.t("dashboard.work_history.file_membership.#{key}")
+    end
+
+    def paper_trail_object
+      paper_trail_version.object || {}
+    end
+
+    def paper_trail_object_changes
+      paper_trail_version.object_changes || {}
+    end
+end

--- a/app/presenters/work_version_change_presenter.rb
+++ b/app/presenters/work_version_change_presenter.rb
@@ -27,9 +27,9 @@ class WorkVersionChangePresenter
   end
 
   def action
-    return 'Published' if publish?
+    return t('publish') if publish?
 
-    "#{event}d".titleize # "update" becomes "Updated"
+    t(event)
   end
 
   def timestamp
@@ -47,7 +47,7 @@ class WorkVersionChangePresenter
   def changed_attributes_truncated(count = 3)
     truncated = changed_attributes.first(count)
     remainder = changed_attributes.length - truncated.length
-    truncated << "and #{remainder} more" if remainder > 0
+    truncated << t('truncated_attributes', count: remainder) if remainder > 0
     truncated
   end
 
@@ -69,6 +69,10 @@ class WorkVersionChangePresenter
   end
 
   private
+
+    def t(key, options = {})
+      I18n.t("dashboard.work_history.work_version.#{key}", options)
+    end
 
     def diff
       @diff ||= WorkVersionChangeDiff.call(paper_trail_version)

--- a/app/services/build_new_work_version.rb
+++ b/app/services/build_new_work_version.rb
@@ -15,7 +15,8 @@ class BuildNewWorkVersion
     previous_version.file_version_memberships.each do |previous_membership|
       new_version.file_version_memberships.build(
         file_resource_id: previous_membership.file_resource_id,
-        title: previous_membership.title
+        title: previous_membership.title,
+        changed_by_system: true
       )
     end
 

--- a/app/views/dashboard/work_histories/_file_membership_change.html.erb
+++ b/app/views/dashboard/work_histories/_file_membership_change.html.erb
@@ -5,7 +5,7 @@
   <small>
     <% if change.rename? %>
       <code><%= change.previous_filename %></code>
-      <%= t('dashboard.work_history.renamed_to').html_safe %>
+      <%= t 'dashboard.work_history.renamed_to.html' %>
     <% end %>
     <code><%= change.current_filename %></code>
   </small>

--- a/app/views/dashboard/work_histories/_file_membership_change.html.erb
+++ b/app/views/dashboard/work_histories/_file_membership_change.html.erb
@@ -1,0 +1,18 @@
+<%# Note `change` is a FileMembershipChangePresenter %>
+<div id="change_<%= change.id %>" class="work-history__change work-history__change--file">
+  <strong><%= change.action %></strong>
+
+  <small>
+    <% if change.rename? %>
+      <code><%= change.previous_filename %></code>
+      <%= t('dashboard.work_history.renamed_to').html_safe %>
+    <% end %>
+    <code><%= change.current_filename %></code>
+  </small>
+
+  <div class="work-history__change-metadata">
+    <span class="work-history__change-timestamp"><%= change.timestamp %></span>
+    <span class="text-secondary"><%= t 'dashboard.work_history.by' %></span>
+    <span class="work-history__change-user"><%= change.user.access_id %></span>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,3 +75,8 @@ en:
       heading: "History of %{work}"
       show_diff: Show Changes
       by: by
+      renamed_to: "&rarr;"
+      file_membership:
+        create: Added
+        rename: Renamed
+        destroy: Deleted

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,8 +75,16 @@ en:
       heading: "History of %{work}"
       show_diff: Show Changes
       by: by
-      renamed_to: "&rarr;"
+      renamed_to:
+        html: "&rarr;"
       file_membership:
         create: Added
         rename: Renamed
+        update: Updated
         destroy: Deleted
+      work_version:
+        create: Created
+        publish: Published
+        update: Updated
+        destroy: Deleted
+        truncated_attributes: "and %{count} more"

--- a/db/migrate/20191125154241_add_work_version_id_to_versions.rb
+++ b/db/migrate/20191125154241_add_work_version_id_to_versions.rb
@@ -1,0 +1,6 @@
+class AddWorkVersionIdToVersions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :versions, :work_version_id, :integer
+    add_index :versions, :work_version_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_22_162529) do
+ActiveRecord::Schema.define(version: 2019_11_25_154241) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -108,7 +108,9 @@ ActiveRecord::Schema.define(version: 2019_11_22_162529) do
     t.jsonb "object"
     t.datetime "created_at"
     t.jsonb "object_changes"
+    t.integer "work_version_id"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
+    t.index ["work_version_id"], name: "index_versions_on_work_version_id"
   end
 
   create_table "work_creations", force: :cascade do |t|

--- a/spec/features/dashboard/work_history_spec.rb
+++ b/spec/features/dashboard/work_history_spec.rb
@@ -4,17 +4,27 @@ require 'rails_helper'
 
 RSpec.describe 'Dashboard Work History', with_user: :user, versioning: true do
   let(:user) { create :user }
-  let(:work) { create :work, versions_count: 2, has_draft: true, depositor: user }
+  let(:work) { create :work, versions_count: 1, has_draft: false, depositor: user }
 
   before do
     # This is usually done in the controller, but we need to do it here to get
     # our user on the changes both made in the factory and below
     PaperTrail.request.whodunnit = user.id
 
+    # Create a new draft version
+    draft_version = BuildNewWorkVersion.call(work.latest_published_version)
+    draft_version.save!
+
+    # Update some attributes on the draft version
     work.draft_version.update!(
       title: 'MY UPDATED TITLE',
       subtitle: 'MY UPDATED SUBTITLE'
     )
+
+    # Rename a file on the draft version
+    work.draft_version.file_version_memberships.first.tap do |file_version_membership|
+      file_version_membership.update!(title: 'MY_UPDATED_FILENAME.png')
+    end
   end
 
   it 'shows the edit history of the work' do
@@ -27,6 +37,7 @@ RSpec.describe 'Dashboard Work History', with_user: :user, versioning: true do
 
     within "#work_version_changes_#{work.latest_published_version.id}" do
       expect(page).to have_content 'Created'
+      expect(page).to have_content(/Added image-\d+.png/)
     end
 
     within "#work_version_changes_#{work.draft_version.id}" do
@@ -35,6 +46,9 @@ RSpec.describe 'Dashboard Work History', with_user: :user, versioning: true do
       expect(page).to have_content 'Title, Subtitle' # changed attributes
       expect(page).to have_content 'MY UPDATED TITLE' # diff
       expect(page).to have_content user.access_id
+
+      expect(page).not_to have_content(/Added image-\d+.png/)
+      expect(page).to have_content(/Renamed image-\d+.png.+MY_UPDATED_FILENAME.png/)
     end
   end
 end

--- a/spec/models/file_version_membership_spec.rb
+++ b/spec/models/file_version_membership_spec.rb
@@ -57,6 +57,31 @@ RSpec.describe FileVersionMembership, type: :model do
     end
   end
 
+  describe 'PaperTrail::Versions', versioning: true do
+    it { is_expected.to respond_to(:changed_by_system).and respond_to(:changed_by_system=) }
+    it { is_expected.to be_versioned }
+
+    context 'when the record is marked as changed by the system' do
+      let(:file_version_membership) { create(:file_version_membership, changed_by_system: true) }
+
+      it 'does not write a papertrail version' do
+        expect(file_version_membership.reload.versions).to be_empty
+      end
+    end
+
+    context 'when the record is NOT marked as changed by the system' do
+      let(:file_version_membership) { create(:file_version_membership, changed_by_system: false) }
+
+      it "writes a version and stores the WorkVersion's FK into the version metadata" do
+        paper_trail_version = file_version_membership.versions.first
+
+        expect(paper_trail_version.work_version_id).to eq(
+          file_version_membership.work_version_id
+        )
+      end
+    end
+  end
+
   describe 'initializing #title' do
     # NOTE the :file_resource factory is created with a file named 'image.png'
 

--- a/spec/presenters/file_membership_change_presenter_spec.rb
+++ b/spec/presenters/file_membership_change_presenter_spec.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FileMembershipChangePresenter do
+  subject(:presenter) { described_class.new(
+    paper_trail_version: paper_trail_version,
+    user: user
+  ) }
+
+  let(:paper_trail_version) do
+    instance_spy 'PaperTrail::Version',
+                 item_type: 'FileVersionMembership',
+                 object_changes: nil
+  end
+
+  let(:user) { instance_spy 'User' }
+
+  it { is_expected.to delegate_method(:created_at).to(:paper_trail_version) }
+  it { is_expected.to delegate_method(:event).to(:paper_trail_version) }
+  it { is_expected.to delegate_method(:id).to(:paper_trail_version) }
+
+  describe '#initialize' do
+    context 'when the given PaperTrail::Version does not apply to a FileVersionMembership' do
+      before { allow(paper_trail_version).to receive(:item_type).and_return('SomeOtherClass') }
+
+      it { expect { presenter }.to raise_error(ArgumentError) }
+    end
+  end
+
+  describe '#to_partial_path' do
+    it { expect(presenter.to_partial_path).to eq 'file_membership_change' }
+  end
+
+  describe '#action' do
+    subject { presenter.action }
+
+    before do
+      allow(paper_trail_version).to receive(:event).and_return(event)
+    end
+
+    context 'when created' do
+      let(:event) { 'create' }
+
+      it { is_expected.to eq I18n.t('dashboard.work_history.file_membership.create') }
+    end
+
+    context 'when destroyed' do
+      let(:event) { 'destroy' }
+
+      it { is_expected.to eq I18n.t('dashboard.work_history.file_membership.destroy') }
+    end
+
+    context 'when renamed (a special case of update)' do
+      let(:event) { 'update' }
+
+      before do
+        allow(paper_trail_version).to receive(:object_changes).and_return(
+          'title' => %w(old new)
+        )
+      end
+
+      it { is_expected.to eq I18n.t('dashboard.work_history.file_membership.rename') }
+    end
+
+    context 'when generically updated (unlikely scenario)' do
+      let(:event) { 'update' }
+
+      it { is_expected.to eq 'Updated' }
+    end
+  end
+
+  describe '#current_filename' do
+    subject { presenter.current_filename }
+
+    context 'when created' do
+      before do
+        allow(paper_trail_version).to receive(:event).and_return('create')
+        allow(paper_trail_version).to receive(:object).and_return(nil)
+        allow(paper_trail_version).to receive(:object_changes).and_return(
+          'title' => [nil, 'the_current_filename']
+        )
+      end
+
+      it { is_expected.to eq 'the_current_filename' }
+    end
+
+    context 'when updated' do
+      before do
+        allow(paper_trail_version).to receive(:event).and_return('update')
+        allow(paper_trail_version).to receive(:object).and_return(
+          'title' => 'the_old_filename'
+        )
+        allow(paper_trail_version).to receive(:object_changes).and_return(
+          'title' => ['the_old_filename', 'the_current_filename']
+        )
+      end
+
+      it { is_expected.to eq 'the_current_filename' }
+    end
+
+    context 'when destroyed' do
+      before do
+        allow(paper_trail_version).to receive(:event).and_return('destroy')
+        allow(paper_trail_version).to receive(:object).and_return(
+          'title' => 'the_current_filename'
+        )
+        allow(paper_trail_version).to receive(:object_changes).and_return(
+          'title' => ['the_current_filename', nil]
+        )
+      end
+
+      it { is_expected.to eq 'the_current_filename' }
+    end
+  end
+
+  describe '#previous_filename' do
+    subject { presenter.previous_filename }
+
+    context 'when updated' do
+      before do
+        allow(paper_trail_version).to receive(:event).and_return('update')
+        allow(paper_trail_version).to receive(:object).and_return(
+          'title' => 'the_old_filename'
+        )
+        allow(paper_trail_version).to receive(:object_changes).and_return(
+          'title' => ['the_old_filename', 'the_current_filename']
+        )
+      end
+
+      it { is_expected.to eq 'the_old_filename' }
+    end
+
+    context 'when some other event' do
+      before do
+        allow(paper_trail_version).to receive(:event).and_return('create')
+      end
+
+      it { is_expected.to eq nil }
+    end
+  end
+
+  describe '#timestamp' do
+    let(:created_at) { Time.zone.parse('2019-10-21 15:10:00') }
+
+    before { allow(paper_trail_version).to receive(:created_at).and_return(created_at) }
+
+    it "returns a human-friendly version of the papertrail's #created_at" do
+      expect(presenter.timestamp).to eq 'October 21, 2019 15:10'
+    end
+  end
+
+  describe '#rename?' do
+    subject { presenter.rename? }
+
+    context 'when renamed (a special case of update)' do
+      before do
+        allow(paper_trail_version).to receive(:event).and_return('update')
+        allow(paper_trail_version).to receive(:object_changes).and_return(
+          'title' => %w(old new)
+        )
+      end
+
+      it { is_expected.to eq true }
+    end
+
+    context 'when generically updated (unlikely scenario)' do
+      before do
+        allow(paper_trail_version).to receive(:event).and_return('update')
+      end
+
+      it { is_expected.to eq false }
+    end
+  end
+end

--- a/spec/presenters/work_history_presenter_spec.rb
+++ b/spec/presenters/work_history_presenter_spec.rb
@@ -36,9 +36,10 @@ RSpec.describe WorkHistoryPresenter, versioning: true do
     end
 
     it 'returns a 2d array, where dimension 2 is the changes to each version, mapped to Presenter objects' do
-      _version, changes = changes_by_work_version.first
-      expect(changes).not_to be_empty
-      expect(changes).to all(be_a(WorkVersionChangePresenter))
+      _published_version, changes = changes_by_work_version.find { |v, _| v == v1 }
+
+      expect(changes).to include(an_instance_of(WorkVersionChangePresenter))
+      expect(changes).to include(an_instance_of(FileMembershipChangePresenter))
 
       # Spot check that one presenter is instantiated correctly
       changes.first.tap do |change|


### PR DESCRIPTION
One thing I thought about doing but decided against, was making a base class for both WorkVersionChangePresenter and FileMembershipChangePresenter to inherit from. They do share a decent amount of code, but... `¯\_(ツ)_/¯`