### PR TITLE
Displaying file diffs between two versions

### DIFF
--- a/app/controllers/dashboard/work_versions_controller.rb
+++ b/app/controllers/dashboard/work_versions_controller.rb
@@ -71,7 +71,10 @@ module Dashboard
       @work_version = WorkVersionDecorator.new(policy_scope(WorkVersion).find(params[:work_version_id]))
       @previous_version = WorkVersionDecorator.new(policy_scope(WorkVersion).find(params[:previous_version_id]))
       @work = WorkDecorator.new(@work_version.work)
-      @presenter = DiffPresenter.new(MetadataDiff.call(@previous_version, @work_version))
+      @presenter = DiffPresenter.new(
+        MetadataDiff.call(@previous_version, @work_version),
+        file_diff: FileVersionMembershipDiff.call(@previous_version, @work_version)
+      )
     end
 
     private

--- a/app/presenters/diff_presenter.rb
+++ b/app/presenters/diff_presenter.rb
@@ -1,19 +1,51 @@
 # frozen_string_literal: true
 
 class DiffPresenter
-  def initialize(diff)
-    diff.map do |key, value|
+  # @note Struct representing a renamed file. The title is a Diffy::Diff so we can show what parts of the titile
+  # changed, but it also includes the size and mime type so we can display it like any other file.
+  RenamedFile = Struct.new(:title, :size, :mime_type)
+
+  attr_reader :files
+
+  # @param [Hash] output from MetadataDiff.call
+  # @param [Hash, nil] output from WorkVersionMembershipDiff.call
+  def initialize(metadata_diff, file_diff: nil)
+    metadata_diff.map do |key, value|
       hash[key] = Diffy::Diff.new(*value)
     end
+    @files = file_diff || {}
   end
 
+  # @return [Array<Symbol>] for each changed metadata term
   def terms
     hash.keys
   end
 
+  # @note this uses the same structure as the MetadataDiff hash, but the value of each changed term is a Diffy::Diff
   def hash
     @hash ||= ActiveSupport::HashWithIndifferentAccess.new
   end
 
   delegate :[], to: :hash
+
+  # @return [Array<RenamedFile>]
+  def renamed_files
+    files.fetch(:renamed, []).map do |renamed_files|
+      RenamedFile.new(
+        Diffy::Diff.new(*renamed_files.map(&:title)),
+        renamed_files.first.size,
+        renamed_files.first.mime_type
+      )
+    end
+  end
+
+  # @return [Array<FileVersionMembership>]
+  def deleted_files
+    files.fetch(:deleted, [])
+  end
+
+  # @return [Array<FileVersionMembership>]
+  def added_files
+    files.fetch(:added, [])
+  end
 end

--- a/app/services/file_version_membership_diff.rb
+++ b/app/services/file_version_membership_diff.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# @abstract Returns a hash with the differences between the file memberships of two WorkVersions. Renamed files
+# is array of tuples, each with a FileVersionMembership, representating the two changed memberships. Added and deleted
+# files are returned as arrays of FileVersionMembership objects.
+# @example Given two objects with two different titles
+#   >  FileVersionMembershipDiff.call(obj1, obj2)
+#   => {
+#        renamed:
+#          [
+#            [FileVersionMembership, FileVersionMembership],
+#            [FileVersionMembership, FileVersionMembership]
+#          ]
+#        added: [FileVersionMembership, FileVersionMembership],
+#        deleted: [FileVersionMembership]
+#      }
+#
+class FileVersionMembershipDiff
+  # @param obj1 [WorkVersion]
+  # @param obj2 [WorkVersion]
+  def self.call(*args)
+    new(*args).diff
+  end
+
+  attr_reader :base_version, :comparison_version
+
+  def initialize(*args)
+    @base_version = args[0]
+    @comparison_version = args[1]
+  end
+
+  def diff
+    { renamed: renamed, deleted: deleted, added: added }
+  end
+
+  # @return [Array<[FileVersionMembership, FileVersionMembership]>]
+  def renamed
+    identical_file_resource_ids.map do |id|
+      original_file = base_version_memberships.find { |mem| mem.file_resource_id == id }
+      renamed_file = comparison_version_memberships.find { |mem| mem.file_resource_id == id }
+      next if original_file.title == renamed_file.title
+
+      [original_file, renamed_file]
+    end.compact
+  end
+
+  # @return [Array<FileVersionMembership>]
+  def deleted
+    base_version_memberships.reject do |file_version_membership|
+      identical_file_resource_ids.include?(file_version_membership.file_resource_id)
+    end
+  end
+
+  # @return [Array<FileVersionMembership>]
+  def added
+    comparison_version_memberships.reject do |file_version_membership|
+      identical_file_resource_ids.include?(file_version_membership.file_resource_id)
+    end
+  end
+
+  private
+
+    def base_version_memberships
+      @base_version_memberships ||= base_version.file_version_memberships
+    end
+
+    def comparison_version_memberships
+      @comparison_version_memberships ||= comparison_version.file_version_memberships
+    end
+
+    def identical_file_resource_ids
+      @identical_file_resource_ids ||= begin
+        base = Set.new(base_version_memberships.map(&:file_resource_id))
+        comparison = Set.new(comparison_version_memberships.map(&:file_resource_id))
+
+        base.intersection(comparison)
+      end
+    end
+end

--- a/app/views/dashboard/work_versions/diff.html.erb
+++ b/app/views/dashboard/work_versions/diff.html.erb
@@ -20,6 +20,41 @@
         <%= @presenter[term].to_s(:html).html_safe %>
       </p>
     <% end %>
+
+    <% if @presenter.files.present? %>
+      <table class="table">
+        <thead>
+          <tr>
+            <th><%= t('dashboard.work_versions.files.name') %></th>
+            <th><%= t('dashboard.work_versions.files.size') %></th>
+            <th><%= t('dashboard.work_versions.files.mime_type') %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @presenter.renamed_files.each do |file| %>
+            <tr>
+              <td><%= file.title.to_s(:html).html_safe %></td>
+              <td><%= number_to_human_size file.size %></td>
+              <td><%= file.mime_type %></td>
+            </tr>
+          <% end %>
+          <% @presenter.deleted_files.each do |file| %>
+            <tr class="table-danger">
+              <td><%= file.title %></td>
+              <td><%= number_to_human_size file.size %></td>
+              <td><%= file.mime_type %></td>
+            </tr>
+          <% end %>
+          <% @presenter.added_files.each do |file| %>
+            <tr class="table-success">
+              <td><%= file.title %></td>
+              <td><%= number_to_human_size file.size %></td>
+              <td><%= file.mime_type %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
   </div>
 
   <div class="col-sm-5">

--- a/spec/presenters/diff_presenter_spec.rb
+++ b/spec/presenters/diff_presenter_spec.rb
@@ -47,4 +47,68 @@ RSpec.describe DiffPresenter do
       end
     end
   end
+
+  describe '#renamed_files' do
+    let(:metadata_diff) { {} }
+
+    context 'when no file diff is provided' do
+      subject { described_class.new(metadata_diff) }
+
+      its(:renamed_files) { is_expected.to be_empty }
+    end
+
+    context 'when the diff has renamed files' do
+      let(:file_1) { build(:file_version_membership) }
+      let(:file_2) { build(:file_version_membership) }
+
+      let(:renamed_files) do
+        described_class.new(
+          metadata_diff,
+          file_diff: { renamed: [[file_1, file_2]] }
+        ).renamed_files
+      end
+
+      it 'returns an array of RenamedFile structs' do
+        expect(renamed_files.first.title).to be_a(Diffy::Diff)
+        expect(renamed_files.first.size).to eq(file_1.size)
+        expect(renamed_files.first.mime_type).to eq(file_1.mime_type)
+      end
+    end
+  end
+
+  describe '#deleted_files' do
+    let(:metadata_diff) { {} }
+
+    context 'when no file diff is provided' do
+      subject { described_class.new(metadata_diff) }
+
+      its(:deleted_files) { is_expected.to be_empty }
+    end
+
+    context 'when the file diff has deleted files' do
+      subject { described_class.new(metadata_diff, file_diff: file_diff) }
+
+      let(:file_diff) { { deleted: ['deleted_file'] } }
+
+      its(:deleted_files) { is_expected.to eq(['deleted_file']) }
+    end
+  end
+
+  describe 'added_files' do
+    let(:metadata_diff) { {} }
+
+    context 'when no file diff is provided' do
+      subject { described_class.new(metadata_diff) }
+
+      its(:added_files) { is_expected.to be_empty }
+    end
+
+    context 'when the file diff has added files' do
+      subject { described_class.new(metadata_diff, file_diff: file_diff) }
+
+      let(:file_diff) { { added: ['added_file'] } }
+
+      its(:added_files) { is_expected.to eq(['added_file']) }
+    end
+  end
 end

--- a/spec/services/file_version_membership_diff_spec.rb
+++ b/spec/services/file_version_membership_diff_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FileVersionMembershipDiff do
+  subject { described_class.call(base_version, comparison_version) }
+
+  let!(:base_version) { create(:work_version, :with_files, file_count: 2) }
+
+  let!(:comparison_version) do
+    BuildNewWorkVersion.call(base_version).tap(&:save)
+  end
+
+  context 'when a file has been renamed' do
+    let(:original_second_image) { base_version.file_version_memberships[1] }
+    let(:updated_second_image) { comparison_version.file_version_memberships[1] }
+
+    before do
+      comparison_version.file_version_memberships.last.update(title: 'Image 2.png')
+    end
+
+    it { is_expected.to eq(renamed: [[original_second_image, updated_second_image]], added: [], deleted: []) }
+  end
+
+  context 'when a file has been added' do
+    let(:added_file) { comparison_version.file_version_memberships[2] }
+
+    before do
+      comparison_version.file_resources << build(:file_resource)
+      comparison_version.save
+    end
+
+    it { is_expected.to eq(renamed: [], added: [added_file], deleted: []) }
+  end
+
+  context 'when a file has been deleted' do
+    let(:deleted_file) { base_version.file_version_memberships[2] }
+
+    before do
+      base_version.file_resources << build(:file_resource)
+      base_version.save
+    end
+
+    it { is_expected.to eq(renamed: [], added: [], deleted: [deleted_file]) }
+  end
+end


### PR DESCRIPTION
Shows the changes to files between two work versions. The versions may be of any type, either draft or published. Changed file names are shown using the same method as metadata changes. Any removed or added files are show as differently-colored rows in the table.
![Screen Shot 2019-11-27 at 2 02 51 PM](https://user-images.githubusercontent.com/312085/69752422-2293ee80-111f-11ea-8aaa-54ee26282c1c.png)
