### PR TITLE
Sidekiq

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,9 @@ CMD [ "/app/bin/ci-rspec" ]
 FROM base as eslint
 CMD [ "/app/bin/ci-eslint" ]
 
+FROM base as sidekiq
+CMD [ "/app/bin/sidekiq" ]
+
 FROM base as niftany
 CMD [ "/app/bin/ci-niftany" ]
 

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'rails', '~> 6.0.0'
 gem 'rsolr', '>= 1.0', '< 3'
 gem 'sass-rails', '~> 5'
 gem 'shrine', '~> 3.0'
+gem 'sidekiq', '~> 6.0'
 gem 'uppy-s3_multipart', '~> 0.3'
 gem 'webpacker', '~> 4.0'
 
@@ -65,5 +66,3 @@ group :test do
   gem 'webdrivers'
   gem 'webmock'
 end
-
-gem "sidekiq", "~> 6.0"

--- a/Gemfile
+++ b/Gemfile
@@ -65,3 +65,5 @@ group :test do
   gem 'webdrivers'
   gem 'webmock'
 end
+
+gem "sidekiq", "~> 6.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,7 @@ GEM
     coderay (1.1.2)
     colorize (0.8.1)
     concurrent-ruby (1.1.5)
+    connection_pool (2.2.2)
     content_disposition (1.0.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -273,6 +274,8 @@ GEM
     pundit (2.1.0)
       activesupport (>= 3.0.0)
     rack (2.0.7)
+    rack-protection (2.0.7)
+      rack
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -312,6 +315,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    redis (4.1.3)
     regexp_parser (1.6.0)
     request_store (1.4.1)
       rack (>= 1.4)
@@ -399,6 +403,11 @@ GEM
     shrine (3.0.0)
       content_disposition (~> 1.0)
       down (~> 5.0)
+    sidekiq (6.0.3)
+      connection_pool (>= 2.2.2)
+      rack (>= 2.0.0)
+      rack-protection (>= 2.0.0)
+      redis (>= 4.1.0)
     simplecov (0.17.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -501,6 +510,7 @@ DEPENDENCIES
   selenium-webdriver
   shoulda-matchers (~> 3.1)
   shrine (~> 3.0)
+  sidekiq (~> 6.0)
   simplecov
   spring
   spring-commands-rspec

--- a/bin/sidekiq
+++ b/bin/sidekiq
@@ -1,0 +1,2 @@
+#!/bin/bash
+bundle exec sidekiq

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'boot'
+require_relative '../lib/scholarsphere/redis_config'
 
 require 'rails'
 # Pick the frameworks you want:
@@ -33,9 +34,13 @@ module Scholarsphere
     # the framework and any gems in your application.
 
     # Active Job Configurations
-    if ENV['REDIS_HOST']
+    redis_config = Scholarsphere::RedisConfig.new
+
+    if redis_config.valid?
       config.active_job.queue_adapter = :sidekiq
       # config.active_job.queue_name_prefix = "scholarsphere_production"
+    else
+      config.active_job.queue_adapter = :async
     end
 
     # Don't generate system test files.

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,12 +36,12 @@ module Scholarsphere
     # Active Job Configurations
     redis_config = Scholarsphere::RedisConfig.new
 
-    if redis_config.valid?
-      config.active_job.queue_adapter = :sidekiq
-      # config.active_job.queue_name_prefix = "scholarsphere_production"
-    else
-      config.active_job.queue_adapter = :async
-    end
+    # config.active_job.queue_name_prefix = "scholarsphere_production"
+    config.active_job.queue_adapter = if redis_config.valid?
+                                        :sidekiq
+                                      else
+                                        :async
+                                      end
 
     # Don't generate system test files.
     config.generators.system_tests = nil

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative 'boot'
-require_relative '../lib/scholarsphere/redis_config'
 
 require 'rails'
 # Pick the frameworks you want:
@@ -24,6 +23,8 @@ Bundler.require(*Rails.groups)
 
 module Scholarsphere
   class Application < Rails::Application
+    require 'scholarsphere/redis_config'
+
     config.generators { |generator| generator.test_framework :rspec }
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,7 +36,6 @@ module Scholarsphere
     # Active Job Configurations
     redis_config = Scholarsphere::RedisConfig.new
 
-    # config.active_job.queue_name_prefix = "scholarsphere_production"
     config.active_job.queue_adapter = if redis_config.valid?
                                         :sidekiq
                                       else

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,6 +32,12 @@ module Scholarsphere
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
 
+    # Active Job Configurations
+    if ENV['REDIS_HOST']
+      config.active_job.queue_adapter = :sidekiq
+      # config.active_job.queue_name_prefix = "scholarsphere_production"
+    end
+
     # Don't generate system test files.
     config.generators.system_tests = nil
   end

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+require 'scholarsphere/redis_config'
+
+redis_config = Scholarsphere::RedisConfig.new
+
 OkComputer.mount_at = false
 
 OkComputer::Registry.register 'solr', OkComputer::SolrCheck.new(Rails.application.config_for(:blacklight)[:url])
+
+OkComputer::Registry.register 'redis', OkComputer::RedisCheck.new(redis_config.call) if redis_config.redis_host

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'scholarsphere/redis_config'
-
 redis_config = Scholarsphere::RedisConfig.new
 
 OkComputer.mount_at = false

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -8,4 +8,4 @@ OkComputer.mount_at = false
 
 OkComputer::Registry.register 'solr', OkComputer::SolrCheck.new(Rails.application.config_for(:blacklight)[:url])
 
-OkComputer::Registry.register 'redis', OkComputer::RedisCheck.new(redis_config.call) if redis_config.redis_host
+OkComputer::Registry.register 'redis', OkComputer::RedisCheck.new(redis_config.to_hash) if redis_config.valid?

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,12 +2,12 @@
 
 require 'scholarsphere/redis_config'
 
-redis_config = Scholarsphere::RedisConfig.new.call
+redis_config = Scholarsphere::RedisConfig.new
 
 Sidekiq.configure_server do |config|
-  config.redis = redis_config
+  config.redis = redis_config.to_hash
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = redis_config
+  config.redis = redis_config.to_hash
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'scholarsphere/redis_config'
+
+redis_config = Scholarsphere::RedisConfig.new.call
+
+Sidekiq.configure_server do |config|
+  config.redis = redis_config
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = redis_config
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'scholarsphere/redis_config'
-
 redis_config = Scholarsphere::RedisConfig.new
 
 Sidekiq.configure_server do |config|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
+require 'sidekiq/web'
+
 Rails.application.routes.draw do
+  # TODO only alow admins
+  authenticate :user do
+    mount Sidekiq::Web => '/sidekiq'
+  end
+
   mount OkComputer::Engine, at: '/health'
   mount Blacklight::Engine => '/'
   mount Shrine.uppy_s3_multipart(:cache) => '/s3/multipart'

--- a/config/samples/application.yml
+++ b/config/samples/application.yml
@@ -26,6 +26,13 @@
 # You will need to create a "scholarsphere" bucket in your Minio instance. This can be done via the web interface.
 # Go to http://127.0.0.1:9000/minio and click the red circle plus (+) sign in the bottom-right corner.
 
+
+## Redis Configuration
+# REDIS_HOST:
+# REDIS_PORT:
+# REDIS_PASSWORD:
+# REDIS_DATABASE:
+
 POSTGRES_USER: "[username]" # This is typically $ whoami
 
 SOLR_HOST: localhost

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,8 @@
 version: '3.5'
-services:
-  web:
-    tty: true
-    stdin_open: true
-    environment:
+x-web_env: &web_env
+  environment:
+      REDIS_HOST: redis
+      REDIS_PASSWORD: redispassword
       POSTGRES_DB: scholarsphere
       POSTGRES_USER: scholarsphere
       POSTGRES_PASSWORD: scholarsphere
@@ -16,13 +15,37 @@ services:
       SOLR_HOST: solr
       SOLR_COLLECTION: scholarsphere
       POSTGRES_HOST: db
+services:
+  redis:
+    image: redis:5.0.5
+    command: redis-server --requirepass redispassword
+    volumes:
+      - redis-data:/data
+    ports:
+    - "6379:6379"
+  sidekiq:
+    tty: true
+    stdin_open: true
+    <<: *web_env
+    build:
+      context: . 
+      target: sidekiq
+    volumes:
+    - bundle-data:/app/vendor/bundle
+    - node-data:/app/node_modules
+    - type: bind
+      source: ./
+      target: /app/
+  web:
+    tty: true
+    stdin_open: true
+    <<: *web_env
     build: 
       context: . 
       target: base
     volumes:
-    # This is an empty volume to prevent empty dir bind it's way into the container
-    - /app/vendor/bundle
-    - /app/node_modules
+    - bundle-data:/app/vendor/bundle
+    - node-data:/app/node_modules
     - type: bind
       source: ./
       target: /app/
@@ -71,7 +94,9 @@ services:
     - db-data:/var/lib/postgresql/data
 
 volumes:
+  redis-data:
   bundle-data:
+  node-data:
   minio-data:
   solr-data:
   db-data:

--- a/lib/scholarsphere/redis_config.rb
+++ b/lib/scholarsphere/redis_config.rb
@@ -2,32 +2,33 @@
 
 module Scholarsphere
   class RedisConfig
-    def call
-      redis_config
-    end
 
-    def redis_host
+    def host
       ENV.fetch('REDIS_HOST', nil)
     end
 
-    def redis_port
+    def port
       ENV.fetch('REDIS_PORT', 6379)
     end
 
-    def redis_database
+    def database
       ENV.fetch('REDIS_DATABASE', 0)
     end
 
-    def redis_password
+    def password
       ENV.fetch('REDIS_PASSWORD', nil)
     end
 
-    def redis_config
-      config = {
-        url: "redis://#{redis_host}:#{redis_port}/#{redis_database}",
-        password: redis_password
+    def valid?
+      return true if host
+      false
+    end
+
+    def to_hash
+      {
+        url: "redis://#{host}:#{port}/#{database}",
+        password: password
       }
-      config
     end
   end
 end

--- a/lib/scholarsphere/redis_config.rb
+++ b/lib/scholarsphere/redis_config.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Scholarsphere
+  class RedisConfig
+    def call
+      redis_config
+    end
+
+    def redis_host
+      ENV.fetch('REDIS_HOST', nil)
+    end
+
+    def redis_port
+      ENV.fetch('REDIS_PORT', 6379)
+    end
+
+    def redis_database
+      ENV.fetch('REDIS_DATABASE', 0)
+    end
+
+    def redis_password
+      ENV.fetch('REDIS_PASSWORD', nil)
+    end
+
+    def redis_config
+      config = {
+        url: "redis://#{redis_host}:#{redis_port}/#{redis_database}",
+        password: redis_password
+      }
+      config
+    end
+  end
+end

--- a/lib/scholarsphere/redis_config.rb
+++ b/lib/scholarsphere/redis_config.rb
@@ -2,7 +2,6 @@
 
 module Scholarsphere
   class RedisConfig
-
     def host
       ENV.fetch('REDIS_HOST', nil)
     end
@@ -21,6 +20,7 @@ module Scholarsphere
 
     def valid?
       return true if host
+
       false
     end
 

--- a/start.sh
+++ b/start.sh
@@ -1,13 +1,11 @@
 
-
-if [ ${APP_ROLE:-app} == "sidekiq" ]; then
-    echo "starting sidekiq"
-    bundle exec sidekiq
-else
-    echo "starting rails"
-    rm -f tmp/pids/server.pid
-    bundle exec rails db:create
-    bundle exec rails db:migrate
-    bundle exec rails solr:init
-    bundle exec rails s -b '0.0.0.0'
+if [ ${RAILS_ENV:-development} != "production" ]; then
+  bundle check || bundle
 fi
+
+echo "starting rails"
+rm -f tmp/pids/server.pid
+bundle exec rails db:create
+bundle exec rails db:migrate
+bundle exec rails solr:init
+bundle exec rails s -b '0.0.0.0'


### PR DESCRIPTION
Fixes #104 

- adds sidekiq
- adds redis to docker-compose
- mounts sidekiq/web at `/sidekiq` for authenticated users
- conditionally sets the active job adapter to `:sidekiq`

TODO:
Once #37  is closed, we will need to add 
```
authenticate :user, lambda { |u| u.is_admin? } do
  mount Sidekiq::Web => '/sidekiq'
end
```