### PR TITLE
Tie members into groups

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -4,4 +4,10 @@ class Group < ApplicationRecord
   has_many :access_controls,
            as: :agent,
            dependent: :destroy
+
+  has_many :user_group_memberships,
+           dependent: :destroy
+
+  has_many :users,
+           through: :user_group_memberships
 end

--- a/app/models/user_group_membership.rb
+++ b/app/models/user_group_membership.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class UserGroupMembership < ApplicationRecord
+  belongs_to :user
+  belongs_to :group
+end

--- a/db/migrate/20191211190116_create_user_group_memberships.rb
+++ b/db/migrate/20191211190116_create_user_group_memberships.rb
@@ -1,0 +1,10 @@
+class CreateUserGroupMemberships < ActiveRecord::Migration[6.0]
+  def change
+    create_table :user_group_memberships do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :group, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20191211194026_add_index_to_groups_name.rb
+++ b/db/migrate/20191211194026_add_index_to_groups_name.rb
@@ -1,0 +1,5 @@
+class AddIndexToGroupsName < ActiveRecord::Migration[6.0]
+  def change
+    add_index :groups, :name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_02_155736) do
+ActiveRecord::Schema.define(version: 2019_12_11_194026) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -78,6 +78,7 @@ ActiveRecord::Schema.define(version: 2019_12_02_155736) do
     t.string "name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_groups_on_name"
   end
 
   create_table "searches", id: :serial, force: :cascade do |t|
@@ -87,6 +88,15 @@ ActiveRecord::Schema.define(version: 2019_12_02_155736) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_searches_on_user_id"
+  end
+
+  create_table "user_group_memberships", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "group_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["group_id"], name: "index_user_group_memberships_on_group_id"
+    t.index ["user_id"], name: "index_user_group_memberships_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -146,6 +156,8 @@ ActiveRecord::Schema.define(version: 2019_12_02_155736) do
   add_foreign_key "aliases", "creators"
   add_foreign_key "file_version_memberships", "file_resources"
   add_foreign_key "file_version_memberships", "work_versions"
+  add_foreign_key "user_group_memberships", "groups"
+  add_foreign_key "user_group_memberships", "users"
   add_foreign_key "work_creations", "aliases"
   add_foreign_key "work_creations", "works"
   add_foreign_key "work_versions", "works"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,9 @@
 version: '3.5'
-x-web_env: &web_env
-  environment:
-      REDIS_HOST: redis
-      REDIS_PASSWORD: redispassword
+services:
+  web:
+    tty: true
+    stdin_open: true
+    environment:
       POSTGRES_DB: scholarsphere
       POSTGRES_USER: scholarsphere
       POSTGRES_PASSWORD: scholarsphere
@@ -15,37 +16,13 @@ x-web_env: &web_env
       SOLR_HOST: solr
       SOLR_COLLECTION: scholarsphere
       POSTGRES_HOST: db
-services:
-  redis:
-    image: redis:5.0.5
-    command: redis-server --requirepass redispassword
-    volumes:
-      - redis-data:/data
-    ports:
-    - "6379:6379"
-  sidekiq:
-    tty: true
-    stdin_open: true
-    <<: *web_env
-    build:
-      context: . 
-      target: sidekiq
-    volumes:
-    - bundle-data:/app/vendor/bundle
-    - node-data:/app/node_modules
-    - type: bind
-      source: ./
-      target: /app/
-  web:
-    tty: true
-    stdin_open: true
-    <<: *web_env
     build: 
       context: . 
       target: base
     volumes:
-    - bundle-data:/app/vendor/bundle
-    - node-data:/app/node_modules
+    # This is an empty volume to prevent empty dir bind it's way into the container
+    - /app/vendor/bundle
+    - /app/node_modules
     - type: bind
       source: ./
       target: /app/
@@ -94,9 +71,7 @@ services:
     - db-data:/var/lib/postgresql/data
 
 volumes:
-  redis-data:
   bundle-data:
-  node-data:
   minio-data:
   solr-data:
   db-data:

--- a/spec/factories/psu_oauth_responses.rb
+++ b/spec/factories/psu_oauth_responses.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
       given_name { Faker::Name.first_name }
       surname { Faker::Name.last_name }
       email { "#{access_id}@psu.edu" }
+      groups { Array.new(3) { Faker::Coffee.blend_name } }
     end
 
     provider { 'psu' }
@@ -24,7 +25,7 @@ FactoryBot.define do
         given_name: given_name,
         surname: surname,
         primary_affiliation: 'STAFF',
-        groups: ['some-group']
+        groups: groups
       }
     end
   end

--- a/spec/factories/user_group_memberships.rb
+++ b/spec/factories/user_group_memberships.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :user_group_membership do
+    user
+    group
+  end
+end

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe 'Dashboard' do
   it "lists the user's current work in published and draft states", with_user: :user do
     visit(dashboard_works_path)
     within('#user-util-collapse') do
+      # Must reload the user to get their current name (used below), because now
+      # a user's name is updated from OAuth when they log in. Our OAuth mock
+      # itself generates Fakerized attributes for the user, so we need to reload
+      # the user from the DB to access these in the test.
+      user.reload
+
       expect(page).to have_content("#{user.name} (#{user.access_id})")
       expect(page).to have_link('Works')
     end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe Group, type: :model do
   describe 'table' do
     it { is_expected.to have_db_column(:name) }
+    it { is_expected.to have_db_index(:name) }
   end
 
   describe 'factory' do
@@ -13,5 +14,7 @@ RSpec.describe Group, type: :model do
 
   describe 'associations' do
     it { is_expected.to have_many(:access_controls) }
+    it { is_expected.to have_many(:user_group_memberships) }
+    it { is_expected.to have_many(:users).through(:user_group_memberships) }
   end
 end

--- a/spec/models/user_group_membership_spec.rb
+++ b/spec/models/user_group_membership_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UserGroupMembership, type: :model do
+  describe 'table' do
+    it { is_expected.to have_db_column(:user_id) }
+    it { is_expected.to have_db_column(:group_id) }
+  end
+
+  describe 'factory' do
+    it { is_expected.to have_valid_factory(:user_group_membership) }
+  end
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:group) }
+  end
+end


### PR DESCRIPTION
A list of groups that the user belongs to will be coming out of our auth proxy. We take this list and sync it into the Groups table which maintains a relationship with the user's record.

With the user's group membership maintained locally, we can then use the groups to contruct access controls for enforcing group-based access on resources.

Fixes #37 

