### PR TITLE
renew vault token, don't pass the token on the CLI

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,9 +11,8 @@ function start_envconsul() {
     envconsul \
         -vault-addr=${VAULT_ADDR} \
         -secret=${VAULT_PATH} \
-        -vault-token=${VAULT_TOKEN} \
         -no-prefix=true \
-        -vault-renew-token=false \
+        -vault-renew-token=true \
         -once \
         -exec='bash start.sh'
 }


### PR DESCRIPTION
envconsul will read `VAULT_TOKEN` from the env, no need to pass it on the CLI. 

previously, we had thought a failed service would restart the whole pod, thus getting a _new_ token from vault, however this is not the case. a failed service will only restart that services container. in those cases, the token will be expired and the service will be in a crashing loop. have envconsul renew the token, so a service can restart itself.