### PR TITLE
DataCite metadata mapper

### DIFF
--- a/lib/data_cite.rb
+++ b/lib/data_cite.rb
@@ -2,4 +2,5 @@
 
 module DataCite
   require 'data_cite/client'
+  require 'data_cite/metadata'
 end

--- a/lib/data_cite/metadata.rb
+++ b/lib/data_cite/metadata.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module DataCite
+  class Metadata
+    class Error < StandardError; end
+    class ValidationError < Error; end
+
+    attr_reader :work_version
+
+    RESOURCE_TYPES = {
+      Work::Types::DATASET => 'Dataset'
+    }.freeze
+
+    def initialize(work_version:)
+      @work_version = work_version
+      @work = work_version.work
+    end
+
+    def attributes
+      {
+        titles: [{ title: work_version.title }],
+        creators: [creator],
+        publicationYear: publication_year,
+        types: {
+          resourceTypeGeneral: resource_type
+        }
+      }
+    end
+
+    def validate!
+      raise ValidationError.new("title can't be blank") if attributes[:titles].map { |t| t[:title] }.all?(&:blank?)
+
+      raise ValidationError.new("publicationYear can't be blank") if attributes[:publicationYear].blank?
+
+      raise ValidationError.new("Unknown mapping for work type: #{work.work_type.inspect}") if attributes.dig(
+        :types, :resourceTypeGeneral
+      ).blank?
+    end
+
+    def valid?
+      validate! && true
+    rescue Error
+      false
+    end
+
+    private
+
+      attr_reader :work
+
+      def creator
+        {
+          givenName: work.depositor.given_name,
+          familyName: work.depositor.surname
+        }
+      end
+
+      def publication_year
+        date = parsed_publication_date || work_version.created_at
+        date&.year
+      end
+
+      def parsed_publication_date
+        Time.zone.parse(work_version.published_date.first)
+      rescue ArgumentError, TypeError
+        nil
+      end
+
+      def resource_type
+        RESOURCE_TYPES[work.work_type]
+      end
+  end
+end

--- a/spec/lib/data_cite/metadata_spec.rb
+++ b/spec/lib/data_cite/metadata_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'data_cite'
+require 'factory_bot'
+
+RSpec.describe DataCite::Metadata do
+  subject(:metadata) { described_class.new(work_version: work_version) }
+
+  let(:attributes) { metadata.attributes }
+
+  let(:work_version) { FactoryBot.build_stubbed :work_version, :with_complete_metadata }
+  let(:work) { work_version.work }
+
+  describe '#initialize' do
+    it 'accepts a WorkVersion' do
+      metadata = described_class.new(work_version: work_version)
+      expect(metadata.work_version).to eq work_version
+    end
+  end
+
+  describe '#attributes' do
+    context 'when given the happy path' do
+      it "maps the given WorkVersion's attributes into ones needed by DataCite" do
+        expect(attributes[:titles]).to eq([{ title: work_version.title }])
+        expect(attributes[:creators]).to eq(
+          [{
+            givenName: work_version.work.depositor.given_name,
+            familyName: work_version.work.depositor.surname
+          }]
+        )
+
+        # The following are tested thoroughly below
+        expect(attributes[:publicationYear]).to be_present
+        expect(attributes.dig(:types, :resourceTypeGeneral)).to be_present
+      end
+    end
+
+    context 'when given variants of the publication year' do
+      subject(:publicationYear) { attributes[:publicationYear] }
+
+      context 'when the publication_date can be parsed' do
+        before { work_version.published_date = ['2019-12-16'] }
+
+        it 'parses the publication_date and uses the year' do
+          expect(publicationYear).to eq 2019
+        end
+      end
+
+      context 'when the publication_date cannot be parsed' do
+        before do
+          work_version.published_date = ['nonsense']
+          work_version.created_at = Time.zone.parse('2019-12-16')
+        end
+
+        it 'uses the year from the date the record was created' do
+          expect(publicationYear).to eq 2019
+        end
+      end
+    end
+
+    context 'when given variants of the work_type' do
+      context 'when work_type is DATASET' do
+        before { allow(work).to receive(:work_type).and_return(Work::Types::DATASET) }
+
+        it 'maps to the correct resource type' do
+          expect(attributes.dig(:types, :resourceTypeGeneral)).to eq 'Dataset'
+        end
+      end
+    end
+  end
+
+  describe '#validate! and #valid?' do
+    context 'when title is blank' do
+      before { work_version.title = nil }
+
+      it { expect { metadata.validate! }.to raise_error(described_class::ValidationError) }
+      it { expect(metadata).not_to be_valid }
+    end
+
+    context 'when publication_date and created_at are empty/blank' do
+      before do
+        work_version.published_date = []
+        work_version.created_at = nil
+      end
+
+      it { expect { metadata.validate! }.to raise_error(described_class::ValidationError) }
+      it { expect(metadata).not_to be_valid }
+    end
+
+    context 'when work_type is empty' do
+      before { work.work_type = nil }
+
+      it { expect { metadata.validate! }.to raise_error(described_class::ValidationError) }
+      it { expect(metadata).not_to be_valid }
+    end
+  end
+end


### PR DESCRIPTION
Takes a WorkVersion and maps it to the minimum required set of metadata for DataCite

References #101 