### PR TITLE
Define permissions based on access controls

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,3 +35,7 @@ RSpec/MultipleExpectations:
 RSpec/EmptyLineAfterSubject:
   Exclude:
     - 'spec/factories/work_versions.rb'
+
+RSpec/LeakyConstantDeclaration:
+  Exclude:
+    - 'spec/models/permissions_builder_spec.rb'

--- a/app/models/access_control.rb
+++ b/app/models/access_control.rb
@@ -1,8 +1,26 @@
 # frozen_string_literal: true
 
 class AccessControl < ApplicationRecord
+  class Level
+    DISCOVER = 'discover'
+    READ = 'read'
+    EDIT = 'edit'
+
+    def self.all
+      [DISCOVER, READ, EDIT]
+    end
+
+    def self.default
+      DISCOVER
+    end
+  end
+
   belongs_to :agent,
              polymorphic: true
   belongs_to :resource,
              polymorphic: true
+
+  validates :access_level,
+            uniqueness: { scope: [:agent, :resource] },
+            inclusion: { in: AccessControl::Level.all }
 end

--- a/app/models/concerns/permissions.rb
+++ b/app/models/concerns/permissions.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Permissions
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :access_controls,
+             as: :resource,
+             dependent: :destroy
+  end
+
+  include PermissionsBuilder.new(level: AccessControl::Level::DISCOVER, agents: [User, Group])
+  include PermissionsBuilder.new(level: AccessControl::Level::READ, agents: [User, Group])
+  include PermissionsBuilder.new(level: AccessControl::Level::EDIT, agents: [User, Group])
+
+  def apply_open_access
+    return if open_access?
+
+    access_controls.build(access_level: AccessControl::Level::READ, agent: Group.public_agent)
+  end
+
+  def open_access?
+    access_controls.any? { |control| control.agent.public? }
+  end
+
+  def apply_authorized_access
+    return if authorized_access?
+
+    access_controls.build(access_level: AccessControl::Level::READ, agent: Group.authorized_agent)
+  end
+
+  def authorized_access?
+    access_controls.any? { |control| control.agent.authorized? }
+  end
+end

--- a/app/models/concerns/permissions_builder.rb
+++ b/app/models/concerns/permissions_builder.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# @abstract Uses the module builder pattern to add permissions to a class based on an agent type and a level of access.
+#
+# @example
+# class ControledResource
+#   include PermissionsBuilder.new(level: 'scratch', agents: [Dog, Cat])
+# end
+#
+# >  pole = ControlledResource.new
+# >  dog = Dog.new
+# >  cat = Cat.new
+# >  pole.apply_scratch_access(dog)
+# >  pole.scratch_access?(dog)
+# => true
+# >  pole.scratch_access?(cat)
+# => false
+# >  pole.scratch_agents
+# => [dog]
+# >  pole.scratch_dogs
+# => [dog]
+# >  pole.scratch_cats
+# => []
+#
+
+class PermissionsBuilder < Module
+  def initialize(level:, agents:)
+    define_method "#{level}_agents" do
+      access_controls.map do |control|
+        control.agent if control.access_level == level
+      end
+    end
+
+    define_method "#{level}_access?" do |agent|
+      send("#{level}_agents").include?(agent)
+    end
+
+    define_method "apply_#{level}_access" do |agent|
+      return if send("#{level}_access?", agent)
+
+      access_controls.build(access_level: level, agent: agent)
+    end
+
+    agents.each do |agent|
+      define_method "#{level}_#{agent.to_s.pluralize.downcase}" do
+        send("#{level}_agents").select { |level_agent| level_agent.is_a?(agent) }
+      end
+    end
+  end
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,6 +1,27 @@
 # frozen_string_literal: true
 
 class Group < ApplicationRecord
+  PUBLIC_AGENT_NAME = 'public'
+  AUTHORIZED_AGENT_NAME = 'authorized'
+
+  def self.public_agent
+    @public_agent ||= find_or_create_by(name: PUBLIC_AGENT_NAME)
+  end
+  delegate :public_agent, to: :class
+
+  def self.authorized_agent
+    @authorized_agent ||= find_or_create_by(name: AUTHORIZED_AGENT_NAME)
+  end
+  delegate :authorized_agent, to: :class
+
+  def public?
+    self == public_agent
+  end
+
+  def authorized?
+    self == authorized_agent
+  end
+
   has_many :access_controls,
            as: :agent,
            dependent: :destroy

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Work < ApplicationRecord
+  include Permissions
+
   belongs_to :depositor,
              class_name: 'User',
              foreign_key: 'depositor_id',
@@ -11,10 +13,6 @@ class Work < ApplicationRecord
 
   has_many :aliases,
            through: :work_creations
-
-  has_many :access_controls,
-           as: :resource,
-           dependent: :destroy
 
   has_many :versions,
            -> { order(created_at: :asc) },

--- a/spec/factories/access_controls.rb
+++ b/spec/factories/access_controls.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :access_control do
-    access_level { 'MyString' }
+    access_level { AccessControl::Level.default }
 
     association(:agent, factory: :user)
     association(:resource, factory: :work)

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -44,4 +44,12 @@ FactoryBot.define do
   sequence(:work_title) do |n|
     FactoryBotHelpers.work_title(n)
   end
+
+  trait(:with_open_access) do
+    after(:build, &:apply_open_access)
+  end
+
+  trait(:with_authorized_access) do
+    after(:build, &:apply_authorized_access)
+  end
 end

--- a/spec/models/access_control_spec.rb
+++ b/spec/models/access_control_spec.rb
@@ -24,7 +24,37 @@ RSpec.describe AccessControl, type: :model do
     it { is_expected.to belong_to(:resource) }
   end
 
-  describe 'validations' do
-    pending 'needed on access_level?'
+  describe '#valid?' do
+    subject { described_class.new(agent: agent, resource: resource, access_level: access_level) }
+
+    let(:resource) { create(:work) }
+    let(:agent) { create(:user) }
+    let(:access_level) { AccessControl::Level::READ }
+
+    context 'when specifying a duplicate type of access' do
+      before { described_class.create(agent: agent, resource: resource, access_level: access_level) }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'when specifying a different type of access' do
+      before { described_class.create(agent: agent, resource: resource, access_level: AccessControl::Level::EDIT) }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'when specifying an unsupported access level type' do
+      let(:access_level) { 'bogus' }
+
+      it { is_expected.not_to be_valid }
+    end
+  end
+
+  describe 'AccessControl::Level' do
+    specify { expect(AccessControl::Level::DISCOVER).to eq('discover') }
+    specify { expect(AccessControl::Level::READ).to eq('read') }
+    specify { expect(AccessControl::Level::EDIT).to eq('edit') }
+    specify { expect(AccessControl::Level.default).to eq('discover') }
+    specify { expect(AccessControl::Level.all).to contain_exactly('discover', 'read', 'edit') }
   end
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -17,4 +17,64 @@ RSpec.describe Group, type: :model do
     it { is_expected.to have_many(:user_group_memberships) }
     it { is_expected.to have_many(:users).through(:user_group_memberships) }
   end
+
+  describe '.PUBLIC_AGENT_NAME' do
+    subject { described_class::PUBLIC_AGENT_NAME }
+
+    it { is_expected.to eq('public') }
+  end
+
+  describe '.public_agent' do
+    subject { described_class.public_agent }
+
+    its(:name) { is_expected.to eq(described_class::PUBLIC_AGENT_NAME) }
+  end
+
+  describe '#public_agent' do
+    its(:public_agent) { is_expected.to eq(described_class.public_agent) }
+  end
+
+  describe '#public?' do
+    context 'with the public group' do
+      subject { described_class.public_agent }
+
+      it { is_expected.to be_public }
+    end
+
+    context 'with any other group' do
+      subject { described_class.new }
+
+      it { is_expected.not_to be_public }
+    end
+  end
+
+  describe '.AUTHORIZED_AGENT_NAME' do
+    subject { described_class::AUTHORIZED_AGENT_NAME }
+
+    it { is_expected.to eq('authorized') }
+  end
+
+  describe '.authorized_agent' do
+    subject { described_class.authorized_agent }
+
+    its(:name) { is_expected.to eq(described_class::AUTHORIZED_AGENT_NAME) }
+  end
+
+  describe '#authorized_agent' do
+    its(:authorized_agent) { is_expected.to eq(described_class.authorized_agent) }
+  end
+
+  describe '#authorized?' do
+    context 'with the authorized group' do
+      subject { described_class.authorized_agent }
+
+      it { is_expected.to be_authorized }
+    end
+
+    context 'with any other group' do
+      subject { described_class.new }
+
+      it { is_expected.not_to be_authorized }
+    end
+  end
 end

--- a/spec/models/permissions_builder_spec.rb
+++ b/spec/models/permissions_builder_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe PermissionsBuilder do
+  subject { Pole.new }
+
+  before(:all) do
+    class Dog; end
+    class Cat; end
+
+    class Pole
+      include PermissionsBuilder.new(level: 'scratch', agents: [Dog, Cat])
+    end
+  end
+
+  after(:all) do
+    ActiveSupport::Dependencies.remove_constant('Dog')
+    ActiveSupport::Dependencies.remove_constant('Cat')
+    ActiveSupport::Dependencies.remove_constant('Pole')
+  end
+
+  it { is_expected.to respond_to(:apply_scratch_access) }
+  it { is_expected.to respond_to(:scratch_access?) }
+  it { is_expected.to respond_to(:scratch_agents) }
+  it { is_expected.to respond_to(:scratch_dogs) }
+  it { is_expected.to respond_to(:scratch_cats) }
+end

--- a/spec/models/permissions_spec.rb
+++ b/spec/models/permissions_spec.rb
@@ -1,0 +1,287 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Permissions do
+  subject { resource }
+
+  let(:resource) { build(:work) }
+
+  it { is_expected.to respond_to(:discover_agents) }
+  it { is_expected.to respond_to(:discover_users) }
+  it { is_expected.to respond_to(:discover_groups) }
+  it { is_expected.to respond_to(:read_agents) }
+  it { is_expected.to respond_to(:read_users) }
+  it { is_expected.to respond_to(:read_groups) }
+  it { is_expected.to respond_to(:edit_agents) }
+  it { is_expected.to respond_to(:edit_users) }
+  it { is_expected.to respond_to(:edit_groups) }
+
+  describe '#apply_open_access' do
+    context 'when the resource is not open access' do
+      it 'adds the necessary access controls to allow open access' do
+        expect(resource.access_controls).to be_empty
+        resource.apply_open_access
+        expect(resource.access_controls.first.agent).to eq(Group.public_agent)
+        expect(resource.access_controls.first.access_level).to eq(AccessControl::Level::READ)
+      end
+    end
+
+    context 'when the resource already is open access' do
+      let(:resource) { build(:work, :with_open_access) }
+
+      it 'does not add a duplicate access control' do
+        expect(resource.access_controls.map(&:agent)).to contain_exactly(Group.public_agent)
+        resource.apply_open_access
+        expect(resource.access_controls.map(&:agent)).to contain_exactly(Group.public_agent)
+      end
+    end
+  end
+
+  describe '#open_access?' do
+    context 'with an open access resource' do
+      let(:resource) { build(:work, :with_open_access) }
+
+      it { is_expected.to be_open_access }
+    end
+
+    context 'when a restricted resource' do
+      let(:resource) { build(:work) }
+
+      it { is_expected.not_to be_open_access }
+    end
+  end
+
+  describe '#apply_authorized_access' do
+    context 'when the resource is not authorized access' do
+      it 'adds the necessary access controls to allow authorized access' do
+        expect(resource.access_controls).to be_empty
+        resource.apply_authorized_access
+        expect(resource.access_controls.first.agent).to eq(Group.authorized_agent)
+        expect(resource.access_controls.first.access_level).to eq(AccessControl::Level::READ)
+      end
+    end
+
+    context 'when the resource already has authorized access' do
+      let(:resource) { build(:work, :with_authorized_access) }
+
+      it 'does not add any duplicate access controls' do
+        expect(resource.access_controls.map(&:agent)).to contain_exactly(Group.authorized_agent)
+        resource.apply_authorized_access
+        expect(resource.access_controls.map(&:agent)).to contain_exactly(Group.authorized_agent)
+      end
+    end
+  end
+
+  describe '#authorized?' do
+    context 'with an autorized resource' do
+      let(:resource) { build(:work, :with_authorized_access) }
+
+      it { is_expected.to be_authorized_access }
+    end
+
+    context 'when a restricted resource' do
+      let(:resource) { build(:work) }
+
+      it { is_expected.not_to be_authorized_access }
+    end
+  end
+
+  describe '#apply_discover_access' do
+    before { resource.apply_discover_access(agent) }
+
+    context 'with a group agent' do
+      let(:agent) { build(:group) }
+
+      its(:discover_groups) { is_expected.to contain_exactly(agent) }
+    end
+
+    context 'with a user agent' do
+      let(:agent) { build(:user) }
+
+      its(:discover_users) { is_expected.to contain_exactly(agent) }
+    end
+
+    context 'when a user already has discover access' do
+      let(:agent) { build(:user) }
+
+      it 'does not add any duplicate access controls' do
+        expect(resource.access_controls.map(&:agent)).to contain_exactly(agent)
+        resource.apply_discover_access(agent)
+        expect(resource.access_controls.map(&:agent)).to contain_exactly(agent)
+      end
+    end
+
+    context 'when a group already has discover access' do
+      let(:agent) { build(:group) }
+
+      it 'does not add any duplicate access controls' do
+        expect(resource.access_controls.map(&:agent)).to contain_exactly(agent)
+        resource.apply_discover_access(agent)
+        expect(resource.access_controls.map(&:agent)).to contain_exactly(agent)
+      end
+    end
+  end
+
+  describe '#discover_access?' do
+    context 'when a user has discover access to the resource' do
+      let(:agent) { build(:user) }
+
+      before { resource.apply_discover_access(agent) }
+
+      specify { expect(resource.discover_access?(agent)).to be(true) }
+    end
+
+    context 'when a user does NOT have discover access to the resource' do
+      let(:agent) { build(:user) }
+
+      specify { expect(resource.discover_access?(agent)).to be(false) }
+    end
+
+    context 'when a group has discover access to the resource' do
+      let(:agent) { build(:group) }
+
+      before { resource.apply_discover_access(agent) }
+
+      specify { expect(resource.discover_access?(agent)).to be(true) }
+    end
+
+    context 'when a group does NOT have discover access to the resource' do
+      let(:agent) { build(:group) }
+
+      specify { expect(resource.discover_access?(agent)).to be(false) }
+    end
+  end
+
+  describe '#apply_read_access' do
+    before { resource.apply_read_access(agent) }
+
+    context 'with a group agent' do
+      let(:agent) { build(:group) }
+
+      its(:read_groups) { is_expected.to contain_exactly(agent) }
+    end
+
+    context 'with a user agent' do
+      let(:agent) { build(:user) }
+
+      its(:read_users) { is_expected.to contain_exactly(agent) }
+    end
+
+    context 'when a user already has read access' do
+      let(:agent) { build(:user) }
+
+      it 'does not add any duplicate access controls' do
+        expect(resource.access_controls.map(&:agent)).to contain_exactly(agent)
+        resource.apply_read_access(agent)
+        expect(resource.access_controls.map(&:agent)).to contain_exactly(agent)
+      end
+    end
+
+    context 'when a group already has read access' do
+      let(:agent) { build(:group) }
+
+      it 'does not add any duplicate access controls' do
+        expect(resource.access_controls.map(&:agent)).to contain_exactly(agent)
+        resource.apply_read_access(agent)
+        expect(resource.access_controls.map(&:agent)).to contain_exactly(agent)
+      end
+    end
+  end
+
+  describe '#read_access?' do
+    context 'when a user has read access to the resource' do
+      let(:agent) { build(:user) }
+
+      before { resource.apply_read_access(agent) }
+
+      specify { expect(resource.read_access?(agent)).to be(true) }
+    end
+
+    context 'when a user does NOT have read access to the resource' do
+      let(:agent) { build(:user) }
+
+      specify { expect(resource.read_access?(agent)).to be(false) }
+    end
+
+    context 'when a group has read access to the resource' do
+      let(:agent) { build(:group) }
+
+      before { resource.apply_read_access(agent) }
+
+      specify { expect(resource.read_access?(agent)).to be(true) }
+    end
+
+    context 'when a group does NOT have read access to the resource' do
+      let(:agent) { build(:group) }
+
+      specify { expect(resource.read_access?(agent)).to be(false) }
+    end
+  end
+
+  describe '#apply_edit_access' do
+    before { resource.apply_edit_access(agent) }
+
+    context 'with a group agent' do
+      let(:agent) { build(:group) }
+
+      its(:edit_groups) { is_expected.to contain_exactly(agent) }
+    end
+
+    context 'with a user agent' do
+      let(:agent) { build(:user) }
+
+      its(:edit_users) { is_expected.to contain_exactly(agent) }
+    end
+
+    context 'when a user already has edit access' do
+      let(:agent) { build(:user) }
+
+      it 'does not add any duplicate access controls' do
+        expect(resource.access_controls.map(&:agent)).to contain_exactly(agent)
+        resource.apply_edit_access(agent)
+        expect(resource.access_controls.map(&:agent)).to contain_exactly(agent)
+      end
+    end
+
+    context 'when a group already has edit access' do
+      let(:agent) { build(:group) }
+
+      it 'does not add any duplicate access controls' do
+        expect(resource.access_controls.map(&:agent)).to contain_exactly(agent)
+        resource.apply_edit_access(agent)
+        expect(resource.access_controls.map(&:agent)).to contain_exactly(agent)
+      end
+    end
+  end
+
+  describe '#edit_access?' do
+    context 'when a user has edit access to the resource' do
+      let(:agent) { build(:user) }
+
+      before { resource.apply_edit_access(agent) }
+
+      specify { expect(resource.edit_access?(agent)).to be(true) }
+    end
+
+    context 'when a user does NOT have edit access to the resource' do
+      let(:agent) { build(:user) }
+
+      specify { expect(resource.edit_access?(agent)).to be(false) }
+    end
+
+    context 'when a group has edit access to the resource' do
+      let(:agent) { build(:group) }
+
+      before { resource.apply_edit_access(agent) }
+
+      specify { expect(resource.edit_access?(agent)).to be(true) }
+    end
+
+    context 'when a group does NOT have edit access to the resource' do
+      let(:agent) { build(:group) }
+
+      specify { expect(resource.edit_access?(agent)).to be(false) }
+    end
+  end
+end


### PR DESCRIPTION
Using a set of "levels" for defining access rights to work resources, an agent, such as a user or group, is granted a level of access that affords them a set of abilities with a given resource.  These levels include:

  * discover access, for reading metadata but not downloading
content
  * read access, for both metadata and binary content access
  * edit access, for all other rights, including the ability to create,
edit, and delete content, as well as create new versions of works

Two application-wide groups are provided for granting open access, and access to anyone at Penn State. A Permissions module manages the agents who are granted different levels of access and ensures that each combination of agent and level is unique to a particular resource. The module builder pattern dynamically adds the methods for creating different permission dimensions. See https://dejimata.com/2017/5/20/the-ruby-module-builder-pattern

Fixes #132, #133, #135