### PR TITLE
Depositor has edit access

### DIFF
--- a/app/models/concerns/permissions.rb
+++ b/app/models/concerns/permissions.rb
@@ -13,6 +13,14 @@ module Permissions
   include PermissionsBuilder.new(level: AccessControl::Level::READ, agents: [User, Group])
   include PermissionsBuilder.new(level: AccessControl::Level::EDIT, agents: [User, Group])
 
+  # @note This does not create an access control granting the depositor edit access. The depositor is already linked to
+  # the work by the User -> Work relationship.
+  def edit_users
+    return super if edit_access?(depositor)
+
+    super.append(depositor)
+  end
+
   def apply_open_access
     return if open_access?
 

--- a/spec/models/permissions_spec.rb
+++ b/spec/models/permissions_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe Permissions do
     context 'with a user agent' do
       let(:agent) { build(:user) }
 
-      its(:edit_users) { is_expected.to contain_exactly(agent) }
+      its(:edit_users) { is_expected.to contain_exactly(agent, resource.depositor) }
     end
 
     context 'when a user already has edit access' do
@@ -282,6 +282,23 @@ RSpec.describe Permissions do
       let(:agent) { build(:group) }
 
       specify { expect(resource.edit_access?(agent)).to be(false) }
+    end
+  end
+
+  describe '#edit_users' do
+    context 'when the depositor does NOT have edit access with an AccessControl object' do
+      it 'is added to the list of users' do
+        expect(resource.access_controls).to be_empty
+        expect(resource.edit_users).to contain_exactly(resource.depositor)
+      end
+    end
+
+    context 'when the depositor has edit access via an AccessControl object' do
+      before { resource.apply_edit_access(resource.depositor) }
+
+      it 'is not duplicated in the list of edit users' do
+        expect(resource.edit_users).to contain_exactly(resource.depositor)
+      end
     end
   end
 end


### PR DESCRIPTION
Ensures that the depositor is always a member of 'edit_users' and therefore has edit access. A separate ACL is NOT created in order to provide this access because the depsitor is already linked to the work via the Work -> User relationship.

Fixes #131 