### PR TITLE
Mint and/or update a DOI for WorkVersions and Works

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,7 @@ Metrics/BlockLength:
 RSpec/DescribeClass:
   Exclude:
     - 'spec/features/**/*'
+    - 'spec/integration/**/*'
 
 RSpec/ExampleLength:
   Enabled:

--- a/app/services/doi_service.rb
+++ b/app/services/doi_service.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'data_cite'
+
+class DoiService
+  class Error < StandardError; end
+
+  def self.call(resource, client_source: nil, metadata_source: nil)
+    instance = new(resource)
+    instance.client_source = client_source
+    instance.metadata_source = metadata_source
+    instance.call
+  end
+
+  attr_reader :resource
+
+  attr_writer :client_source,
+              :metadata_source
+
+  def initialize(resource)
+    @resource = resource
+
+    raise Error.new("Cannot mint a doi for an invalid resource: #{resource.inspect}") unless resource.valid?
+
+    if resource.is_a? WorkVersion
+      @work_version = resource
+    elsif resource.is_a? Work
+      @work_version = resource.latest_version
+    else
+      raise ArgumentError, 'DoiService expects resource to be a Work or WorkVersion'
+    end
+  end
+
+  def call
+    if resource.doi.blank? && work_version.draft?
+      register_and_save_new_doi
+    elsif resource.doi.present? && work_version.draft?
+      # No-op
+    else
+      existing_doi = resource.doi.presence
+      should_save_new_doi = existing_doi.blank?
+
+      publish_doi(
+        doi: existing_doi, # will register a new doi if nil
+        update_resource: should_save_new_doi
+      )
+    end
+  end
+
+  def client_source
+    @client_source ||= DataCite::Client.public_method(:new)
+  end
+
+  def metadata_source
+    @metadata_source ||= DataCite::Metadata.public_method(:new)
+  end
+
+  private
+
+    attr_reader :work_version
+
+    def register_and_save_new_doi
+      new_doi, _response_metadata = client_source.call.register
+      save_doi(new_doi)
+    end
+
+    def publish_doi(doi:, update_resource:)
+      metadata = metadata_source
+        .call(work_version: work_version)
+        .tap(&:validate!)
+        .attributes
+
+      response_doi, _response_metadata = client_source.call.publish(
+        doi: doi,
+        metadata: metadata
+      )
+
+      save_doi(response_doi) if update_resource
+    end
+
+    def save_doi(doi)
+      resource.update!(doi: doi)
+    end
+end

--- a/db/migrate/20191217203329_add_doi_to_works_and_work_versions.rb
+++ b/db/migrate/20191217203329_add_doi_to_works_and_work_versions.rb
@@ -1,0 +1,6 @@
+class AddDoiToWorksAndWorkVersions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :works, :doi, :string
+    add_column :work_versions, :doi, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_11_194026) do
+ActiveRecord::Schema.define(version: 2019_12_17_203329) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -141,6 +141,7 @@ ActiveRecord::Schema.define(version: 2019_12_11_194026) do
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "uuid", default: -> { "uuid_generate_v4()" }
     t.integer "version_number", null: false
+    t.string "doi"
     t.index ["work_id"], name: "index_work_versions_on_work_id"
   end
 
@@ -150,6 +151,7 @@ ActiveRecord::Schema.define(version: 2019_12_11_194026) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "uuid", default: -> { "uuid_generate_v4()" }
+    t.string "doi"
     t.index ["depositor_id"], name: "index_works_on_depositor_id"
   end
 

--- a/lib/data_cite/client.rb
+++ b/lib/data_cite/client.rb
@@ -54,6 +54,10 @@ module DataCite
       process_response put(doi: doi, data: data)
     end
 
+    def get(doi:)
+      process_response connection.get("/dois/#{doi}")
+    end
+
     def delete(doi:)
       process_response connection.delete("/dois/#{doi}")
     end

--- a/lib/data_cite/metadata.rb
+++ b/lib/data_cite/metadata.rb
@@ -23,7 +23,8 @@ module DataCite
         publicationYear: publication_year,
         types: {
           resourceTypeGeneral: resource_type
-        }
+        },
+        url: generate_url
       }
     end
 
@@ -67,6 +68,10 @@ module DataCite
 
       def resource_type
         RESOURCE_TYPES[work.work_type]
+      end
+
+      def generate_url
+        'http://example.test'
       end
   end
 end

--- a/spec/fixtures/vcr_cassettes/DataCite_Client/_get/with_an_existing_DRAFT_doi/retrieves_the_doi.yml
+++ b/spec/fixtures/vcr_cassettes/DataCite_Client/_get/with_an_existing_DRAFT_doi/retrieves_the_doi.yml
@@ -1,0 +1,111 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.test.datacite.org/dois
+    body:
+      encoding: UTF-8
+      string: '{"data":{"type":"dois","attributes":{"doi":"10.33532/abc950"}}}'
+    headers:
+      User-Agent:
+      - Faraday v0.17.0
+      Content-Type:
+      - application/vnd.api+json
+      Authorization:
+      - Basic cHN1LnNzLWRldjpzc2RldjIwMTg=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 18 Dec 2019 23:18:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 201 Created
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding, Origin
+      X-Credential-Username:
+      - psu.ss-dev
+      X-Request-Id:
+      - 48ed7d81-8ebc-473b-8f71-8e655d67da59
+      Location:
+      - https://api.test.datacite.org/dois/3393474
+      Etag:
+      - W/"7857bd604b2a974028cd25524bac5054"
+      X-Runtime:
+      - '0.071607'
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+      Server:
+      - nginx/1.17.3 + Phusion Passenger 6.0.4
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"id":"10.33532/abc950","type":"dois","attributes":{"doi":"10.33532/abc950","prefix":"10.33532","suffix":"abc950","identifiers":null,"creators":[],"titles":null,"publisher":null,"container":{},"publicationYear":null,"subjects":null,"contributors":[],"dates":null,"language":null,"types":{},"relatedIdentifiers":null,"sizes":null,"formats":null,"version":null,"rightsList":[],"descriptions":null,"geoLocations":null,"fundingReferences":null,"xml":null,"url":null,"contentUrl":null,"metadataVersion":0,"schemaVersion":null,"source":null,"isActive":false,"state":"draft","reason":null,"landingPage":null,"created":"2019-12-18T23:18:12.000Z","registered":null,"published":"","updated":"2019-12-18T23:18:12.000Z"},"relationships":{"client":{"data":{"id":"psu.ss-dev","type":"clients"}},"media":{"data":{"id":"10.33532/abc950","type":"media"}}}},"included":[{"id":"psu.ss-dev","type":"clients","attributes":{"name":"Scholarsphere
+        Devlopement","symbol":"PSU.SS-DEV","year":2018,"contactEmail":"awead@psu.edu","alternateName":null,"description":null,"language":null,"clientType":"repository","domains":"*","re3data":null,"opendoar":null,"issn":null,"url":null,"created":"2018-11-02T18:30:18.000Z","updated":"2018-11-02T18:31:18.000Z","isActive":true,"hasPassword":true},"relationships":{"provider":{"data":{"id":"psu","type":"providers"}},"prefixes":{"data":[{"id":"10.33532","type":"prefixes"}]}}}]}'
+    http_version: 
+  recorded_at: Wed, 18 Dec 2019 23:18:12 GMT
+- request:
+    method: get
+    uri: https://api.test.datacite.org/dois/10.33532/abc950
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.0
+      Authorization:
+      - Basic cHN1LnNzLWRldjpzc2RldjIwMTg=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 18 Dec 2019 23:18:13 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding, Origin
+      X-Credential-Username:
+      - psu.ss-dev
+      X-Request-Id:
+      - b2dec157-bb1d-4c8f-8a6d-09038c9ba6bb
+      Etag:
+      - W/"68a02bd72c0e0a9eedda1ce52cabd356"
+      X-Runtime:
+      - '0.021443'
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+      Server:
+      - nginx/1.17.3 + Phusion Passenger 6.0.4
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"id":"10.33532/abc950","type":"dois","attributes":{"doi":"10.33532/abc950","prefix":"10.33532","suffix":"abc950","identifiers":null,"creators":[],"titles":null,"publisher":null,"container":{},"publicationYear":null,"subjects":null,"contributors":[],"dates":null,"language":null,"types":{},"relatedIdentifiers":null,"sizes":null,"formats":null,"version":null,"rightsList":[],"descriptions":null,"geoLocations":null,"fundingReferences":null,"xml":null,"url":null,"contentUrl":null,"metadataVersion":0,"schemaVersion":null,"source":null,"isActive":false,"state":"draft","reason":null,"landingPage":null,"created":"2019-12-18T23:18:12.000Z","registered":null,"published":"","updated":"2019-12-18T23:18:12.000Z"},"relationships":{"client":{"data":{"id":"psu.ss-dev","type":"clients"}},"media":{"data":{"id":"10.33532/abc950","type":"media"}}}},"included":[{"id":"psu.ss-dev","type":"clients","attributes":{"name":"Scholarsphere
+        Devlopement","symbol":"PSU.SS-DEV","year":2018,"contactEmail":"awead@psu.edu","alternateName":null,"description":null,"language":null,"clientType":"repository","domains":"*","re3data":null,"opendoar":null,"issn":null,"url":null,"created":"2018-11-02T18:30:18.000Z","updated":"2018-11-02T18:31:18.000Z","isActive":true,"hasPassword":true},"relationships":{"provider":{"data":{"id":"psu","type":"providers"}},"prefixes":{"data":[{"id":"10.33532","type":"prefixes"}]}}}]}'
+    http_version: 
+  recorded_at: Wed, 18 Dec 2019 23:18:13 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/DataCite_Client/_get/with_an_existing_PUBLISHED_doi/retrieves_the_doi.yml
+++ b/spec/fixtures/vcr_cassettes/DataCite_Client/_get/with_an_existing_PUBLISHED_doi/retrieves_the_doi.yml
@@ -1,0 +1,113 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.test.datacite.org/dois
+    body:
+      encoding: UTF-8
+      string: '{"data":{"type":"dois","attributes":{"titles":[{"title":"Work Title"}],"creators":[{"name":"Creator"}],"publicationYear":2019,"types":{"resourceTypeGeneral":"Text"},"url":"http://example.test","event":"publish","publisher":"scholarsphere","prefix":"10.33532"}}}'
+    headers:
+      User-Agent:
+      - Faraday v0.17.0
+      Content-Type:
+      - application/vnd.api+json
+      Authorization:
+      - Basic cHN1LnNzLWRldjpzc2RldjIwMTg=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 18 Dec 2019 23:22:56 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 201 Created
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding, Origin
+      X-Credential-Username:
+      - psu.ss-dev
+      X-Request-Id:
+      - 1b5992c0-61a9-4a78-b50e-3a0fe22492e7
+      Location:
+      - https://api.test.datacite.org/dois/3393476
+      Etag:
+      - W/"33ba2e025bf5209b423459f84f7d5fba"
+      X-Runtime:
+      - '0.101825'
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+      Server:
+      - nginx/1.17.3 + Phusion Passenger 6.0.4
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"id":"10.33532/0gye-r156","type":"dois","attributes":{"doi":"10.33532/0gye-r156","prefix":"10.33532","suffix":"0gye-r156","identifiers":null,"creators":[{"name":"Creator","affiliation":[]}],"titles":[{"title":"Work
+        Title"}],"publisher":"scholarsphere","container":{},"publicationYear":2019,"subjects":null,"contributors":[],"dates":null,"language":null,"types":{"resourceTypeGeneral":"Text"},"relatedIdentifiers":null,"sizes":null,"formats":null,"version":null,"rightsList":[],"descriptions":null,"geoLocations":null,"fundingReferences":null,"xml":"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMzM1MzIvMEdZRS1SMTU2PC9pZGVudGlmaWVyPgogIDxjcmVhdG9ycz4KICAgIDxjcmVhdG9yPgogICAgICA8Y3JlYXRvck5hbWU+Q3JlYXRvcjwvY3JlYXRvck5hbWU+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzPgogICAgPHRpdGxlPldvcmsgVGl0bGU8L3RpdGxlPgogIDwvdGl0bGVzPgogIDxwdWJsaXNoZXI+c2Nob2xhcnNwaGVyZTwvcHVibGlzaGVyPgogIDxwdWJsaWNhdGlvblllYXI+MjAxOTwvcHVibGljYXRpb25ZZWFyPgogIDxyZXNvdXJjZVR5cGUgcmVzb3VyY2VUeXBlR2VuZXJhbD0iVGV4dCIvPgogIDx2ZXJzaW9uLz4KPC9yZXNvdXJjZT4K","url":"http://example.test","contentUrl":null,"metadataVersion":0,"schemaVersion":null,"source":null,"isActive":true,"state":"findable","reason":null,"landingPage":null,"created":"2019-12-18T23:22:56.000Z","registered":null,"published":"2019","updated":"2019-12-18T23:22:56.000Z"},"relationships":{"client":{"data":{"id":"psu.ss-dev","type":"clients"}},"media":{"data":{"id":"10.33532/0gye-r156","type":"media"}}}},"included":[{"id":"psu.ss-dev","type":"clients","attributes":{"name":"Scholarsphere
+        Devlopement","symbol":"PSU.SS-DEV","year":2018,"contactEmail":"awead@psu.edu","alternateName":null,"description":null,"language":null,"clientType":"repository","domains":"*","re3data":null,"opendoar":null,"issn":null,"url":null,"created":"2018-11-02T18:30:18.000Z","updated":"2018-11-02T18:31:18.000Z","isActive":true,"hasPassword":true},"relationships":{"provider":{"data":{"id":"psu","type":"providers"}},"prefixes":{"data":[{"id":"10.33532","type":"prefixes"}]}}}]}'
+    http_version: 
+  recorded_at: Wed, 18 Dec 2019 23:22:56 GMT
+- request:
+    method: get
+    uri: https://api.test.datacite.org/dois/10.33532/0gye-r156
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.0
+      Authorization:
+      - Basic cHN1LnNzLWRldjpzc2RldjIwMTg=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 18 Dec 2019 23:22:57 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding, Origin
+      X-Credential-Username:
+      - psu.ss-dev
+      X-Request-Id:
+      - c97346ad-ff9d-46e7-8bf6-7229f3cdff5f
+      Etag:
+      - W/"45dadcacb0785a00caf6261858d6952e"
+      X-Runtime:
+      - '0.021837'
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+      Server:
+      - nginx/1.17.3 + Phusion Passenger 6.0.4
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"id":"10.33532/0gye-r156","type":"dois","attributes":{"doi":"10.33532/0gye-r156","prefix":"10.33532","suffix":"0gye-r156","identifiers":null,"creators":[{"name":"Creator","affiliation":[]}],"titles":[{"title":"Work
+        Title"}],"publisher":"scholarsphere","container":{},"publicationYear":2019,"subjects":null,"contributors":[],"dates":null,"language":null,"types":{"resourceTypeGeneral":"Text"},"relatedIdentifiers":null,"sizes":null,"formats":null,"version":null,"rightsList":[],"descriptions":null,"geoLocations":null,"fundingReferences":null,"xml":"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMzM1MzIvMEdZRS1SMTU2PC9pZGVudGlmaWVyPgogIDxjcmVhdG9ycz4KICAgIDxjcmVhdG9yPgogICAgICA8Y3JlYXRvck5hbWU+Q3JlYXRvcjwvY3JlYXRvck5hbWU+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzPgogICAgPHRpdGxlPldvcmsgVGl0bGU8L3RpdGxlPgogIDwvdGl0bGVzPgogIDxwdWJsaXNoZXI+c2Nob2xhcnNwaGVyZTwvcHVibGlzaGVyPgogIDxwdWJsaWNhdGlvblllYXI+MjAxOTwvcHVibGljYXRpb25ZZWFyPgogIDxyZXNvdXJjZVR5cGUgcmVzb3VyY2VUeXBlR2VuZXJhbD0iVGV4dCIvPgogIDx2ZXJzaW9uLz4KPC9yZXNvdXJjZT4K","url":"http://example.test","contentUrl":null,"metadataVersion":0,"schemaVersion":null,"source":null,"isActive":true,"state":"findable","reason":null,"landingPage":null,"created":"2019-12-18T23:22:56.000Z","registered":"2019-12-18T23:22:57.000Z","published":"2019","updated":"2019-12-18T23:22:57.000Z"},"relationships":{"client":{"data":{"id":"psu.ss-dev","type":"clients"}},"media":{"data":{"id":"10.33532/0gye-r156","type":"media"}}}},"included":[{"id":"psu.ss-dev","type":"clients","attributes":{"name":"Scholarsphere
+        Devlopement","symbol":"PSU.SS-DEV","year":2018,"contactEmail":"awead@psu.edu","alternateName":null,"description":null,"language":null,"clientType":"repository","domains":"*","re3data":null,"opendoar":null,"issn":null,"url":null,"created":"2018-11-02T18:30:18.000Z","updated":"2018-11-02T18:31:18.000Z","isActive":true,"hasPassword":true},"relationships":{"provider":{"data":{"id":"psu","type":"providers"}},"prefixes":{"data":[{"id":"10.33532","type":"prefixes"}]}}}]}'
+    http_version: 
+  recorded_at: Wed, 18 Dec 2019 23:22:57 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/DataCite_Client/_get/with_an_invalid_doi/raises_an_error.yml
+++ b/spec/fixtures/vcr_cassettes/DataCite_Client/_get/with_an_invalid_doi/raises_an_error.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.test.datacite.org/dois/bogus
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.0
+      Authorization:
+      - Basic cHN1LnNzLWRldjpzc2RldjIwMTg=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Wed, 18 Dec 2019 23:23:37 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 404 Not Found
+      Cache-Control:
+      - no-cache
+      Vary:
+      - Accept-Encoding, Origin
+      X-Request-Id:
+      - f039ff3f-c60b-4912-9dbb-dc9b9ca0fd61
+      X-Runtime:
+      - '0.009046'
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+      Server:
+      - nginx/1.17.3 + Phusion Passenger 6.0.4
+    body:
+      encoding: ASCII-8BIT
+      string: '{"errors":[{"status":"404","title":"The resource you are looking for
+        doesn''t exist."}]}'
+    http_version: 
+  recorded_at: Wed, 18 Dec 2019 23:23:37 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/DataCite_Client/_publish/when_called_multiple_times_with_the_same_doi/can_be_idempotentently_called_multiple_times_to_update_metadata.yml
+++ b/spec/fixtures/vcr_cassettes/DataCite_Client/_publish/when_called_multiple_times_with_the_same_doi/can_be_idempotentently_called_multiple_times_to_update_metadata.yml
@@ -1,0 +1,169 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.test.datacite.org/dois
+    body:
+      encoding: UTF-8
+      string: '{"data":{"type":"dois","attributes":{"doi":"10.33532/abc891"}}}'
+    headers:
+      User-Agent:
+      - Faraday v0.17.0
+      Content-Type:
+      - application/vnd.api+json
+      Authorization:
+      - Basic cHN1LnNzLWRldjpzc2RldjIwMTg=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 17 Dec 2019 20:03:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 201 Created
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding, Origin
+      X-Credential-Username:
+      - psu.ss-dev
+      X-Request-Id:
+      - 8d6edb1b-b40e-4e06-8e78-0abb49033e80
+      Location:
+      - https://api.test.datacite.org/dois/3387447
+      Etag:
+      - W/"b7796ca60cdf9d3ef973fea48117a633"
+      X-Runtime:
+      - '0.080071'
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+      Server:
+      - nginx/1.17.3 + Phusion Passenger 6.0.4
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"id":"10.33532/abc891","type":"dois","attributes":{"doi":"10.33532/abc891","prefix":"10.33532","suffix":"abc891","identifiers":null,"creators":[],"titles":null,"publisher":null,"container":{},"publicationYear":null,"subjects":null,"contributors":[],"dates":null,"language":null,"types":{},"relatedIdentifiers":null,"sizes":null,"formats":null,"version":null,"rightsList":[],"descriptions":null,"geoLocations":null,"fundingReferences":null,"xml":null,"url":null,"contentUrl":null,"metadataVersion":0,"schemaVersion":null,"source":null,"isActive":false,"state":"draft","reason":null,"landingPage":null,"created":"2019-12-17T20:03:12.000Z","registered":null,"published":"","updated":"2019-12-17T20:03:12.000Z"},"relationships":{"client":{"data":{"id":"psu.ss-dev","type":"clients"}},"media":{"data":{"id":"10.33532/abc891","type":"media"}}}},"included":[{"id":"psu.ss-dev","type":"clients","attributes":{"name":"Scholarsphere
+        Devlopement","symbol":"PSU.SS-DEV","year":2018,"contactEmail":"awead@psu.edu","alternateName":null,"description":null,"language":null,"clientType":"repository","domains":"*","re3data":null,"opendoar":null,"issn":null,"url":null,"created":"2018-11-02T18:30:18.000Z","updated":"2018-11-02T18:31:18.000Z","isActive":true,"hasPassword":true},"relationships":{"provider":{"data":{"id":"psu","type":"providers"}},"prefixes":{"data":[{"id":"10.33532","type":"prefixes"}]}}}]}'
+    http_version: 
+  recorded_at: Tue, 17 Dec 2019 20:03:12 GMT
+- request:
+    method: put
+    uri: https://api.test.datacite.org/dois/10.33532/abc891
+    body:
+      encoding: UTF-8
+      string: '{"data":{"type":"dois","attributes":{"titles":[{"title":"Work Title"}],"creators":[{"name":"Creator"}],"publicationYear":2019,"types":{"resourceTypeGeneral":"Text"},"url":"http://example.test","event":"publish","publisher":"scholarsphere"},"id":"10.33532/abc891"}}'
+    headers:
+      User-Agent:
+      - Faraday v0.17.0
+      Content-Type:
+      - application/vnd.api+json
+      Authorization:
+      - Basic cHN1LnNzLWRldjpzc2RldjIwMTg=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Dec 2019 20:03:13 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding, Origin
+      X-Credential-Username:
+      - psu.ss-dev
+      X-Request-Id:
+      - 59fe5519-a955-4199-92e8-bf8047e96f8e
+      Etag:
+      - W/"2f34b0c38b650dd7ec77e1ba9adc28e1"
+      X-Runtime:
+      - '0.096151'
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+      Server:
+      - nginx/1.17.3 + Phusion Passenger 6.0.4
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"id":"10.33532/abc891","type":"dois","attributes":{"doi":"10.33532/abc891","prefix":"10.33532","suffix":"abc891","identifiers":null,"creators":[{"name":"Creator","affiliation":[]}],"titles":[{"title":"Work
+        Title"}],"publisher":"scholarsphere","container":{},"publicationYear":2019,"subjects":null,"contributors":[],"dates":null,"language":null,"types":{"resourceTypeGeneral":"Text"},"relatedIdentifiers":null,"sizes":null,"formats":null,"version":null,"rightsList":[],"descriptions":null,"geoLocations":null,"fundingReferences":null,"xml":"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMzM1MzIvQUJDODkxPC9pZGVudGlmaWVyPgogIDxjcmVhdG9ycz4KICAgIDxjcmVhdG9yPgogICAgICA8Y3JlYXRvck5hbWU+Q3JlYXRvcjwvY3JlYXRvck5hbWU+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzPgogICAgPHRpdGxlPldvcmsgVGl0bGU8L3RpdGxlPgogIDwvdGl0bGVzPgogIDxwdWJsaXNoZXI+c2Nob2xhcnNwaGVyZTwvcHVibGlzaGVyPgogIDxwdWJsaWNhdGlvblllYXI+MjAxOTwvcHVibGljYXRpb25ZZWFyPgogIDxyZXNvdXJjZVR5cGUgcmVzb3VyY2VUeXBlR2VuZXJhbD0iVGV4dCIvPgogIDx2ZXJzaW9uLz4KPC9yZXNvdXJjZT4K","url":"http://example.test","contentUrl":null,"metadataVersion":0,"schemaVersion":null,"source":null,"isActive":true,"state":"findable","reason":null,"landingPage":null,"created":"2019-12-17T20:03:12.000Z","registered":null,"published":"2019","updated":"2019-12-17T20:03:13.000Z"},"relationships":{"client":{"data":{"id":"psu.ss-dev","type":"clients"}},"media":{"data":{"id":"10.33532/abc891","type":"media"}}}},"included":[{"id":"psu.ss-dev","type":"clients","attributes":{"name":"Scholarsphere
+        Devlopement","symbol":"PSU.SS-DEV","year":2018,"contactEmail":"awead@psu.edu","alternateName":null,"description":null,"language":null,"clientType":"repository","domains":"*","re3data":null,"opendoar":null,"issn":null,"url":null,"created":"2018-11-02T18:30:18.000Z","updated":"2018-11-02T18:31:18.000Z","isActive":true,"hasPassword":true},"relationships":{"provider":{"data":{"id":"psu","type":"providers"}},"prefixes":{"data":[{"id":"10.33532","type":"prefixes"}]}}}]}'
+    http_version: 
+  recorded_at: Tue, 17 Dec 2019 20:03:13 GMT
+- request:
+    method: put
+    uri: https://api.test.datacite.org/dois/10.33532/abc891
+    body:
+      encoding: UTF-8
+      string: '{"data":{"type":"dois","attributes":{"titles":[{"title":"Updated Title"}],"creators":[{"name":"Creator"}],"publicationYear":2019,"types":{"resourceTypeGeneral":"Text"},"url":"http://example.test","event":"publish","publisher":"scholarsphere"},"id":"10.33532/abc891"}}'
+    headers:
+      User-Agent:
+      - Faraday v0.17.0
+      Content-Type:
+      - application/vnd.api+json
+      Authorization:
+      - Basic cHN1LnNzLWRldjpzc2RldjIwMTg=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Dec 2019 20:03:13 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Vary:
+      - Accept-Encoding, Origin
+      X-Credential-Username:
+      - psu.ss-dev
+      X-Request-Id:
+      - bdecf7e1-bca5-4cc7-9e9b-764d47d56cd7
+      Etag:
+      - W/"40c95a40d3bdb4f83d07df664980ce36"
+      X-Runtime:
+      - '0.096655'
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+      Server:
+      - nginx/1.17.3 + Phusion Passenger 6.0.4
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"id":"10.33532/abc891","type":"dois","attributes":{"doi":"10.33532/abc891","prefix":"10.33532","suffix":"abc891","identifiers":null,"creators":[{"name":"Creator","affiliation":[]}],"titles":[{"title":"Updated
+        Title"}],"publisher":"scholarsphere","container":{},"publicationYear":2019,"subjects":null,"contributors":[],"dates":null,"language":null,"types":{"resourceTypeGeneral":"Text"},"relatedIdentifiers":null,"sizes":null,"formats":null,"version":null,"rightsList":[],"descriptions":null,"geoLocations":null,"fundingReferences":null,"xml":"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCBodHRwOi8vc2NoZW1hLmRhdGFjaXRlLm9yZy9tZXRhL2tlcm5lbC00L21ldGFkYXRhLnhzZCI+CiAgPGlkZW50aWZpZXIgaWRlbnRpZmllclR5cGU9IkRPSSI+MTAuMzM1MzIvQUJDODkxPC9pZGVudGlmaWVyPgogIDxjcmVhdG9ycz4KICAgIDxjcmVhdG9yPgogICAgICA8Y3JlYXRvck5hbWU+Q3JlYXRvcjwvY3JlYXRvck5hbWU+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzPgogICAgPHRpdGxlPlVwZGF0ZWQgVGl0bGU8L3RpdGxlPgogIDwvdGl0bGVzPgogIDxwdWJsaXNoZXI+c2Nob2xhcnNwaGVyZTwvcHVibGlzaGVyPgogIDxwdWJsaWNhdGlvblllYXI+MjAxOTwvcHVibGljYXRpb25ZZWFyPgogIDxyZXNvdXJjZVR5cGUgcmVzb3VyY2VUeXBlR2VuZXJhbD0iVGV4dCIvPgogIDx2ZXJzaW9uLz4KPC9yZXNvdXJjZT4K","url":"http://example.test","contentUrl":null,"metadataVersion":0,"schemaVersion":null,"source":null,"isActive":true,"state":"findable","reason":null,"landingPage":null,"created":"2019-12-17T20:03:12.000Z","registered":"2019-12-17T20:03:13.000Z","published":"2019","updated":"2019-12-17T20:03:13.000Z"},"relationships":{"client":{"data":{"id":"psu.ss-dev","type":"clients"}},"media":{"data":{"id":"10.33532/abc891","type":"media"}}}},"included":[{"id":"psu.ss-dev","type":"clients","attributes":{"name":"Scholarsphere
+        Devlopement","symbol":"PSU.SS-DEV","year":2018,"contactEmail":"awead@psu.edu","alternateName":null,"description":null,"language":null,"clientType":"repository","domains":"*","re3data":null,"opendoar":null,"issn":null,"url":null,"created":"2018-11-02T18:30:18.000Z","updated":"2018-11-02T18:31:18.000Z","isActive":true,"hasPassword":true},"relationships":{"provider":{"data":{"id":"psu","type":"providers"}},"prefixes":{"data":[{"id":"10.33532","type":"prefixes"}]}}}]}'
+    http_version: 
+  recorded_at: Tue, 17 Dec 2019 20:03:13 GMT
+recorded_with: VCR 5.0.0

--- a/spec/integration/mint_doi_spec.rb
+++ b/spec/integration/mint_doi_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'data_cite'
+
+RSpec.describe 'minting a doi', skip: !ci_build? do
+  let!(:work) { create :work, versions: [work_version] }
+  let(:work_version) { build :work_version, :able_to_be_published, work: nil }
+
+  let(:client) { DataCite::Client.new }
+
+  it 'mints a doi correctly' do
+    # Create a draft doi for the draft WorkVersion
+    expect {
+      DoiService.call(work_version)
+    }.to change {
+      work_version.reload.doi
+    }.from(nil).to(a_string_matching(%r{#{client.prefix}/.+}))
+
+    api_sleep
+    _doi, draft_version_datacite_metadata = client.get(doi: work_version.doi)
+    expect(draft_version_datacite_metadata.dig('data', 'attributes', 'published')).to be_blank
+
+    # Publish the WorkVersion, and update the doi
+    work_version.publish
+    work_version.save!
+    api_sleep
+    DoiService.call(work_version)
+
+    api_sleep
+    _doi, published_verison_datacite_metadata = client.get(doi: work_version.doi)
+    expect(published_verison_datacite_metadata.dig('data', 'attributes', 'published')).to be_present
+
+    # mint a DOI for the work
+    work.reload
+    expect {
+      api_sleep
+      DoiService.call(work)
+    }.to change {
+      work.reload.doi
+    }.from(nil).to(a_string_matching(%r{#{client.prefix}/.+}))
+
+    api_sleep
+    _doi, work_datacite_metadata = client.get(doi: work.doi)
+    expect(work_datacite_metadata.dig('data', 'attributes', 'published')).to be_present
+
+    # Create a new version of the Work
+    new_version = BuildNewWorkVersion.call(work_version)
+    new_version.title = 'Updated Title'
+    new_version.save!
+    new_version.publish
+    new_version.save!
+    work.reload
+    api_sleep
+    DoiService.call(work)
+
+    api_sleep
+    _doi, updated_work_datacite_metadata = client.get(doi: work.doi)
+    expect(updated_work_datacite_metadata.dig('data', 'attributes', 'titles', 0, 'title')).to eq 'Updated Title'
+  end
+
+  def api_sleep
+    sleep 0.5
+  end
+end

--- a/spec/lib/data_cite/client_spec.rb
+++ b/spec/lib/data_cite/client_spec.rb
@@ -5,7 +5,8 @@ require 'support/vcr'
 require 'data_cite'
 
 RSpec.describe DataCite::Client do
-  subject(:client) { described_class.new }
+  # Specify the prefix we used when we recorded these reponses from DataCite using VCR.
+  subject(:client) { described_class.new(prefix: '10.33532') }
 
   let(:valid_metadata) {
     {

--- a/spec/lib/data_cite/client_spec.rb
+++ b/spec/lib/data_cite/client_spec.rb
@@ -131,6 +131,39 @@ RSpec.describe DataCite::Client do
     end
   end
 
+  describe '#get' do
+    context 'with an existing DRAFT doi', :vcr do
+      it 'retrieves the doi' do
+        draft_doi, _resp = client.register('abc950')
+        doi, response_hash = client.get(doi: draft_doi)
+
+        expect(doi).to eq draft_doi
+        expect(response_hash.dig('data', 'attributes', 'doi')).to eq draft_doi
+      end
+    end
+
+    context 'with an existing PUBLISHED doi', :vcr do
+      it 'retrieves the doi' do
+        published_doi, _resp = client.publish(metadata: valid_metadata)
+        doi, response_hash = client.get(doi: published_doi)
+
+        expect(doi).to eq published_doi
+        expect(response_hash.dig('data', 'attributes', 'doi')).to eq published_doi
+      end
+    end
+
+    context 'with an invalid doi', :vcr do
+      it 'raises an error' do
+        expect {
+          client.get(doi: 'bogus')
+        }.to raise_error(
+          DataCite::Client::Error,
+          /The resource you are looking for doesn't exist/
+        )
+      end
+    end
+  end
+
   describe '#delete' do
     context 'with an existing DRAFT doi', :vcr do
       it 'deletes the doi' do

--- a/spec/lib/data_cite/metadata_spec.rb
+++ b/spec/lib/data_cite/metadata_spec.rb
@@ -29,10 +29,15 @@ RSpec.describe DataCite::Metadata do
             familyName: work_version.work.depositor.surname
           }]
         )
+        expect(attributes[:url]).to be_present
 
         # The following are tested thoroughly below
         expect(attributes[:publicationYear]).to be_present
         expect(attributes.dig(:types, :resourceTypeGeneral)).to be_present
+      end
+
+      pending 'uses the real public URL for a resource' do
+        expect(attributes[:url]).to match(/\.psu\.edu/)
       end
     end
 

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Work, type: :model do
     it { is_expected.to have_db_column(:depositor_id) }
     it { is_expected.to have_db_index(:depositor_id) }
     it { is_expected.to have_db_column(:uuid).of_type(:uuid) }
+    it { is_expected.to have_db_column(:doi).of_type(:string) }
   end
 
   describe 'factories' do
@@ -134,6 +135,7 @@ RSpec.describe Work, type: :model do
         is_expected.to contain_exactly(
           'created_at_dtsi',
           'depositor_id_isi',
+          'doi_tesim',
           'id',
           'model_ssi',
           'updated_at_dtsi',
@@ -154,6 +156,7 @@ RSpec.describe Work, type: :model do
           'created_at_dtsi',
           'depositor_id_isi',
           'description_tesim',
+          'doi_tesim',
           'id',
           'identifier_tesim',
           'keywords_tesim',

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe WorkVersion, type: :model do
     it { is_expected.to have_db_column(:metadata).of_type(:jsonb) }
     it { is_expected.to have_db_column(:uuid).of_type(:uuid) }
     it { is_expected.to have_db_column(:version_number).of_type(:integer) }
+    it { is_expected.to have_db_column(:doi).of_type(:string) }
     it { is_expected.to have_jsonb_accessor(:title).of_type(:string) }
     it { is_expected.to have_jsonb_accessor(:subtitle).of_type(:string) }
     it { is_expected.to have_jsonb_accessor(:version_name).of_type(:string) }

--- a/spec/services/doi_service_spec.rb
+++ b/spec/services/doi_service_spec.rb
@@ -1,0 +1,242 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'data_cite'
+
+RSpec.describe DoiService do
+  subject(:call_service) { described_class.call(resource) }
+
+  let(:client_mock) { instance_spy 'DataCite::Client' }
+  let(:metadata_mock) { instance_spy 'DataCite::Metadata' }
+
+  before do
+    allow(DataCite::Client).to receive(:new).and_return(client_mock)
+    allow(DataCite::Metadata).to receive(:new).and_return(metadata_mock)
+  end
+
+  describe '.call' do
+    context 'when given a WorkVersion' do
+      let(:resource) { work_version }
+      let(:work_version) { FactoryBot.build_stubbed :work_version }
+
+      before do
+        allow(resource).to receive(:update!)
+        allow(resource).to receive(:valid?).and_return(true)
+      end
+
+      context "when the WorkVersion's doi field is empty" do
+        before { work_version.doi = nil }
+
+        context 'when the WorkVersion is DRAFT' do
+          before { allow(work_version).to receive(:draft?).and_return(true) }
+
+          it 'registers a new doi' do
+            call_service
+            expect(client_mock).to have_received(:register)
+          end
+
+          it 'saves the doi on the WorkVersion db record' do
+            allow(client_mock).to receive(:register).and_return(['new/doi', { some: :metadata }])
+            call_service
+            expect(work_version).to have_received(:update!).with(doi: 'new/doi')
+          end
+        end
+
+        context 'when the WorkVersion is PUBLISHED' do
+          before do
+            allow(work_version).to receive(:draft?).and_return(false)
+            allow(work_version).to receive(:published?).and_return(true)
+          end
+
+          it 'publishes a new doi with metadata' do
+            allow(metadata_mock).to receive(:attributes).and_return(mocked: :metadata)
+            call_service
+            expect(DataCite::Metadata).to have_received(:new).with(work_version: work_version)
+            expect(client_mock).to have_received(:publish).with(
+              doi: nil,
+              metadata: { mocked: :metadata }
+            )
+          end
+
+          it 'saves the doi on the WorkVersion db record' do
+            allow(client_mock).to receive(:publish).and_return(['new/doi', { some: :metadata }])
+            call_service
+            expect(work_version).to have_received(:update!).with(doi: 'new/doi')
+          end
+        end
+      end
+
+      context "when the WorkVersion's doi field is present" do
+        before { work_version.doi = 'existing/doi' }
+
+        context 'when the WorkVersion is DRAFT' do
+          before { allow(work_version).to receive(:draft?).and_return(true) }
+
+          it 'does nothing' do
+            call_service
+            expect(client_mock).not_to have_received(:register)
+            expect(client_mock).not_to have_received(:publish)
+          end
+        end
+
+        context 'when the WorkVersion is PUBLISHED' do
+          before do
+            allow(work_version).to receive(:draft?).and_return(false)
+            allow(work_version).to receive(:published?).and_return(true)
+          end
+
+          it 'publishes the doi with metadata' do
+            allow(metadata_mock).to receive(:attributes).and_return(mocked: :metadata)
+            call_service
+            expect(DataCite::Metadata).to have_received(:new).with(work_version: work_version)
+            expect(client_mock).to have_received(:publish).with(
+              doi: 'existing/doi',
+              metadata: { mocked: :metadata }
+            )
+          end
+
+          it 'does not update the WorkVerison db record' do
+            call_service
+            expect(work_version).not_to have_received(:update!)
+          end
+        end
+      end
+    end
+
+    context 'when given a Work' do
+      let(:resource) { work }
+      let(:work) { FactoryBot.build_stubbed :work }
+      let(:latest_work_version) { FactoryBot.build_stubbed :work_version, work: work }
+
+      before do
+        allow(work).to receive(:latest_version).and_return(latest_work_version)
+        allow(work).to receive(:update!)
+        allow(work).to receive(:valid?).and_return(true)
+      end
+
+      context "when the Work's doi field is empty" do
+        before { work.doi = nil }
+
+        context "when the work's latest version is a DRAFT version" do
+          before { allow(latest_work_version).to receive(:draft?).and_return(true) }
+
+          it 'registers a new doi' do
+            call_service
+            expect(client_mock).to have_received(:register)
+          end
+
+          it 'saves the doi on the Work db record' do
+            allow(client_mock).to receive(:register).and_return(['new/doi', { some: :metadata }])
+            call_service
+            expect(work).to have_received(:update!).with(doi: 'new/doi')
+          end
+        end
+
+        context "when the work's latest version is a PUBLISHED verison" do
+          before do
+            allow(latest_work_version).to receive(:draft?).and_return(false)
+            allow(latest_work_version).to receive(:published?).and_return(true)
+          end
+
+          it 'publishes a new doi with metadata' do
+            allow(metadata_mock).to receive(:attributes).and_return(mocked: :metadata)
+            call_service
+            expect(DataCite::Metadata).to have_received(:new).with(work_version: latest_work_version)
+            expect(client_mock).to have_received(:publish).with(
+              doi: nil,
+              metadata: { mocked: :metadata }
+            )
+          end
+
+          it 'saves the doi on the Work db record' do
+            allow(client_mock).to receive(:publish).and_return(['new/doi', { some: :metadata }])
+            call_service
+            expect(work).to have_received(:update!).with(doi: 'new/doi')
+          end
+        end
+      end
+
+      context "when the Work's doi field is present" do
+        before { work.doi = 'existing/doi' }
+
+        context "when the work's latest version is a DRAFT version" do
+          before { allow(latest_work_version).to receive(:draft?).and_return(true) }
+
+          it 'does nothing' do
+            call_service
+            expect(client_mock).not_to have_received(:register)
+            expect(client_mock).not_to have_received(:publish)
+          end
+        end
+
+        context "when the work's latest version is a PUBLISHED verison" do
+          before do
+            allow(latest_work_version).to receive(:draft?).and_return(false)
+            allow(latest_work_version).to receive(:published?).and_return(true)
+          end
+
+          it 'publishes the doi with metadata' do
+            allow(metadata_mock).to receive(:attributes).and_return(mocked: :metadata)
+            call_service
+            expect(DataCite::Metadata).to have_received(:new).with(work_version: latest_work_version)
+            expect(client_mock).to have_received(:publish).with(
+              doi: 'existing/doi',
+              metadata: { mocked: :metadata }
+            )
+          end
+
+          it 'does not update the Work db record' do
+            call_service
+            expect(work).not_to have_received(:update!)
+          end
+        end
+      end
+    end
+
+    context 'when given some other type of object' do
+      let(:resource) { FactoryBot.build_stubbed :user }
+
+      it { expect { call_service }.to raise_error(ArgumentError) }
+    end
+
+    context 'when given an invalid resource' do
+      let(:resource) { instance_spy('Work', valid?: false) }
+
+      it do
+        expect {
+          call_service
+        }.to raise_error(described_class::Error)
+      end
+    end
+
+    context 'when the metadata mapper cannot build valid metadata' do
+      let(:resource) { FactoryBot.build_stubbed :work_version, doi: nil }
+
+      before do
+        allow(resource).to receive(:draft?).and_return(false)
+        allow(metadata_mock).to receive(:validate!).and_raise(DataCite::Metadata::ValidationError)
+      end
+
+      it do
+        expect {
+          call_service
+        }.to raise_error(DataCite::Metadata::ValidationError)
+      end
+    end
+
+    context 'when the doi client raises an error' do
+      let(:resource) { FactoryBot.build_stubbed :work_version, doi: nil }
+
+      before do
+        allow(resource).to receive(:draft?).and_return(true)
+        allow(client_mock).to receive(:register).and_raise(DataCite::Client::Error)
+      end
+
+      it do
+        expect {
+          call_service
+        }.to raise_error(DataCite::Client::Error)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a service object that ties together the DataCite client that Adam and I wrote, along with the DataCite metadata mapper class. 

In order to pull this off, I needed to add a few things besides just make a service:
* Verify that `DataCite::Client#publish` is idempotent on DataCite's side. That is, we can call it multiple times and it'll do the right thing (i.e. update the metadata on the second call, without having a freakout that it's already been published.)
* Add a method `DataCite::Client#get` to retrieve the metadata of a particular DOI. This is used for testing
* Add a public URL to the Datacite::Metadata mapper. **_Please note that I did not know what a particular resource's public URL should actually be, and I remember there being some discussion around this. So in the mean time I put in a bogus value, and then put in a (currently failing) pending spec to ensure that it's something reasonable once we figure that out._**

Currently the integration test hits the real DataCite API, and _only_ runs on CI. Dann and I had thought of a few ways we could make this fancier, but ultimately `skip: !ci_build?` is simple and effective.

Fixes #103 