### PR TITLE
exit if any command exits non-zero

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,4 @@
+set -e 
 
 if [ ${RAILS_ENV:-development} != "production" ]; then
   bundle check || bundle


### PR DESCRIPTION
We should not start a deployment if any of the tasks in `start.sh` fails. this allows the script to exit early, allowing the old replica to continue to run until an administrator can mitigate the issue. 