### PR TITLE
Set the visibility of a work in order to publish

### DIFF
--- a/app/controllers/dashboard/works_controller.rb
+++ b/app/controllers/dashboard/works_controller.rb
@@ -54,6 +54,7 @@ module Dashboard
           .require(:work)
           .permit(
             :work_type,
+            :visibility,
             versions_attributes: [
               :title
             ]

--- a/app/models/concerns/permissions.rb
+++ b/app/models/concerns/permissions.rb
@@ -15,6 +15,13 @@ module Permissions
     def self.default
       OPEN
     end
+
+    def self.options_for_select_box
+      {
+        'Open Access' => OPEN,
+        'Penn State' => AUTHORIZED
+      }
+    end
   end
 
   included do

--- a/app/models/concerns/permissions_builder.rb
+++ b/app/models/concerns/permissions_builder.rb
@@ -10,7 +10,7 @@
 # >  pole = ControlledResource.new
 # >  dog = Dog.new
 # >  cat = Cat.new
-# >  pole.apply_scratch_access(dog)
+# >  pole.grant_scratch_access(dog)
 # >  pole.scratch_access?(dog)
 # => true
 # >  pole.scratch_access?(cat)
@@ -35,10 +35,18 @@ class PermissionsBuilder < Module
       send("#{level}_agents").include?(agent)
     end
 
-    define_method "apply_#{level}_access" do |agent|
-      return if send("#{level}_access?", agent)
+    define_method "grant_#{level}_access" do |*args|
+      args.map do |agent|
+        access_controls.build(access_level: level, agent: agent) unless send("#{level}_access?", agent)
+      end
+    end
 
-      access_controls.build(access_level: level, agent: agent)
+    define_method "revoke_#{level}_access" do |*args|
+      args.map do |agent|
+        self.access_controls = access_controls.reject do |control|
+          control.access_level == level && control.agent == agent
+        end
+      end
     end
 
     agents.each do |agent|

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -4,13 +4,25 @@ class Group < ApplicationRecord
   PUBLIC_AGENT_NAME = 'public'
   AUTHORIZED_AGENT_NAME = 'authorized'
 
+  # @note Database cleaner and transactional fixtures are causing caching problems so we re-find/create each time but
+  # only in test.
   def self.public_agent
-    @public_agent ||= find_or_create_by(name: PUBLIC_AGENT_NAME)
+    if Rails.env.test?
+      find_or_create_by(name: PUBLIC_AGENT_NAME)
+    else
+      @public_agent ||= find_or_create_by(name: PUBLIC_AGENT_NAME)
+    end
   end
   delegate :public_agent, to: :class
 
+  # @note Database cleaner and transactional fixtures are causing caching problems so we re-find/create each time but
+  # only in test.
   def self.authorized_agent
-    @authorized_agent ||= find_or_create_by(name: AUTHORIZED_AGENT_NAME)
+    if Rails.env.test?
+      find_or_create_by(name: AUTHORIZED_AGENT_NAME)
+    else
+      @authorized_agent ||= find_or_create_by(name: AUTHORIZED_AGENT_NAME)
+    end
   end
   delegate :authorized_agent, to: :class
 

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -46,6 +46,13 @@ class WorkVersion < ApplicationRecord
             presence: true,
             uniqueness: { scope: :work_id }
 
+  validates :visibility,
+            inclusion: {
+              in: [Permissions::Visibility::OPEN, Permissions::Visibility::AUTHORIZED],
+              message: 'cannot be private'
+            },
+            if: :published?
+
   after_save :update_index, if: :published?
 
   aasm do
@@ -112,7 +119,7 @@ class WorkVersion < ApplicationRecord
     WorkIndexer.call(work, commit: true)
   end
 
-  delegate :depositor, to: :work
+  delegate :depositor, :visibility, to: :work
 
   private
 

--- a/app/views/dashboard/work_versions/publish.html.erb
+++ b/app/views/dashboard/work_versions/publish.html.erb
@@ -31,16 +31,6 @@
     <%= form_with(model: @work_version, url: dashboard_work_version_path(@work_version), local: true) do |form| %>
 
       <div class="form-group">
-        <%= label_tag :access_level %>
-        <div class="input-group">
-          <%= select_tag :access_level,
-                         options_for_select(['Public', 'Penn State']),
-                         include_blank: false,
-                         class: 'form-control' %>
-        </div>
-      </div>
-
-      <div class="form-group">
         <%= label_tag :depositor_agreement %>
         <div class="form-check">
           <%= form.check_box :depositor_agreement,

--- a/app/views/dashboard/works/new.html.erb
+++ b/app/views/dashboard/works/new.html.erb
@@ -29,6 +29,13 @@
     </div>
   </div>
 
+  <div class="form-group">
+    <%= form.label :visibility %>
+    <div class="input-group">
+      <%= form.select :visibility, Permissions::Visibility.options_for_select_box, {}, class: 'form-control' %>
+    </div>
+  </div>
+
   <div class="actions">
     <%= form.submit class: 'btn btn-primary' %>
     <%= link_to 'Cancel', dashboard_works_path, class: 'btn btn-text' %>

--- a/spec/controllers/dashboard/works_controller_spec.rb
+++ b/spec/controllers/dashboard/works_controller_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Dashboard::WorksController, type: :controller do
   let(:valid_attributes) {
     {
       'work_type' => Work::Types.all.first,
+      'visibility' => Permissions::Visibility.default,
       'versions_attributes' => [
         { 'title' => 'My new work' }
       ]
@@ -93,6 +94,12 @@ RSpec.describe Dashboard::WorksController, type: :controller do
         it "returns a success response (i.e. to display the 'new' template)" do
           post :create, params: { work: invalid_attributes }
           expect(response).to be_successful
+        end
+      end
+
+      context 'with an invalid visibility' do
+        it 'raises an error' do
+          expect { post :create, params: { work: { visibility: 'bogus' } } }.to raise_error(ArgumentError)
         end
       end
     end

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -46,10 +46,16 @@ FactoryBot.define do
   end
 
   trait(:with_open_access) do
-    after(:build, &:apply_open_access)
+    after(:build, &:grant_open_access)
   end
 
   trait(:with_authorized_access) do
-    after(:build, &:apply_authorized_access)
+    after(:build, &:grant_authorized_access)
+  end
+
+  trait(:with_no_access) do
+    after(:build) do |work|
+      work.access_controls.destroy_all
+    end
   end
 end

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :work do
     association :depositor, factory: :user
     work_type { Work::Types.all.first }
+    visibility { Permissions::Visibility.default }
 
     # Postgres does this for us, but for testing, we can do it here to save having to call create/reload.
     uuid { SecureRandom.uuid }
@@ -43,14 +44,6 @@ FactoryBot.define do
 
   sequence(:work_title) do |n|
     FactoryBotHelpers.work_title(n)
-  end
-
-  trait(:with_open_access) do
-    after(:build, &:grant_open_access)
-  end
-
-  trait(:with_authorized_access) do
-    after(:build, &:grant_authorized_access)
   end
 
   trait(:with_no_access) do

--- a/spec/models/permissions_builder_spec.rb
+++ b/spec/models/permissions_builder_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe PermissionsBuilder do
     ActiveSupport::Dependencies.remove_constant('Pole')
   end
 
-  it { is_expected.to respond_to(:apply_scratch_access) }
+  it { is_expected.to respond_to(:grant_scratch_access) }
+  it { is_expected.to respond_to(:revoke_scratch_access) }
   it { is_expected.to respond_to(:scratch_access?) }
   it { is_expected.to respond_to(:scratch_agents) }
   it { is_expected.to respond_to(:scratch_dogs) }

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -71,6 +71,15 @@ RSpec.describe WorkVersion, type: :model do
         work_version.validate
         expect(work_version.errors[:file_resources]).to be_empty
       end
+
+      it 'validates the visibility of the work' do
+        work_version.work.access_controls.destroy_all
+        work_version.validate
+        expect(work_version.errors[:visibility]).to eq(['cannot be private'])
+        work_version.work.grant_open_access
+        work_version.validate
+        expect(work_version.errors[:visibility]).to be_empty
+      end
     end
 
     context 'with the version number' do


### PR DESCRIPTION
Visibility is now set when the work is first created, and any works may not be published unless the work is either available to the public, i.e. open access or open visibility, or is available within Penn State, i.e. authorized access or Penn State visibility.

The major change here is that the user must select the visibility when first creating the work, along with its title and datatype, as opposed to the _end_ of the process when it is published.

![Screen Shot 2020-01-08 at 10 12 22 AM](https://user-images.githubusercontent.com/312085/71989288-63dbeb80-31ff-11ea-9313-f0430d0e49ba.png)

Fixes #146 
