### PR TITLE
Index ACLs and enforce them in search results

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,4 +7,8 @@ class ApplicationController < ActionController::Base
 
   # Authorization
   include Pundit
+
+  def current_user
+    super || User.guest
+  end
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -3,6 +3,12 @@
 class CatalogController < ApplicationController
   include Blacklight::Catalog
 
+  # @note pass the current user in the @context hash of Blacklight::SearchService which allows the SearchBuilder to have
+  # access to the current user in order to enforce access controls in Solr queries.
+  def search_service_context
+    { current_user: current_user }
+  end
+
   configure_blacklight do |config|
     ## Class for sending and receiving requests from a search index
     # config.repository_class = Blacklight::Solr::Repository

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -3,10 +3,64 @@
 class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
 
-  self.default_processor_chain += [:show_works_only]
+  self.default_processor_chain += %i(
+    restrict_search_to_works
+    apply_gated_discovery
+    log_solr_parameters
+  )
 
-  def show_works_only(solr_parameters)
+  def restrict_search_to_works(solr_parameters)
     solr_parameters[:fq] ||= []
     solr_parameters[:fq] << 'model_ssi:Work'
   end
+
+  def apply_gated_discovery(solr_parameters)
+    return if current_user.admin?
+
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] << gated_discovery_filters.compact.join(' OR ')
+  end
+
+  def log_solr_parameters(solr_parameters)
+    Rails.logger.debug("Solr parameters: #{solr_parameters.inspect}")
+  end
+
+  private
+
+    def gated_discovery_filters
+      [:apply_group_permissions, :apply_user_permissions].map do |method|
+        send(method)
+      end
+    end
+
+    # For groups
+    # @return [String] a lucence syntax term query suitable for :fq
+    # @example "({!terms f=discover_groups_ssim}public,faculty,africana-faculty,registered)"
+    def apply_group_permissions
+      groups = current_user.groups
+      return if groups.empty?
+
+      "({!terms f=discover_groups_ssim}#{groups.map(&:name).join(',')})"
+    end
+
+    # For individual user access
+    # @return [String] a lucence syntax term query suitable for :fq
+    # @example 'discover_access_person_ssim:user_1@abc.com'
+    def apply_user_permissions
+      return if current_user.guest?
+
+      escape_filter('discover_users_ssim', current_user.access_id)
+    end
+
+    def current_user
+      @current_user ||= @scope.context[:current_user]
+    end
+
+    def escape_filter(key, value)
+      [key, escape_value(value)].join(':')
+    end
+
+    def escape_value(value)
+      RSolr.solr_escape(value).gsub(/ /, '\ ')
+    end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,8 @@ class User < ApplicationRecord
 
   devise :omniauthable, omniauth_providers: %i[psu]
 
+  attr_writer :guest
+
   has_many :works,
            foreign_key: 'depositor_id',
            inverse_of: 'depositor',
@@ -24,6 +26,10 @@ class User < ApplicationRecord
   validates :email,
             presence: true,
             uniqueness: true
+
+  def self.guest
+    new(guest: true, groups: [Group.public_agent]).tap(&:readonly!)
+  end
 
   def self.from_omniauth(auth)
     user = User.find_or_initialize_by(provider: auth.provider, uid: auth.uid) do |new_user|
@@ -51,5 +57,9 @@ class User < ApplicationRecord
 
   def name
     "#{given_name} #{surname}"
+  end
+
+  def guest?
+    @guest || false
   end
 end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -74,6 +74,10 @@ class Work < ApplicationRecord
   def to_solr
     SolrDocumentBuilder.call(resource: latest_published_version)
       .merge(SolrDocumentBuilder.call(resource: self))
+      .merge(
+        'discover_users_ssim' => (discover_users + read_users).map(&:access_id).uniq,
+        'discover_groups_ssim' => (discover_groups + read_groups).map(&:name).uniq
+      )
       .except(:latest_version_bsi)
   end
 end

--- a/app/views/shared/_user_util_links.html.erb
+++ b/app/views/shared/_user_util_links.html.erb
@@ -4,7 +4,11 @@
   <% end %>
 
   <% if has_user_authentication_provider? %>
-    <% if current_user %>
+    <% if current_user.guest? %>
+      <li class="nav-item">
+        <%= link_to t('blacklight.header_links.login'), new_user_session_path, class: 'nav-link' %>
+      </li>
+    <% else %>
       <li class="nav-item">
         <%= link_to t('blacklight.header_links.logout'), destroy_user_session_path, class: 'nav-link' %>
       </li>
@@ -15,10 +19,6 @@
         <div class="dropdown-menu" aria-labelledby="navbarDropdown">
           <%= link_to 'Works', dashboard_works_path, class: 'dropdown-item' %>
         </div>
-      </li>
-    <% else %>
-      <li class="nav-item">
-        <%= link_to t('blacklight.header_links.login'), new_user_session_path, class: 'nav-link' %>
       </li>
     <% end %>
   <% end %>

--- a/spec/factories/psu_oauth_responses.rb
+++ b/spec/factories/psu_oauth_responses.rb
@@ -11,7 +11,9 @@ FactoryBot.define do
       given_name { Faker::Name.first_name }
       surname { Faker::Name.last_name }
       email { "#{access_id}@psu.edu" }
-      groups { Array.new(3) { Faker::Coffee.blend_name } }
+
+      # Group names cannot contain spaces (see #155)
+      groups { Array.new(3) { "up.libraries.#{Faker::Currency.code.downcase}" } }
     end
 
     provider { 'psu' }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     trait :admin do
       groups { [Group.new(name: Rails.application.config.admin_group)] }
     end
+    groups { User.default_groups }
     email { "#{access_id}@psu.edu" }
     sequence(:access_id) { |n| FactoryBotHelpers.generate_access_id_from_name(given_name, surname, n) }
     given_name { Faker::Name.first_name }

--- a/spec/features/discovery_search_spec.rb
+++ b/spec/features/discovery_search_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Searching discoverable resources' do
+  let!(:public_work) { create(:work, has_draft: false) }
+  let!(:authorized_work) { create(:work, visibility: Permissions::Visibility::AUTHORIZED, has_draft: false) }
+
+  context 'with a public user' do
+    it 'searches only public works' do
+      visit search_catalog_path
+      click_button('Search')
+
+      expect(page).to have_content(public_work.latest_published_version.title)
+      expect(page).not_to have_content(authorized_work.latest_published_version.title)
+    end
+  end
+
+  context 'with a Penn State user' do
+    let(:user) { create(:user) }
+
+    it 'searches public and Penn State works', with_user: :user do
+      visit search_catalog_path
+      click_button('Search')
+
+      expect(page).to have_content(public_work.latest_published_version.title)
+      expect(page).to have_content(authorized_work.latest_published_version.title)
+    end
+  end
+end

--- a/spec/features/oauth_login_spec.rb
+++ b/spec/features/oauth_login_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Logging in using OAuth' do
+  let(:user) { create(:user) }
+  let(:oauth_response) { build(:psu_oauth_response, access_id: user.access_id) }
+
+  before do
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:psu] = oauth_response
+  end
+
+  it 'uses OAuth to authenticate to the application' do
+    visit(dashboard_works_path)
+    expect(page).to have_content(I18n.t('devise.omniauth_callbacks.success', kind: 'Penn State'))
+    expect(page).to have_content(I18n.t('dashboard.works.index.heading'))
+    expect(page).to have_content(user.reload.surname)
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -34,6 +34,14 @@ RSpec.describe User, type: :model do
     it { is_expected.to respond_to(:bookmarks) }
   end
 
+  describe '.guest' do
+    subject { described_class.guest }
+
+    it { is_expected.to be_guest }
+    its(:groups) { is_expected.to contain_exactly(Group.public_agent) }
+    it { is_expected.to be_readonly }
+  end
+
   describe '.from_omniauth' do
     let(:auth_params) { build :psu_oauth_response,
                               given_name: 'Joe',
@@ -114,6 +122,26 @@ RSpec.describe User, type: :model do
 
     it 'concatenates given_name and surname' do
       expect(user.name).to eq 'Joe Developer'
+    end
+  end
+
+  describe '#guest?' do
+    context 'with a new user' do
+      subject { described_class.new }
+
+      it { is_expected.not_to be_guest }
+    end
+
+    context 'with an existing user' do
+      subject { build(:user) }
+
+      it { is_expected.not_to be_guest }
+    end
+
+    context 'with a guest user' do
+      subject { build(:user, guest: true) }
+
+      it { is_expected.to be_guest }
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -65,8 +65,13 @@ RSpec.describe User, type: :model do
         expect(new_user.surname).to eq 'Developer'
         expect(new_user.email).to eq 'jd1@psu.edu'
 
-        expect(new_user.groups.length).to eq 2
-        expect(new_user.groups.map(&:name)).to contain_exactly('admin', 'reporter')
+        expect(new_user.groups.length).to eq 4
+        expect(new_user.groups.map(&:name)).to contain_exactly(
+          'admin',
+          'reporter',
+          Group::AUTHORIZED_AGENT_NAME,
+          Group::PUBLIC_AGENT_NAME
+        )
       end
     end
 
@@ -95,7 +100,12 @@ RSpec.describe User, type: :model do
         existing_user.groups.create!(name: 'MY OLD GROUP THAT SHOULD GO AWAY')
         described_class.from_omniauth(auth_params)
 
-        expect(existing_user.reload.groups.map(&:name)).to contain_exactly('admin', 'reporter')
+        expect(existing_user.reload.groups.map(&:name)).to contain_exactly(
+          'admin',
+          'reporter',
+          Group::AUTHORIZED_AGENT_NAME,
+          Group::PUBLIC_AGENT_NAME
+        )
       end
 
       it 'returns the User record' do

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -140,7 +140,9 @@ RSpec.describe Work, type: :model do
           'model_ssi',
           'updated_at_dtsi',
           'uuid_ssi',
-          'work_type_tesim'
+          'work_type_tesim',
+          'discover_users_ssim',
+          'discover_groups_ssim'
         )
       end
     end
@@ -176,7 +178,9 @@ RSpec.describe Work, type: :model do
           'version_name_tesim',
           'version_number_isi',
           'work_id_isi',
-          'work_type_tesim'
+          'work_type_tesim',
+          'discover_users_ssim',
+          'discover_groups_ssim'
         )
       end
     end


### PR DESCRIPTION
Enforces ACLs in search results by indexing discover and read permissions in Solr, and then ensuring Blacklight only returns search results that obey those permissions. For example, everyone will be able to search and retrieve public works, but works designated as "Penn State only" can only be searched by registered users.

Originally, we had intended to use Blacklight's access controls gem, but it proven to be incompatible and overly complicated.

In order to complete this, three other changes were made in separate commits:
* implementing a guest user to effect a "null object" type of pattern so we don't have to check for a user all the time
* adding default groups to users to control access rights to public content
* refactoring feature tests to use Warden instead of OAuth when applicable

Fixes #128 