### PR TITLE
Clean group names from LDAP records

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,9 +46,12 @@ class User < ApplicationRecord
     user.given_name = auth.info.given_name
     user.surname = auth.info.surname
 
-    psu_groups = auth.info.groups.map do |group_name|
-      Group.find_or_create_by(name: group_name)
-    end
+    psu_groups = auth.info.groups
+      .map { |ldap_group_name| LdapGroupCleaner.call(ldap_group_name) }
+      .compact
+      .map do |group_name|
+        Group.find_or_create_by(name: group_name)
+      end
 
     user.groups = psu_groups + default_groups
 

--- a/app/services/ldap_group_cleaner.rb
+++ b/app/services/ldap_group_cleaner.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class LdapGroupCleaner
+  class Error < RuntimeError; end
+
+  class << self
+    def call(ldap_record)
+      call!(ldap_record)
+    rescue Error
+      nil
+    end
+
+    def call!(ldap_record)
+      _cn, value = ldap_record
+        .split(',')
+        .map { |str| str.split('=') }
+        .find { |key, _v| key == 'cn' }
+
+      raise Error.new('LDAP group cannot contain spaces') if value.to_s.match?(/\s/)
+      raise Error.new('LDAP group is empty') if value.to_s.empty?
+
+      value
+    end
+  end
+end

--- a/app/services/ldap_group_cleaner.rb
+++ b/app/services/ldap_group_cleaner.rb
@@ -4,9 +4,12 @@ class LdapGroupCleaner
   class Error < RuntimeError; end
 
   class << self
+    attr_writer :logger_source
+
     def call(ldap_record)
       call!(ldap_record)
-    rescue Error
+    rescue Error => e
+      logger_source.call("#{e.class}: #{e.message.inspect} with record #{ldap_record.inspect}")
       nil
     end
 
@@ -20,6 +23,10 @@ class LdapGroupCleaner
       raise Error.new('LDAP group is empty') if value.to_s.empty?
 
       value
+    end
+
+    def logger_source
+      @logger_source ||= ->(msg) { Rails.logger.error(msg) }
     end
   end
 end

--- a/spec/factories/psu_oauth_responses.rb
+++ b/spec/factories/psu_oauth_responses.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
       email { "#{access_id}@psu.edu" }
 
       # Group names cannot contain spaces (see #155)
-      groups { Array.new(3) { "up.libraries.#{Faker::Currency.code.downcase}" } }
+      groups { Array.new(3) { "cn=up.libraries.#{Faker::Currency.code.downcase},dc=psu,dc=edu" } }
     end
 
     provider { 'psu' }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -47,7 +47,11 @@ RSpec.describe User, type: :model do
                               given_name: 'Joe',
                               surname: 'Developer',
                               access_id: 'jd1',
-                              groups: ['admin', 'reporter']
+                              groups: [
+                                'cn=admin,dc=psu,dc=edu',
+                                'cn=reporter,dc=psu,dc=edu',
+                                'cn=totally invalid with spaces,dc=psu,dc=edu'
+                              ]
     }
 
     context 'when the User record does not yet exist' do

--- a/spec/services/ldap_group_cleaner_spec.rb
+++ b/spec/services/ldap_group_cleaner_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../app/services/ldap_group_cleaner'
+
+RSpec.describe LdapGroupCleaner do
+  describe '.call' do
+    let(:call) { described_class.call(input) }
+
+    context 'with the happy path' do
+      let(:input) { 'cn=umg/up.dlt.scholarsphere-admin.admin,dc=psu,dc=edu' }
+
+      it 'returns the parsed group name' do
+        expect(call).to eq 'umg/up.dlt.scholarsphere-admin.admin'
+      end
+    end
+
+    context 'with a value that would raise an error to .call! (see below)' do
+      let(:input) { 'cn=i have spaces,dc=psu,dc=edu' }
+
+      it 'traps the error and returns nil' do
+        expect(call).to eq nil
+      end
+    end
+  end
+
+  describe '.call!' do
+    context 'with valid ldap records' do
+      it 'returns the parsed group name' do
+        expect(described_class.call!('cn=psu.up.staff,dc=psu,dc=edu')).to eq 'psu.up.staff'
+        expect(described_class.call!('cn=umg/psu.aws.aws.304225443749.administrator,dc=psu,dc=edu'))
+          .to eq 'umg/psu.aws.aws.304225443749.administrator'
+      end
+    end
+
+    context 'with an ldap record with spaces' do
+      let(:call!) { described_class.call!('cn=cn with spaces,dc=psu,dc=edu') }
+
+      it { expect { call! }.to raise_error(described_class::Error) }
+    end
+
+    context 'with an ldap record with no group' do
+      let(:call!) { described_class.call!('cn=,dc=psu,dc=edu') }
+
+      it { expect { call! }.to raise_error(described_class::Error) }
+    end
+
+    context 'with an ldap record with invalid formatting' do
+      let(:call!) { described_class.call!('invalid formatting') }
+
+      it { expect { call! }.to raise_error(described_class::Error) }
+    end
+  end
+end

--- a/spec/services/ldap_group_cleaner_spec.rb
+++ b/spec/services/ldap_group_cleaner_spec.rb
@@ -17,9 +17,21 @@ RSpec.describe LdapGroupCleaner do
 
     context 'with a value that would raise an error to .call! (see below)' do
       let(:input) { 'cn=i have spaces,dc=psu,dc=edu' }
+      let(:mock_logger) { instance_spy 'Proc' }
+
+      before { @old_logger = described_class.logger_source }
+
+      after { described_class.logger_source = @old_logger }
 
       it 'traps the error and returns nil' do
         expect(call).to eq nil
+      end
+
+      it 'logs the error' do
+        described_class.logger_source = mock_logger
+        call
+        expect(mock_logger).to have_received(:call)
+          .with(a_string_matching(input))
       end
     end
   end


### PR DESCRIPTION
- Extract the group name from the LDAP record
- Any groups with spaces in the name are gracefully ignored

Fixes #155 