### PR TITLE
Determine access using a user's groups

### DIFF
--- a/app/models/concerns/permissions_builder.rb
+++ b/app/models/concerns/permissions_builder.rb
@@ -31,8 +31,13 @@ class PermissionsBuilder < Module
       end
     end
 
+    # @note There's a little bit of "concern bleed" because an agent, like a user, can have associated agents, i.e.
+    # groups, which impact how we determine access. For now, we can ask the agent if it has any groups, and that should
+    # be fine, but we can refactor later, if desired.
     define_method "#{level}_access?" do |agent|
-      send("#{level}_agents").include?(agent)
+      associated_agents = agent.try(:groups) || []
+      available_agents = associated_agents.to_a + [agent]
+      (send("#{level}_agents") & available_agents).any?
     end
 
     define_method "grant_#{level}_access" do |*args|

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :group do
-    name { 'MyString' }
+    name { Faker::Currency.code.downcase }
   end
 end

--- a/spec/models/permissions_spec.rb
+++ b/spec/models/permissions_spec.rb
@@ -212,6 +212,15 @@ RSpec.describe Permissions do
 
       specify { expect(resource.discover_access?(agent)).to be(false) }
     end
+
+    context 'when a user is a member of a group with discover access' do
+      let(:group) { build(:group) }
+      let(:agent) { build(:user, groups: [group]) }
+
+      before { resource.grant_discover_access(group) }
+
+      specify { expect(resource.discover_access?(agent)).to be(true) }
+    end
   end
 
   describe '#grant_read_access' do
@@ -301,6 +310,15 @@ RSpec.describe Permissions do
 
       specify { expect(resource.read_access?(agent)).to be(false) }
     end
+
+    context 'when a user is a member of a group with read access' do
+      let(:group) { build(:group) }
+      let(:agent) { build(:user, groups: [group]) }
+
+      before { resource.grant_read_access(group) }
+
+      specify { expect(resource.read_access?(agent)).to be(true) }
+    end
   end
 
   describe '#grant_edit_access' do
@@ -389,6 +407,15 @@ RSpec.describe Permissions do
       let(:agent) { build(:group) }
 
       specify { expect(resource.edit_access?(agent)).to be(false) }
+    end
+
+    context 'when a user is a member of a group with edit access' do
+      let(:group) { build(:group) }
+      let(:agent) { build(:user, groups: [group]) }
+
+      before { resource.grant_edit_access(group) }
+
+      specify { expect(resource.edit_access?(agent)).to be(true) }
     end
   end
 


### PR DESCRIPTION
Fixes a bug where a user who is a member of a group that is granted a level of access, must be allowed to access that resource. For example, given a group that is granted read access to a resource, any user that is a member of that group must also be allowed read access.

One of the issues created with this fix is that the PermissionsBuilder class must know that "groups" is a means of finding associated agents from another agent. This blurs the abstract nature of agents a bit, but would make good fodder for refactoring.