### PR TITLE
Disable DOI integration test

### DIFF
--- a/spec/integration/mint_doi_spec.rb
+++ b/spec/integration/mint_doi_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'minting a doi', skip: !ci_build? do
   let(:client) { DataCite::Client.new }
 
   it 'mints a doi correctly' do
+    skip 'this can fail for unexpected reasons and should not prevent merges or test deploys'
     # Create a draft doi for the draft WorkVersion
     expect {
       DoiService.call(work_version)


### PR DESCRIPTION
The DOI integration test is failing because of network issues unrelated to the application. We need to find another way of running these tests that is more tolerant of failure.