### PR TITLE
Authorized and open access only applies to groups

### DIFF
--- a/app/models/access_control.rb
+++ b/app/models/access_control.rb
@@ -23,4 +23,12 @@ class AccessControl < ApplicationRecord
   validates :access_level,
             uniqueness: { scope: [:agent, :resource] },
             inclusion: { in: AccessControl::Level.all }
+
+  def public?
+    agent.is_a?(Group) && agent.public? && access_level == AccessControl::Level::READ
+  end
+
+  def authorized?
+    agent.is_a?(Group) && agent.authorized? && access_level == AccessControl::Level::READ
+  end
 end

--- a/app/models/concerns/permissions.rb
+++ b/app/models/concerns/permissions.rb
@@ -50,13 +50,11 @@ module Permissions
   end
 
   def revoke_open_access
-    self.access_controls = access_controls.reject do |control|
-      control.agent.public? && control.access_level == AccessControl::Level::READ
-    end
+    self.access_controls = access_controls.reject(&:public?)
   end
 
   def open_access?
-    access_controls.any? { |control| control.agent.public? && control.access_level == AccessControl::Level::READ }
+    access_controls.any?(&:public?)
   end
 
   def grant_authorized_access
@@ -67,13 +65,11 @@ module Permissions
   end
 
   def revoke_authorized_access
-    self.access_controls = access_controls.reject do |control|
-      control.agent.authorized? && control.access_level == AccessControl::Level::READ
-    end
+    self.access_controls = access_controls.reject(&:authorized?)
   end
 
   def authorized_access?
-    access_controls.any? { |control| control.agent.authorized? && control.access_level == AccessControl::Level::READ }
+    access_controls.any?(&:authorized?)
   end
 
   def visibility

--- a/spec/models/access_control_spec.rb
+++ b/spec/models/access_control_spec.rb
@@ -50,6 +50,44 @@ RSpec.describe AccessControl, type: :model do
     end
   end
 
+  describe '#public?' do
+    subject { described_class.new(agent: agent, resource: resource, access_level: access_level) }
+
+    let(:resource) { create(:work) }
+    let(:access_level) { AccessControl::Level::READ }
+
+    context 'when the access control defines public access' do
+      let(:agent) { Group.public_agent }
+
+      it { is_expected.to be_public }
+    end
+
+    context 'when the access control does NOT define public access' do
+      let(:agent) { create(:group) }
+
+      it { is_expected.not_to be_public }
+    end
+  end
+
+  describe '#authorized?' do
+    subject { described_class.new(agent: agent, resource: resource, access_level: access_level) }
+
+    let(:resource) { create(:work) }
+    let(:access_level) { AccessControl::Level::READ }
+
+    context 'when the access control defines authorized access' do
+      let(:agent) { Group.authorized_agent }
+
+      it { is_expected.to be_authorized }
+    end
+
+    context 'when the access control does NOT define authorized access' do
+      let(:agent) { create(:group) }
+
+      it { is_expected.not_to be_authorized }
+    end
+  end
+
   describe 'AccessControl::Level' do
     specify { expect(AccessControl::Level::DISCOVER).to eq('discover') }
     specify { expect(AccessControl::Level::READ).to eq('read') }


### PR DESCRIPTION
If a user is granted read level access, it will cause NoMethodError because we were not checking the agent type. Open and authorized access only applies to groups with read level permissions.

This also refactors how we determine public and authorized agents by defining them in the access control resource.