### PR TITLE
Actual public resource URL provided to DOI service

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -92,6 +92,7 @@ steps:
         -e DATACITE_PUBLISHER=$DATACITE_PUBLISHER
         -e AWS_REGION=us-east-1
         -e REDIS_HOST=redis
+        -e DEFAULT_URL_HOST=scholarsphere
         -e APP_HOST=test-$DRONE_BUILD_NUMBER
         -e POSTGRES_USER=scholarsphere
         -e SELENIUM_URL=http://selenium:4444/wd/hub
@@ -209,6 +210,6 @@ volumes:
     path: /var/run/docker.sock
 ---
 kind: signature
-hmac: fec077364ec8d7b5af5d66761821be7226d877d9eda915f46125094a2660aa8d
+hmac: 1a1f3f4e1c2893e31fb1cdef8830cd316b4fcae1f3527d0b2cad386584a4adf4
 
 ...

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,4 +57,4 @@ CMD [ "/app/bin/ci-niftany" ]
 # Final Target
 FROM base as production
 
-RUN RAILS_ENV=production SECRET_KEY_BASE=$(bundle exec rails secret) AWS_BUCKET=bucket AWS_ACCESS_KEY_ID=key AWS_SECRET_ACCESS_KEY=secret AWS_REGION=us-east-1 bundle exec rails assets:precompile
+RUN RAILS_ENV=production DEFAULT_URL_HOST=localhost SECRET_KEY_BASE=$(bundle exec rails secret) AWS_BUCKET=bucket AWS_ACCESS_KEY_ID=key AWS_SECRET_ACCESS_KEY=secret AWS_REGION=us-east-1 bundle exec rails assets:precompile

--- a/app/services/doi_service.rb
+++ b/app/services/doi_service.rb
@@ -66,7 +66,7 @@ class DoiService
 
     def publish_doi(doi:, update_resource:)
       metadata = metadata_source
-        .call(work_version: work_version)
+        .call(work_version: work_version, public_identifier: resource.uuid)
         .tap(&:validate!)
         .attributes
 

--- a/config/initializers/default_url_host.rb
+++ b/config/initializers/default_url_host.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+default_url_host = ENV['DEFAULT_URL_HOST']
+Rails.application.routes.default_url_options[:host] = default_url_host
+
+if default_url_host.blank?
+  raise "ENV['DEFAULT_URL_HOST'] is required to be set"
+end

--- a/config/samples/application.yml
+++ b/config/samples/application.yml
@@ -59,6 +59,9 @@ SOLR_PORT: 8983
 # MINIO_SECRET_KEY: "asdfasdf"
 # MINIO_PORT: "9000"
 
+# Default URL host. answers the question "who am i?" 
+# DEFAULT_URL_HOST: "" # defaults to nil, required for production, however.
+
 # If the oauth servers authorize path differs from /oauth/authorize, you can set that value here
 # Under normal circumstances, this shouldn't need changing
 # OAUTH_AUTHORIZE_URL: "/oauth/authorize"

--- a/config/samples/application.yml
+++ b/config/samples/application.yml
@@ -59,8 +59,10 @@ SOLR_PORT: 8983
 # MINIO_SECRET_KEY: "asdfasdf"
 # MINIO_PORT: "9000"
 
-# Default URL host. answers the question "who am i?" 
-# DEFAULT_URL_HOST: "" # defaults to nil, required for production, however.
+# Default URL host. answers the question "who am i?"
+# Required for all environments. For development, you can set it to
+# "localhost:3000" for `bin/rails s` or "scholarsphere-4.test" for puma-dev
+DEFAULT_URL_HOST: "localhost:3000"
 
 # If the oauth servers authorize path differs from /oauth/authorize, you can set that value here
 # Under normal circumstances, this shouldn't need changing

--- a/lib/data_cite/metadata.rb
+++ b/lib/data_cite/metadata.rb
@@ -5,15 +5,19 @@ module DataCite
     class Error < StandardError; end
     class ValidationError < Error; end
 
-    attr_reader :work_version
+    attr_reader :work_version,
+                :public_identifier
+
+    attr_writer :public_url_source
 
     RESOURCE_TYPES = {
       Work::Types::DATASET => 'Dataset'
     }.freeze
 
-    def initialize(work_version:)
+    def initialize(work_version:, public_identifier:)
       @work_version = work_version
       @work = work_version.work
+      @public_identifier = public_identifier
     end
 
     def attributes
@@ -44,6 +48,12 @@ module DataCite
       false
     end
 
+    def public_url_source
+      @public_url_source ||= ->(id) {
+        Rails.application.routes.url_helpers.resource_url(id)
+      }
+    end
+
     private
 
       attr_reader :work
@@ -71,7 +81,7 @@ module DataCite
       end
 
       def generate_url
-        'http://example.test'
+        public_url_source.call(public_identifier)
       end
   end
 end

--- a/spec/integration/mint_doi_spec.rb
+++ b/spec/integration/mint_doi_spec.rb
@@ -31,6 +31,9 @@ RSpec.describe 'minting a doi', skip: !ci_build? do
     api_sleep
     _doi, published_verison_datacite_metadata = client.get(doi: work_version.doi)
     expect(published_verison_datacite_metadata.dig('data', 'attributes', 'published')).to be_present
+    expect(published_verison_datacite_metadata.dig('data', 'attributes', 'url')).to eq(
+      Rails.application.routes.url_helpers.resource_url(work_version.uuid)
+    )
 
     # mint a DOI for the work
     work.reload

--- a/spec/lib/data_cite/metadata_spec.rb
+++ b/spec/lib/data_cite/metadata_spec.rb
@@ -5,17 +5,24 @@ require 'data_cite'
 require 'factory_bot'
 
 RSpec.describe DataCite::Metadata do
-  subject(:metadata) { described_class.new(work_version: work_version) }
+  subject(:metadata) { described_class.new(work_version: work_version, public_identifier: uuid) }
+
+  let(:uuid) { 'abc-123' }
 
   let(:attributes) { metadata.attributes }
 
   let(:work_version) { FactoryBot.build_stubbed :work_version, :with_complete_metadata }
   let(:work) { work_version.work }
 
+  before do
+    metadata.public_url_source = ->(id) { "http://example.test/resources/#{id}" }
+  end
+
   describe '#initialize' do
-    it 'accepts a WorkVersion' do
-      metadata = described_class.new(work_version: work_version)
+    it 'accepts a WorkVersion and public identifier (uuid)' do
+      metadata = described_class.new(work_version: work_version, public_identifier: uuid)
       expect(metadata.work_version).to eq work_version
+      expect(metadata.public_identifier).to eq uuid
     end
   end
 
@@ -36,8 +43,14 @@ RSpec.describe DataCite::Metadata do
         expect(attributes.dig(:types, :resourceTypeGeneral)).to be_present
       end
 
-      pending 'uses the real public URL for a resource' do
-        expect(attributes[:url]).to match(/\.psu\.edu/)
+      describe 'url generation' do
+        before do
+          metadata.public_url_source = nil # Clear a previously injected mock
+        end
+
+        pending 'uses the real public URL for a resource' do
+          expect(attributes[:url]).to match(/\.psu\.edu\/resources\/#{uuid}/)
+        end
       end
     end
 

--- a/spec/lib/data_cite/metadata_spec.rb
+++ b/spec/lib/data_cite/metadata_spec.rb
@@ -48,8 +48,9 @@ RSpec.describe DataCite::Metadata do
           metadata.public_url_source = nil # Clear a previously injected mock
         end
 
-        pending 'uses the real public URL for a resource' do
-          expect(attributes[:url]).to match(/\.psu\.edu\/resources\/#{uuid}/)
+        it 'uses the real public URL for a resource' do
+          expected_url = Rails.application.routes.url_helpers.resource_url(uuid)
+          expect(attributes[:url]).to eq expected_url
         end
       end
     end

--- a/spec/services/doi_service_spec.rb
+++ b/spec/services/doi_service_spec.rb
@@ -51,7 +51,10 @@ RSpec.describe DoiService do
           it 'publishes a new doi with metadata' do
             allow(metadata_mock).to receive(:attributes).and_return(mocked: :metadata)
             call_service
-            expect(DataCite::Metadata).to have_received(:new).with(work_version: work_version)
+            expect(DataCite::Metadata).to have_received(:new).with(
+              work_version: work_version,
+              public_identifier: work_version.uuid
+            )
             expect(client_mock).to have_received(:publish).with(
               doi: nil,
               metadata: { mocked: :metadata }
@@ -88,7 +91,10 @@ RSpec.describe DoiService do
           it 'publishes the doi with metadata' do
             allow(metadata_mock).to receive(:attributes).and_return(mocked: :metadata)
             call_service
-            expect(DataCite::Metadata).to have_received(:new).with(work_version: work_version)
+            expect(DataCite::Metadata).to have_received(:new).with(
+              work_version: work_version,
+              public_identifier: work_version.uuid
+            )
             expect(client_mock).to have_received(:publish).with(
               doi: 'existing/doi',
               metadata: { mocked: :metadata }
@@ -141,7 +147,10 @@ RSpec.describe DoiService do
           it 'publishes a new doi with metadata' do
             allow(metadata_mock).to receive(:attributes).and_return(mocked: :metadata)
             call_service
-            expect(DataCite::Metadata).to have_received(:new).with(work_version: latest_work_version)
+            expect(DataCite::Metadata).to have_received(:new).with(
+              work_version: latest_work_version,
+              public_identifier: work.uuid
+            )
             expect(client_mock).to have_received(:publish).with(
               doi: nil,
               metadata: { mocked: :metadata }
@@ -178,7 +187,10 @@ RSpec.describe DoiService do
           it 'publishes the doi with metadata' do
             allow(metadata_mock).to receive(:attributes).and_return(mocked: :metadata)
             call_service
-            expect(DataCite::Metadata).to have_received(:new).with(work_version: latest_work_version)
+            expect(DataCite::Metadata).to have_received(:new).with(
+              work_version: latest_work_version,
+              public_identifier: work.uuid
+            )
             expect(client_mock).to have_received(:publish).with(
               doi: 'existing/doi',
               metadata: { mocked: :metadata }


### PR DESCRIPTION
This completes the coding work necessary to provide the full public URL to DataCite. 

In situations like the DOI thing, when we will be outside the request-response cycle (either in a background job, importing over the API, etc) we need to explicitly tell Rails what its own hostname is because it cannot be inferred from the HTTP `Host` header.

I did this by adding an environment variable `DEFAULT_URL_HOST` and setting the Rails config from it in `config/initializers/default_url_host.rb`. This process will raise an exception if no environment variable is defined.

Fixes #92 