### PR TITLE
Avoid Capybara::Ambiguous match error

### DIFF
--- a/spec/factories/work_versions.rb
+++ b/spec/factories/work_versions.rb
@@ -38,7 +38,7 @@ FactoryBot.define do
     end
 
     trait :with_complete_metadata do
-      title { Faker::Book.title }
+      title { generate(:work_title) }
       subtitle { FactoryBotHelpers.work_title }
       keywords { Faker::Science.element }
       rights { Faker::Lorem.sentence }


### PR DESCRIPTION
Avoids the error by ensuring we always have unique titles when calling `:with_complete_metadata`