### PR TITLE
Accept creator and alias metadata in the ingest API

### DIFF
--- a/app/controllers/api/v1/ingest_controller.rb
+++ b/app/controllers/api/v1/ingest_controller.rb
@@ -68,7 +68,16 @@ module Api::V1
             identifier: [],
             based_near: [],
             related_url: [],
-            source: []
+            source: [],
+            creator_aliases_attributes: [
+              :alias,
+              creator_attributes: [
+                :email,
+                :given_name,
+                :surname,
+                :psu_id
+              ]
+            ]
           )
       end
 

--- a/app/models/creator.rb
+++ b/app/models/creator.rb
@@ -9,7 +9,7 @@ class Creator < ApplicationRecord
            through: :work_version_creations,
            inverse_of: :creators
 
-  validates :email,
+  validates :surname,
             presence: true
 
   def self.find_or_create_by_user(user)

--- a/app/views/dashboard/work_versions/_creator_alias_fields.html.erb
+++ b/app/views/dashboard/work_versions/_creator_alias_fields.html.erb
@@ -16,9 +16,9 @@
     <%= f.fields_for :creator do |creator_fields| %>
       <%- readonly = creator_fields.object.psu_id.present? %>
 
-      <div class="form-group required">
+      <div class="form-group">
         <%= creator_fields.label :email %>
-        <%= creator_fields.text_field :email, class: 'form-control', readonly: readonly, required: true %>
+        <%= creator_fields.text_field :email, class: 'form-control', readonly: readonly %>
       </div>
 
       <div class="row">
@@ -29,9 +29,9 @@
           </div>
         </div>
         <div class="col">
-          <div class="form-group">
+          <div class="form-group required">
             <%= creator_fields.label :surname %>
-            <%= creator_fields.text_field :surname, class: 'form-control', readonly: readonly %>
+            <%= creator_fields.text_field :surname, class: 'form-control', readonly: readonly, required: true %>
           </div>
         </div>
         <div class="col">

--- a/spec/controllers/dashboard/profiles_controller_spec.rb
+++ b/spec/controllers/dashboard/profiles_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Dashboard::ProfilesController, type: :controller do
 
   let(:invalid_attributes) {
     {
-      'email' => ''
+      'surname' => ''
     }
   }
 

--- a/spec/models/creator_spec.rb
+++ b/spec/models/creator_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Creator, type: :model do
   end
 
   describe 'validations' do
-    it { is_expected.to validate_presence_of(:email) }
+    it { is_expected.to validate_presence_of(:surname) }
   end
 
   describe '.find_or_create_by_user' do

--- a/spec/services/publish_new_work_spec.rb
+++ b/spec/services/publish_new_work_spec.rb
@@ -12,7 +12,21 @@ RSpec.describe PublishNewWork do
 
     let(:service) do
       described_class.call(
-        metadata: work.metadata.merge(work_type: 'dataset', visibility: Permissions::Visibility::OPEN),
+        metadata: work.metadata.merge(
+          work_type: 'dataset',
+          visibility: Permissions::Visibility::OPEN,
+          creator_aliases_attributes: [
+            {
+              alias: "#{user.given_name} #{user.surname}",
+              creator_attributes: {
+                email: user.email,
+                given_name: user.given_name,
+                surname: user.surname,
+                psu_id: user.access_id
+              }
+            }
+          ]
+        ),
         depositor: user.access_id,
         content: [
           { file: fixture_file_upload(File.join(fixture_path, 'image.png')) },
@@ -25,7 +39,7 @@ RSpec.describe PublishNewWork do
       )
     end
 
-    pending 'creates a new work' do
+    it 'creates a new work' do
       expect { service }.to change(Work, :count).by(1)
       new_work = Work.last
       expect(new_work).to be_open_access


### PR DESCRIPTION
Adds parameters for aliases and creators to the ingest api so that works with their aliased creators can be migrated from Scholarsphere 3.