### PR TITLE
Use singular keyword method name

### DIFF
--- a/app/components/work_version_metadata_component.rb
+++ b/app/components/work_version_metadata_component.rb
@@ -16,7 +16,7 @@ class WorkVersionMetadataComponent < ActionView::Component::Base
     :creator_aliases,
     :version_number,
     :description,
-    :keywords,
+    :keyword,
     :rights,
     :resource_type,
     :contributor,

--- a/app/controllers/api/v1/ingest_controller.rb
+++ b/app/controllers/api/v1/ingest_controller.rb
@@ -57,7 +57,7 @@ module Api::V1
             :subtitle,
             :rights,
             :version_name,
-            keywords: [],
+            keyword: [],
             description: [],
             resource_type: [],
             contributor: [],

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -86,7 +86,7 @@ class CatalogController < ApplicationController
     # case sensitive when searching values)
 
     config.add_facet_field 'aasm_state_tesim', label: 'Status'
-    config.add_facet_field 'keywords_tesim', label: 'Keywords'
+    config.add_facet_field 'keyword_tesim', label: 'Keywords'
     config.add_facet_field 'resouce_type_tesim', label: 'Resource Type'
     config.add_facet_field 'subject_tesim', label: 'Subject'
 
@@ -109,7 +109,7 @@ class CatalogController < ApplicationController
     #   The ordering of the field names is the order of the display
     config.add_index_field 'title_tesim', label: 'Title'
     config.add_index_field 'aasm_state_tesim', label: 'Status'
-    config.add_index_field 'keywords_tesim', label: 'Keywords'
+    config.add_index_field 'keyword_tesim', label: 'Keywords'
     config.add_index_field 'resource_type_tesim', label: 'Resource Type'
     config.add_index_field 'created_at_dtsi', label: 'Date Created'
 
@@ -117,7 +117,7 @@ class CatalogController < ApplicationController
     #   The ordering of the field names is the order of the display
     config.add_show_field 'title_tesim', label: 'Title'
     config.add_show_field 'aasm_state_tesim', label: 'Status'
-    config.add_show_field 'keywords_tesim', label: 'Keywords'
+    config.add_show_field 'keyword_tesim', label: 'Keywords'
     config.add_show_field 'subtitle_tesim', label: 'Subtitle'
     config.add_show_field 'rights_tesim', label: 'Rights'
     config.add_show_field 'description_tesim', label: 'Description'

--- a/app/controllers/dashboard/work_versions_controller.rb
+++ b/app/controllers/dashboard/work_versions_controller.rb
@@ -124,7 +124,7 @@ module Dashboard
             :subtitle,
             :rights,
             :version_name,
-            keywords: [],
+            keyword: [],
             description: [],
             resource_type: [],
             contributor: [],

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -8,7 +8,7 @@ class WorkVersion < ApplicationRecord
                  title: :string,
                  subtitle: :string,
                  version_name: :string,
-                 keywords: [:string, array: true, default: []],
+                 keyword: [:string, array: true, default: []],
                  rights: :string,
                  description: [:string, array: true, default: []],
                  resource_type: [:string, array: true, default: []],
@@ -93,7 +93,7 @@ class WorkVersion < ApplicationRecord
 
   # Fields that can contain multiple values automatically remove blank values
   %i[
-    keywords
+    keyword
     description
     resource_type
     contributor

--- a/app/views/dashboard/work_versions/_form.html.erb
+++ b/app/views/dashboard/work_versions/_form.html.erb
@@ -29,7 +29,7 @@
     </div>
   </div>
 
-  <%= render 'form_fields/multi_text', form: form, attribute: :keywords %>
+  <%= render 'form_fields/multi_text', form: form, attribute: :keyword %>
   <%= render 'form_fields/text', form: form, attribute: :rights %>
   <%= render 'form_fields/multi_text_area', form: form, attribute: :description %>
   <%= render 'form_fields/multi_text', form: form, attribute: :resource_type %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,7 +11,7 @@ en:
       work_version:
         version_name: Version Name
         subtitle: Subtitle
-        keywords: Keywords
+        keyword: Keywords
         rights: Rights
         description: Description
         creator_aliases: Creator

--- a/spec/components/work_histories/work_version_change_component_spec.rb
+++ b/spec/components/work_histories/work_version_change_component_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe WorkHistories::WorkVersionChangeComponent, type: :component do
       work_version.update!(
         title: 'change-many',
         subtitle: 'change-many',
-        keywords: %w(one two),
+        keyword: %w(one two),
         rights: 'change-many',
         description: 'change-many'
       )

--- a/spec/components/work_version_metadata_component_spec.rb
+++ b/spec/components/work_version_metadata_component_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe WorkVersionMetadataComponent, type: :component do
     let(:work_version) { WorkVersion.new(
       subtitle: 'My subtitle',
       created_at: Time.zone.parse('2020-01-15 16:07'),
-      keywords: %w(one two),
+      keyword: %w(one two),
       description: nil
     ) }
 
@@ -23,10 +23,10 @@ RSpec.describe WorkVersionMetadataComponent, type: :component do
     end
 
     it 'renders a multi-value field' do
-      expect(result.css('dd.work-version-keywords .multiple-member').map(&:text))
+      expect(result.css('dd.work-version-keyword .multiple-member').map(&:text))
         .to contain_exactly('one', 'two')
 
-      expect(result.css('dd.work-version-keywords').text).to include('; ')
+      expect(result.css('dd.work-version-keyword').text).to include('; ')
     end
 
     it 'does not render any fields that are empty' do
@@ -43,7 +43,7 @@ RSpec.describe WorkVersionMetadataComponent, type: :component do
       expect(result.css('dt.work-version-subtitle')).to be_present
       expect(result.css('dt.work-version-version-number')).to be_present
       expect(result.css('dt.work-version-description')).to be_present
-      expect(result.css('dt.work-version-keywords')).to be_present
+      expect(result.css('dt.work-version-keyword')).to be_present
       expect(result.css('dt.work-version-rights')).to be_present
       expect(result.css('dt.work-version-resource-type')).to be_present
       expect(result.css('dt.work-version-contributor')).to be_present
@@ -66,7 +66,7 @@ RSpec.describe WorkVersionMetadataComponent, type: :component do
       expect(result.css('dd.work-version-creator-aliases').text).to include work_version.creator_aliases.map(&:alias).first
       expect(result.css('dd.work-version-version-number').text).to eq work_version[:version_number].to_s
       expect(result.css('dd.work-version-description').text).to include work_version[:description].first
-      expect(result.css('dd.work-version-keywords').text).to include work_version[:keywords].first
+      expect(result.css('dd.work-version-keyword').text).to include work_version[:keyword].first
       expect(result.css('dd.work-version-rights').text).to eq work_version[:rights]
       expect(result.css('dd.work-version-resource-type').text).to include work_version[:resource_type].first
       expect(result.css('dd.work-version-contributor').text).to include work_version[:contributor].first

--- a/spec/factories/work_versions.rb
+++ b/spec/factories/work_versions.rb
@@ -57,7 +57,7 @@ FactoryBot.define do
     trait :with_complete_metadata do
       title { generate(:work_title) }
       subtitle { FactoryBotHelpers.work_title }
-      keywords { Faker::Science.element }
+      keyword { Faker::Science.element }
       rights { Faker::Lorem.sentence }
       description { Faker::Lorem.paragraph }
       resource_type { Faker::House.furniture }

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -44,13 +44,13 @@ RSpec.describe 'Blacklight catalog page' do
     click_link('100 per page')
     expect(page).to have_blacklight_label('title_tesim')
     expect(page).to have_blacklight_label('aasm_state_tesim')
-    expect(page).to have_blacklight_label('keywords_tesim')
+    expect(page).to have_blacklight_label('keyword_tesim')
     expect(page).to have_blacklight_label('resource_type_tesim')
     expect(page).to have_blacklight_label('created_at_dtsi')
     records.each do |work|
       expect(page).to have_blacklight_field('title_tesim').with(work[:title])
       expect(page).to have_blacklight_field('aasm_state_tesim').with(work[:status])
-      expect(page).to have_blacklight_field('keywords_tesim').with(work[:keywords].join(', '))
+      expect(page).to have_blacklight_field('keyword_tesim').with(work[:keyword].join(', '))
       expect(page).to have_blacklight_field('resource_type_tesim').with(work[:resource_type].join(', '))
       expect(page).to have_blacklight_field('created_at_dtsi').with(/^#{work[:created_at].strftime("%F")}/)
     end

--- a/spec/features/edit_multiple_fields_spec.rb
+++ b/spec/features/edit_multiple_fields_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Editing multiple fields' do
 
     it 'inserts new inputs with remove buttons', with_user: :user, js: true do
       visit(edit_dashboard_work_version_path(work.latest_version))
-      check_field(:keywords)
+      check_field(:keyword)
       check_field(:description)
       check_field(:resource_type)
       check_field(:contributor)
@@ -63,7 +63,7 @@ RSpec.describe 'Editing multiple fields' do
 
     it 'updates each field with the new information', with_user: :user, js: true do
       visit(edit_dashboard_work_version_path(work.latest_version))
-      fill_in_multiple(:keywords)
+      fill_in_multiple(:keyword)
       fill_in_multiple(:description)
       fill_in_multiple(:resource_type)
       fill_in_multiple(:contributor)
@@ -79,7 +79,7 @@ RSpec.describe 'Editing multiple fields' do
       click_button('Save and Continue')
       visit(edit_dashboard_work_version_path(work.latest_version))
 
-      verify_multiple(:keywords)
+      verify_multiple(:keyword)
       verify_multiple(:description)
       verify_multiple(:resource_type)
       verify_multiple(:contributor)

--- a/spec/features/publish_new_work_spec.rb
+++ b/spec/features/publish_new_work_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Publishing a new work' do
     end
 
     fill_in('Subtitle', with: metadata[:subtitle])
-    fill_in('Keywords', with: metadata[:keywords].first)
+    fill_in('Keywords', with: metadata[:keyword].first)
     fill_in('Rights', with: metadata[:rights])
     fill_in('Description', with: metadata[:description])
     fill_in('Resource Type', with: metadata[:resource_type])
@@ -118,7 +118,7 @@ RSpec.describe 'Publishing a new work' do
     click_button('Save and Continue')
 
     expect(page).to have_field('Subtitle', with: metadata[:subtitle])
-    expect(page).to have_field('Keywords', with: metadata[:keywords].first)
+    expect(page).to have_field('Keywords', with: metadata[:keyword].first)
     expect(page).to have_field('Rights', with: metadata[:rights])
     expect(page).to have_field('Description', with: metadata[:description])
     expect(page).to have_field('Resource Type', with: metadata[:resource_type])

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Work, type: :model do
           'doi_tesim',
           'id',
           'identifier_tesim',
-          'keywords_tesim',
+          'keyword_tesim',
           'language_tesim',
           'model_ssi',
           'published_date_tesim',

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe WorkVersion, type: :model do
     it { is_expected.to have_jsonb_accessor(:title).of_type(:string) }
     it { is_expected.to have_jsonb_accessor(:subtitle).of_type(:string) }
     it { is_expected.to have_jsonb_accessor(:version_name).of_type(:string) }
-    it { is_expected.to have_jsonb_accessor(:keywords).of_type(:string).is_array.with_default([]) }
+    it { is_expected.to have_jsonb_accessor(:keyword).of_type(:string).is_array.with_default([]) }
     it { is_expected.to have_jsonb_accessor(:rights).of_type(:string) }
     it { is_expected.to have_jsonb_accessor(:description).of_type(:string).is_array.with_default([]) }
     it { is_expected.to have_jsonb_accessor(:resource_type).of_type(:string).is_array.with_default([]) }
@@ -103,7 +103,7 @@ RSpec.describe WorkVersion, type: :model do
   end
 
   describe 'multivalued fields' do
-    it_behaves_like 'a multivalued json field', :keywords
+    it_behaves_like 'a multivalued json field', :keyword
     it_behaves_like 'a multivalued json field', :description
     it_behaves_like 'a multivalued json field', :resource_type
     it_behaves_like 'a multivalued json field', :contributor

--- a/spec/presenters/diff_presenter_spec.rb
+++ b/spec/presenters/diff_presenter_spec.rb
@@ -23,25 +23,25 @@ RSpec.describe DiffPresenter do
       end
     end
 
-    context 'with the same titles and different keyworks' do
-      let(:first) { build(:work_version, title: 'The Same Title', keywords: ['foo', 'bar']) }
-      let(:second) { build(:work_version, title: 'The Same Title', keywords: ['foo', 'baz']) }
+    context 'with the same titles and different keywords' do
+      let(:first) { build(:work_version, title: 'The Same Title', keyword: ['foo', 'bar']) }
+      let(:second) { build(:work_version, title: 'The Same Title', keyword: ['foo', 'baz']) }
 
       it 'returns diffs each term' do
         expect(presenter[:title].to_s).to be_empty
-        expect(presenter[:keywords].to_s).to eq(
+        expect(presenter[:keyword].to_s).to eq(
           "-foo, bar\n\\ No newline at end of file\n+foo, baz\n\\ No newline at end of file\n"
         )
       end
     end
 
     context 'with a different number of values for the same term' do
-      let(:first) { build(:work_version, title: 'The Same Title', keywords: ['foo', 'bar']) }
-      let(:second) { build(:work_version, title: 'The Same Title', keywords: ['baz']) }
+      let(:first) { build(:work_version, title: 'The Same Title', keyword: ['foo', 'bar']) }
+      let(:second) { build(:work_version, title: 'The Same Title', keyword: ['baz']) }
 
       it 'returns diffs that include the deleted term' do
         expect(presenter[:title].to_s).to be_empty
-        expect(presenter[:keywords].to_s).to eq(
+        expect(presenter[:keyword].to_s).to eq(
           "-foo, bar\n\\ No newline at end of file\n+baz\n\\ No newline at end of file\n"
         )
       end

--- a/spec/schemas/default_schema_spec.rb
+++ b/spec/schemas/default_schema_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe DefaultSchema do
 
       its(:keys) { is_expected.not_to include('id', 'metadata') }
       it { is_expected.to include('title_tesim' => ['title']) }
-      it { is_expected.to include('keywords_tesim' => ['keywords']) }
+      it { is_expected.to include('keyword_tesim' => ['keyword']) }
       it { is_expected.to include('created_at_dtsi' => ['created_at']) }
       it { is_expected.to include('updated_at_dtsi' => ['updated_at']) }
       it { is_expected.to include('uuid_ssi' => ['uuid']) }

--- a/spec/services/metadata_diff_spec.rb
+++ b/spec/services/metadata_diff_spec.rb
@@ -19,37 +19,37 @@ RSpec.describe MetadataDiff do
   end
 
   context 'with the same titles and different keywords' do
-    let(:first) { build(:work_version, title: 'The Same Title', keywords: ['foo', 'bar']) }
-    let(:second) { build(:work_version, title: 'The Same Title', keywords: ['foo', 'baz']) }
+    let(:first) { build(:work_version, title: 'The Same Title', keyword: ['foo', 'bar']) }
+    let(:second) { build(:work_version, title: 'The Same Title', keyword: ['foo', 'baz']) }
 
-    its(:keys) { is_expected.to contain_exactly('keywords') }
+    its(:keys) { is_expected.to contain_exactly('keyword') }
 
     it 'returns only the terms that are different' do
       expect(diff[:title]).to be_nil
-      expect(diff[:keywords]).to eq(['foo, bar', 'foo, baz'])
+      expect(diff[:keyword]).to eq(['foo, bar', 'foo, baz'])
     end
   end
 
   context 'with a different number of values for the same term' do
-    let(:first) { build(:work_version, title: 'The Same Title', keywords: ['foo', 'bar']) }
-    let(:second) { build(:work_version, title: 'The Same Title', keywords: ['baz']) }
+    let(:first) { build(:work_version, title: 'The Same Title', keyword: ['foo', 'bar']) }
+    let(:second) { build(:work_version, title: 'The Same Title', keyword: ['baz']) }
 
-    its(:keys) { is_expected.to contain_exactly('keywords') }
+    its(:keys) { is_expected.to contain_exactly('keyword') }
 
     it 'returns diffs that include the deleted term' do
       expect(diff[:title]).to be_nil
-      expect(diff[:keywords]).to eq(['foo, bar', 'baz'])
+      expect(diff[:keyword]).to eq(['foo, bar', 'baz'])
     end
   end
 
   context 'with a custom separator' do
     subject(:diff) { described_class.call(first, second, separator: '; ') }
 
-    let(:first) { build(:work_version, title: 'The Same Title', keywords: ['foo', 'bar']) }
-    let(:second) { build(:work_version, title: 'The Same Title', keywords: ['foo', 'baz']) }
+    let(:first) { build(:work_version, title: 'The Same Title', keyword: ['foo', 'bar']) }
+    let(:second) { build(:work_version, title: 'The Same Title', keyword: ['foo', 'baz']) }
 
     it 'shows the diff with the separator' do
-      expect(diff[:keywords]).to eq(['foo; bar', 'foo; baz'])
+      expect(diff[:keyword]).to eq(['foo; bar', 'foo; baz'])
     end
   end
 end

--- a/spec/services/work_version_change_diff_spec.rb
+++ b/spec/services/work_version_change_diff_spec.rb
@@ -25,28 +25,28 @@ RSpec.describe WorkVersionChangeDiff, versioning: true do
 
   context 'with the same titles and different keywords' do
     before do
-      work_version.update!(title: 'The Same Title', keywords: %w(foo bar))
-      work_version.update!(title: 'The Same Title', keywords: %w(foo baz))
+      work_version.update!(title: 'The Same Title', keyword: %w(foo bar))
+      work_version.update!(title: 'The Same Title', keyword: %w(foo baz))
     end
 
-    its(:keys) { is_expected.to contain_exactly('keywords') }
+    its(:keys) { is_expected.to contain_exactly('keyword') }
 
     it 'returns only the terms that are different' do
       expect(diff[:title]).to be_nil
-      expect(diff[:keywords]).to eq(['foo, bar', 'foo, baz'])
+      expect(diff[:keyword]).to eq(['foo, bar', 'foo, baz'])
     end
   end
 
   context 'with a different number of values for the same term' do
     before do
-      work_version.update!(keywords: %w(foo bar))
-      work_version.update!(keywords: %w(baz))
+      work_version.update!(keyword: %w(foo bar))
+      work_version.update!(keyword: %w(baz))
     end
 
-    its(:keys) { is_expected.to contain_exactly('keywords') }
+    its(:keys) { is_expected.to contain_exactly('keyword') }
 
     it 'returns diffs that include the deleted term' do
-      expect(diff[:keywords]).to eq(['foo, bar', 'baz'])
+      expect(diff[:keyword]).to eq(['foo, bar', 'baz'])
     end
   end
 
@@ -54,12 +54,12 @@ RSpec.describe WorkVersionChangeDiff, versioning: true do
     subject(:diff) { described_class.call(last_paper_trail_version, separator: '; ') }
 
     before do
-      work_version.update!(keywords: %w(foo bar))
-      work_version.update!(keywords: %w(foo baz))
+      work_version.update!(keyword: %w(foo bar))
+      work_version.update!(keyword: %w(foo baz))
     end
 
     it 'shows the diff with the separator' do
-      expect(diff[:keywords]).to eq(['foo; bar', 'foo; baz'])
+      expect(diff[:keyword]).to eq(['foo; bar', 'foo; baz'])
     end
   end
 end


### PR DESCRIPTION
Changes the method for "Keywords" to `keyword'. This keep it internally consistent, as other multi valued terms have singular method names; and mirrors Scholarsphere 3's method names as well allowing for easier migration.

Fixes #192 