### PR TITLE
Add creators to work history timeline

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,6 +13,10 @@
 Layout/LineLength:
   Max: 154
 
+Lint/ImplicitStringConcatenation:
+  Exclude:
+    - 'app/components/work_histories/paper_trail_change_base_component.rb'
+
 # Offense count: 1
 # Cop supports --auto-correct.
 Lint/NonDeterministicRequireOrder:

--- a/app/components/work_histories/creator_alias_change_component.html.erb
+++ b/app/components/work_histories/creator_alias_change_component.html.erb
@@ -1,0 +1,21 @@
+<div
+  id="<%= element_id %>"
+  class="work-history__change work-history__change--creator work-history__change--<%= event_class %>">
+
+  <strong class="work-history__change-event"><%= action %></strong>
+  <%= t 'dashboard.work_history.creator_alias.creator' %>
+
+  <small class="work-history__aliases">
+    <% if rename? %>
+      <strong><%= previous_alias %></strong>
+      <%= t 'dashboard.work_history.renamed_to.html' %>
+    <% end %>
+    <strong><%= current_alias %></strong>
+  </small>
+
+  <div class="work-history__change-metadata">
+    <span class="work-history__change-timestamp"><%= timestamp %></span>
+    <span class="text-secondary"><%= t 'dashboard.work_history.by' %></span>
+    <span class="work-history__change-user"><%= user_name %></span>
+  </div>
+</div>

--- a/app/components/work_histories/creator_alias_change_component.rb
+++ b/app/components/work_histories/creator_alias_change_component.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'action_view/component'
+
+class WorkHistories::CreatorAliasChangeComponent < ActionView::Component::Base
+  validates :paper_trail_version,
+            :user,
+            presence: true
+
+  # @param paper_trail_version [PaperTrail::Version] representing a change to a
+  #        WorkVersionCreation
+  # @param user [User]
+  def initialize(paper_trail_version:, user:)
+    if paper_trail_version.item_type != 'WorkVersionCreation'
+      raise ArgumentError, 'paper_trail_version must apply to a WorkVersionCreation'
+    end
+
+    @paper_trail_version = paper_trail_version
+    @user = user
+  end
+
+  private
+
+    attr_reader :paper_trail_version,
+                :user
+
+    def element_id
+      "change_#{paper_trail_version.id}"
+    end
+
+    def event_class
+      return 'create' if create?
+      return 'rename' if rename?
+      return 'update' if update?
+      return 'delete' if destroy?
+    end
+
+    def action
+      return translate('rename') if rename?
+
+      translate(paper_trail_version.event)
+    end
+
+    def timestamp
+      paper_trail_version.created_at.to_s(:long)
+    end
+
+    def user_name
+      user.access_id.presence || I18n.t('dashboard.work_history.unknown_user')
+    end
+
+    def current_alias
+      return paper_trail_object['alias'] if destroy?
+      return paper_trail_object_changes['alias'].last if create?
+
+      paper_trail_object_changes.fetch('alias', []).last ||
+        paper_trail_object['alias']
+    end
+
+    def previous_alias
+      return nil unless rename?
+
+      paper_trail_object_changes.fetch('alias', []).first
+    end
+
+    def create?
+      paper_trail_version.event == 'create'
+    end
+
+    def update?
+      paper_trail_version.event == 'update' && !rename?
+    end
+
+    def rename?
+      paper_trail_version.event == 'update' && paper_trail_object_changes.key?('alias')
+    end
+
+    def destroy?
+      paper_trail_version.event == 'destroy'
+    end
+
+    def translate(key, options = {})
+      I18n.t("dashboard.work_history.creator_alias.#{key}", options)
+    end
+
+    def paper_trail_object
+      paper_trail_version.object || {}
+    end
+
+    def paper_trail_object_changes
+      paper_trail_version.object_changes || {}
+    end
+end

--- a/app/components/work_histories/creator_alias_change_component.rb
+++ b/app/components/work_histories/creator_alias_change_component.rb
@@ -1,52 +1,32 @@
 # frozen_string_literal: true
 
-require 'action_view/component'
-
-class WorkHistories::CreatorAliasChangeComponent < ActionView::Component::Base
-  validates :paper_trail_version,
-            :user,
-            presence: true
-
-  # @param paper_trail_version [PaperTrail::Version] representing a change to a
-  #        WorkVersionCreation
-  # @param user [User]
-  def initialize(paper_trail_version:, user:)
-    if paper_trail_version.item_type != 'WorkVersionCreation'
-      raise ArgumentError, 'paper_trail_version must apply to a WorkVersionCreation'
-    end
-
-    @paper_trail_version = paper_trail_version
-    @user = user
+class WorkHistories::CreatorAliasChangeComponent < WorkHistories::PaperTrailChangeBaseComponent
+  # This apparently is a little quirk of ActionView::Component, and requires an
+  # explicit #initialize method on each class.
+  def initialize(**args)
+    super
   end
 
   private
 
-    attr_reader :paper_trail_version,
-                :user
+    def i18n_key
+      'creator_alias'
+    end
 
-    def element_id
-      "change_#{paper_trail_version.id}"
+    def expected_item_type
+      'WorkVersionCreation'
     end
 
     def event_class
-      return 'create' if create?
       return 'rename' if rename?
-      return 'update' if update?
-      return 'delete' if destroy?
+
+      super
     end
 
     def action
       return translate('rename') if rename?
 
-      translate(paper_trail_version.event)
-    end
-
-    def timestamp
-      paper_trail_version.created_at.to_s(:long)
-    end
-
-    def user_name
-      user.access_id.presence || I18n.t('dashboard.work_history.unknown_user')
+      super
     end
 
     def current_alias
@@ -63,31 +43,11 @@ class WorkHistories::CreatorAliasChangeComponent < ActionView::Component::Base
       paper_trail_object_changes.fetch('alias', []).first
     end
 
-    def create?
-      paper_trail_version.event == 'create'
-    end
-
     def update?
-      paper_trail_version.event == 'update' && !rename?
+      super && !rename?
     end
 
     def rename?
       paper_trail_version.event == 'update' && paper_trail_object_changes.key?('alias')
-    end
-
-    def destroy?
-      paper_trail_version.event == 'destroy'
-    end
-
-    def translate(key, options = {})
-      I18n.t("dashboard.work_history.creator_alias.#{key}", options)
-    end
-
-    def paper_trail_object
-      paper_trail_version.object || {}
-    end
-
-    def paper_trail_object_changes
-      paper_trail_version.object_changes || {}
     end
 end

--- a/app/components/work_histories/file_membership_change_component.rb
+++ b/app/components/work_histories/file_membership_change_component.rb
@@ -1,52 +1,32 @@
 # frozen_string_literal: true
 
-require 'action_view/component'
-
-class WorkHistories::FileMembershipChangeComponent < ActionView::Component::Base
-  validates :paper_trail_version,
-            :user,
-            presence: true
-
-  # @param paper_trail_version [PaperTrail::Version] representing a change to a
-  #        FileVersionMembership
-  # @param user [User]
-  def initialize(paper_trail_version:, user:)
-    if paper_trail_version.item_type != 'FileVersionMembership'
-      raise ArgumentError, 'paper_trail_version must apply to a FileVersionMembership'
-    end
-
-    @paper_trail_version = paper_trail_version
-    @user = user
+class WorkHistories::FileMembershipChangeComponent < WorkHistories::PaperTrailChangeBaseComponent
+  # This apparently is a little quirk of ActionView::Component, and requires an
+  # explicit #initialize method on each class.
+  def initialize(**args)
+    super
   end
 
   private
 
-    attr_reader :paper_trail_version,
-                :user
+    def i18n_key
+      'file_membership'
+    end
 
-    def element_id
-      "change_#{paper_trail_version.id}"
+    def expected_item_type
+      'FileVersionMembership'
     end
 
     def event_class
-      return 'create' if create?
       return 'rename' if rename?
-      return 'update' if update?
-      return 'delete' if destroy?
+
+      super
     end
 
     def action
       return translate('rename') if rename?
 
-      translate(paper_trail_version.event)
-    end
-
-    def timestamp
-      paper_trail_version.created_at.to_s(:long)
-    end
-
-    def user_name
-      user.access_id.presence || I18n.t('dashboard.work_history.unknown_user')
+      super
     end
 
     def current_filename
@@ -63,31 +43,11 @@ class WorkHistories::FileMembershipChangeComponent < ActionView::Component::Base
       paper_trail_object_changes.fetch('title', []).first
     end
 
-    def create?
-      paper_trail_version.event == 'create'
-    end
-
     def update?
-      paper_trail_version.event == 'update' && !rename?
+      super && !rename?
     end
 
     def rename?
       paper_trail_version.event == 'update' && paper_trail_object_changes.key?('title')
-    end
-
-    def destroy?
-      paper_trail_version.event == 'destroy'
-    end
-
-    def translate(key, options = {})
-      I18n.t("dashboard.work_history.file_membership.#{key}", options)
-    end
-
-    def paper_trail_object
-      paper_trail_version.object || {}
-    end
-
-    def paper_trail_object_changes
-      paper_trail_version.object_changes || {}
     end
 end

--- a/app/components/work_histories/paper_trail_change_base_component.rb
+++ b/app/components/work_histories/paper_trail_change_base_component.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'action_view/component'
+
+class WorkHistories::PaperTrailChangeBaseComponent < ActionView::Component::Base
+  validates :paper_trail_version,
+            :user,
+            presence: true
+
+  # @param paper_trail_version [PaperTrail::Version] representing a change to a
+  #        WorkVersionCreation
+  # @param user [User]
+  def initialize(paper_trail_version:, user:)
+    if paper_trail_version.item_type.to_s != expected_item_type.to_s
+      raise ArgumentError, "paper_trail_version must apply to a #{expected_item_type}"
+    end
+
+    @paper_trail_version = paper_trail_version
+    @user = user
+  end
+
+  private
+
+    # Implement these in your subclass
+
+    # Which key under `dashboard.work_history` should we find the translations?
+    def i18n_key
+      raise NotImplementedError, 'Implement #i18n_key in your subclass'
+    end
+
+    # This is the type of object that your component is expecting.
+    # For example, if your component was representing changes to a
+    # FileVersionMembership object, set this method to "FileVersionMembership"
+    def expected_item_type
+      raise NotImplementedError, '''
+        Implement #expected_item_type in your subclass. For details on what it
+        does and how to set it, see the note in PaperTrailChangeBaseComponent
+      '''.squish
+    end
+
+    attr_reader :paper_trail_version,
+                :user
+
+    def element_id
+      "change_#{paper_trail_version.id}"
+    end
+
+    def event_class
+      return 'create' if create?
+      return 'update' if update?
+      return 'delete' if destroy?
+    end
+
+    def action
+      translate(paper_trail_event)
+    end
+
+    def timestamp
+      paper_trail_version.created_at.to_s(:long)
+    end
+
+    def user_name
+      user.access_id.presence || I18n.t('dashboard.work_history.unknown_user')
+    end
+
+    def create?
+      paper_trail_event == 'create'
+    end
+
+    def update?
+      paper_trail_event == 'update'
+    end
+
+    def destroy?
+      paper_trail_event == 'destroy'
+    end
+
+    def paper_trail_event
+      paper_trail_version.event
+    end
+
+    def paper_trail_object
+      paper_trail_version.object || {}
+    end
+
+    def paper_trail_object_changes
+      paper_trail_version.object_changes || {}
+    end
+
+    def translate(key, options = {})
+      I18n.t("dashboard.work_history.#{i18n_key}.#{key}", options)
+    end
+end

--- a/app/components/work_histories/work_version_change_component.rb
+++ b/app/components/work_histories/work_version_change_component.rb
@@ -1,31 +1,20 @@
 # frozen_string_literal: true
 
-require 'action_view/component'
-
-class WorkHistories::WorkVersionChangeComponent < ActionView::Component::Base
-  validates :paper_trail_version,
-            :user,
-            presence: true
-
-  # @param paper_trail_version [PaperTrail::Version] representing a change to a
-  #        WorkVersion
-  # @param user [User]
-  def initialize(paper_trail_version:, user:)
-    if paper_trail_version.item_type != 'WorkVersion'
-      raise ArgumentError, 'paper_trail_version must apply to a WorkVersion'
-    end
-
-    @paper_trail_version = paper_trail_version
-    @user = user
+class WorkHistories::WorkVersionChangeComponent < WorkHistories::PaperTrailChangeBaseComponent
+  # This apparently is a little quirk of ActionView::Component, and requires an
+  # explicit #initialize method on each class.
+  def initialize(**args)
+    super
   end
 
   private
 
-    attr_reader :paper_trail_version,
-                :user
+    def i18n_key
+      'work_version'
+    end
 
-    def element_id
-      "change_#{paper_trail_version.id}"
+    def expected_item_type
+      'WorkVersion'
     end
 
     def diff_id
@@ -35,15 +24,7 @@ class WorkHistories::WorkVersionChangeComponent < ActionView::Component::Base
     def action
       return translate('publish') if publish?
 
-      translate(paper_trail_version.event)
-    end
-
-    def timestamp
-      paper_trail_version.created_at.to_formatted_s(:long)
-    end
-
-    def user_name
-      user.access_id.presence || I18n.t('dashboard.work_history.unknown_user')
+      super
     end
 
     def changed_attributes
@@ -72,11 +53,7 @@ class WorkHistories::WorkVersionChangeComponent < ActionView::Component::Base
     end
 
     def update?
-      paper_trail_version.event == 'update' && !publish?
-    end
-
-    def translate(key, options = {})
-      I18n.t("dashboard.work_history.work_version.#{key}", options)
+      super && !publish?
     end
 
     def diff

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,6 +96,12 @@ en:
       unknown_user: '[unknown user]'
       renamed_to:
         html: "&rarr;"
+      creator_alias:
+        creator: Creator
+        create: Added
+        rename: Renamed
+        update: Updated
+        destroy: Deleted
       file_membership:
         create: Added
         rename: Renamed

--- a/spec/components/work_histories/creator_alias_change_component_spec.rb
+++ b/spec/components/work_histories/creator_alias_change_component_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# @note This spec uses a nonstandard format, where I lumped everything into a
+# single it-block. The reason is that this component represents a
+# PaperTrail::Version object, and we must therefore use real live PaperTrail to
+# test it properly--which is very slow when setting up and tearing down
+# factories between every single test run. Instead I've tried to re-use as many
+# objects as possible in a single it-block with big comments to denote each test
+
+RSpec.describe WorkHistories::CreatorAliasChangeComponent, type: :component do
+  let(:user) { build_stubbed :user }
+
+  describe '#initialize' do
+    it 'requires paper_trail_version to apply to a WorkVersionCreation' do
+      expect {
+        described_class.new(
+          user: user,
+          paper_trail_version: instance_spy('PaperTrail::Version', item_type: 'WorkVersion')
+        )
+      }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe 'rendering', versioning: true do
+    it 'renders the correct state given the paper trail version' do
+      ##########################################################################
+      #
+      # Context: when the WorkVersionCreation has been created
+      #
+      ##########################################################################
+      creator_alias = create :work_version_creation
+      paper_trail_version = creator_alias.versions.last
+      allow(paper_trail_version).to receive(:created_at)
+        .and_return(Time.zone.parse('2019-12-20 14:00:00'))
+      result = render_inline(described_class, paper_trail_version: paper_trail_version, user: user)
+
+      #
+      # It: renders the created state with properly formatted times
+      #
+      expect(result.at('div').attr('id')).to eq "change_#{paper_trail_version.id}"
+      expect(result.css('.work-history__change--create')).to be_present
+      expect(result.css('.work-history__change-event').text).to eq 'Added'
+      expect(result.css('.work-history__change-timestamp').text).to eq 'December 20, 2019 14:00'
+      expect(result.css('.work-history__change-user').text).to eq user.access_id
+      expect(result.css('.work-history__aliases').text).to include creator_alias.alias
+
+      ##########################################################################
+      #
+      # Context: when the User is a null-object
+      #
+      ##########################################################################
+      null_user = User.new
+      result = render_inline(described_class, paper_trail_version: paper_trail_version, user: null_user)
+
+      #
+      # It: renders the null-user properly
+      #
+      expect(result.css('.work-history__change-user').text)
+        .to eq I18n.t('dashboard.work_history.unknown_user')
+
+      ##########################################################################
+      #
+      # Context: when the WorkVersionCreation has been renamed
+      #
+      ##########################################################################
+      creator_alias.update!(alias: 'Old Alias')
+      creator_alias.update!(alias: 'New Alias')
+      paper_trail_version = creator_alias.versions.last
+      result = render_inline(described_class, paper_trail_version: paper_trail_version, user: user)
+
+      #
+      # It: shows both old a new filenames
+      #
+      expect(result.css('.work-history__change--rename')).to be_present
+      expect(result.css('.work-history__change-event').text).to eq 'Renamed'
+      expect(result.css('.work-history__aliases').text).to include('Old Alias').and include('New Alias')
+
+      ##########################################################################
+      #
+      # Context: when the WorkVersionCreation has been destroyed
+      #
+      ##########################################################################
+      creator_alias.update!(alias: 'Destroy Test')
+      creator_alias.destroy
+      paper_trail_version = creator_alias.versions.last
+      result = render_inline(described_class, paper_trail_version: paper_trail_version, user: user)
+
+      #
+      # It: shows the delete event
+      #
+      expect(result.css('.work-history__change--delete')).to be_present
+      expect(result.css('.work-history__change-event').text).to eq 'Deleted'
+      expect(result.css('.work-history__aliases').text).to include('Destroy Test')
+    end
+  end
+end

--- a/spec/components/work_histories/paper_trail_change_base_component_spec.rb
+++ b/spec/components/work_histories/paper_trail_change_base_component_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# @note this class is an abstract base, so this test implements a couple
+# subclasses to test various scenarios
+
+RSpec.describe WorkHistories::PaperTrailChangeBaseComponent, type: :component do
+  let(:user) { build_stubbed :user }
+  let(:paper_trail_version) { instance_spy('PaperTrail::Version', item_type: 'ExpectedItemType') }
+
+  before do
+    no_item_type_class = Class.new(described_class)
+    stub_const('NoItemType', no_item_type_class)
+
+    has_item_type_class = Class.new(described_class) do
+      def expected_item_type
+        'ExpectedItemType'
+      end
+    end
+    stub_const('HasItemType', has_item_type_class)
+  end
+
+  describe '#initialize' do
+    context 'when the subclass does not implement #expected_item_type' do
+      it do
+        expect {
+          NoItemType.new(user: user, paper_trail_version: paper_trail_version)
+        }.to raise_error(NotImplementedError)
+      end
+    end
+
+    context 'when the subclass does implement #expected_item_type' do
+      it 'requires paper_trail_version to apply to the specified class' do
+        expect {
+          allow(paper_trail_version).to receive(:item_type).and_return 'DifferentClass'
+          HasItemType.new(
+            user: user,
+            paper_trail_version: paper_trail_version
+          )
+        }.to raise_error(ArgumentError)
+
+        expect {
+          allow(paper_trail_version).to receive(:item_type).and_return 'ExpectedItemType'
+          HasItemType.new(
+            user: user,
+            paper_trail_version: paper_trail_version
+          )
+        }.not_to raise_error
+      end
+    end
+  end
+
+  describe '#i18n_key' do
+    context 'when the subclass does not implement #i18n_key' do
+      it do
+        expect {
+          HasItemType.new(user: user, paper_trail_version: paper_trail_version)
+            .send(:i18n_key)
+        }.to raise_error(NotImplementedError).with_message(/Implement #i18n_key/)
+      end
+    end
+  end
+end

--- a/spec/components/work_histories/work_history_component_spec.rb
+++ b/spec/components/work_histories/work_history_component_spec.rb
@@ -30,9 +30,10 @@ RSpec.describe WorkHistories::WorkHistoryComponent, type: :component, versioning
       expect(result.css("#work_version_changes_#{draft.id} .work-history__change--work-version")).to be_present
       expect(result.css("#work_version_changes_#{draft.id} .work-history__change--file")).to be_empty
 
-      # Published version has work-version and file changes
+      # Published version has work-version, file, and creator changes
       expect(result.css("#work_version_changes_#{v1.id} .work-history__change--work-version")).to be_present
       expect(result.css("#work_version_changes_#{v1.id} .work-history__change--file")).to be_present
+      expect(result.css("#work_version_changes_#{v1.id} .work-history__change--creator")).to be_present
     end
 
     context 'when the user cannot be found' do

--- a/spec/components/work_version_metadata_component_spec.rb
+++ b/spec/components/work_version_metadata_component_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe WorkVersionMetadataComponent, type: :component do
   end
 
   describe 'fully loaded' do
-    let(:work_version) { build_stubbed :work_version, :with_complete_metadata }
+    let(:work_version) { build_stubbed :work_version, :with_complete_metadata, :with_creators }
 
     it 'renders every field' do
       # Titles

--- a/spec/factories/work_versions.rb
+++ b/spec/factories/work_versions.rb
@@ -10,20 +10,22 @@ FactoryBot.define do
     # Postgres does this for us, but for testing, we can do it here to save having to call create/reload.
     uuid { SecureRandom.uuid }
 
-    transient do
-      creator_count { 1 }
-    end
+    trait :with_creators do
+      transient do
+        creator_count { 1 }
+      end
 
-    after(:build, :stub) do |work_version, evaluator|
-      creators = build_list(:creator, evaluator.creator_count)
+      after(:build, :stub) do |work_version, evaluator|
+        creators = build_list(:creator, evaluator.creator_count)
 
-      creators.each do |creator|
-        # Alias "Pat Doe" to "Dr. Pat Doe"
-        creator_alias = "#{Faker::Name.prefix} #{creator.given_name} #{creator.surname}"
-        work_version.creator_aliases.build(
-          creator: creator,
-          alias: creator_alias
-        )
+        creators.each do |creator|
+          # Alias "Pat Doe" to "Dr. Pat Doe"
+          creator_alias = "#{Faker::Name.prefix} #{creator.given_name} #{creator.surname}"
+          work_version.creator_aliases.build(
+            creator: creator,
+            alias: creator_alias
+          )
+        end
       end
     end
 
@@ -46,6 +48,7 @@ FactoryBot.define do
     trait :able_to_be_published do
       draft
       with_files
+      with_creators
     end
 
     # A valid published work-version

--- a/spec/lib/data_cite/metadata_spec.rb
+++ b/spec/lib/data_cite/metadata_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe DataCite::Metadata do
 
   let(:attributes) { metadata.attributes }
 
-  let(:work_version) { FactoryBot.build_stubbed :work_version, :with_complete_metadata, creator_count: 0, creators: [creator] }
+  let(:work_version) { FactoryBot.build_stubbed :work_version, :with_complete_metadata, creators: [creator] }
   let(:work) { work_version.work }
 
   let(:creator) { FactoryBot.build_stubbed :creator, orcid: nil }

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe WorkVersion, type: :model do
 
   describe '#build_creator_alias' do
     let(:creator) { build_stubbed :creator }
-    let(:work_version) { build_stubbed :work_version, creator_count: 0 }
+    let(:work_version) { build_stubbed :work_version, :with_creators, creator_count: 0 }
 
     it 'builds a creator_alias for the given Creator but does not persist it' do
       expect {


### PR DESCRIPTION
I implemented this the same way as we do files, rather than trying to insert them into the metadata changes (which would be very difficult). See a screenshot below.

If this looks good to you, approve it, but I'd like to consider possibly refactoring all the `-WorkHistoryChange` components to inherit from a base class or module. We're now at the "Rule of Three" and there's a decent amount of duplicated code among  them. (I'm curious to see if Code Climate will catch this) [Update: yes, Code Climate did catch this]

Closes #195 

<img width="446" alt="Screen Shot 2020-02-11 at 4 06 39 PM" src="https://user-images.githubusercontent.com/14730/74279814-a5255680-4ce9-11ea-82fb-01a690df3638.png">
