### PR TITLE
Update API to handle works that can't be saved or published

### DIFF
--- a/app/controllers/api/v1/ingest_controller.rb
+++ b/app/controllers/api/v1/ingest_controller.rb
@@ -2,8 +2,13 @@
 
 module Api::V1
   class IngestController < RestController
-    rescue_from ActionController::ParameterMissing do |exception|
-      render json: { message: 'Bad request', errors: [exception.message] }, status: :bad_request
+    rescue_from StandardError do |exception|
+      if exception.is_a?(ActionController::ParameterMissing)
+        render json: { message: 'Bad request', errors: [exception.message] }, status: :bad_request
+      else
+        render json: { message: "We're sorry, but something went wrong", errors: [exception.class.to_s, exception] },
+               status: :internal_server_error
+      end
     end
 
     def create

--- a/app/models/concerns/permissions.rb
+++ b/app/models/concerns/permissions.rb
@@ -50,7 +50,7 @@ module Permissions
   # @note Always add the visibility group when setting the list of read groups. This avoids the problem of inadvertently
   # removing a visiliblity setting via the read groups setter.
   def read_groups=(list)
-    super(list.append(visibility_agent))
+    super(list.append(visibility_agent).compact)
   end
 
   def grant_open_access

--- a/app/models/concerns/permissions.rb
+++ b/app/models/concerns/permissions.rb
@@ -5,8 +5,8 @@ module Permissions
 
   class Visibility
     OPEN = 'open'
-    AUTHORIZED = 'authorized'
-    PRIVATE = 'private'
+    AUTHORIZED = 'authenticated'
+    PRIVATE = 'restricted'
 
     def self.all
       [OPEN, AUTHORIZED, PRIVATE]

--- a/spec/components/visibility_badge_component_spec.rb
+++ b/spec/components/visibility_badge_component_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe VisibilityBadgeComponent, type: :component do
       expect(image.attributes['src'].value).to match(/visibility-authorized/)
       expect(image.classes).to contain_exactly('visibility')
       expect(badge.text).to include('Penn State')
-      expect(badge.classes).to include('badge', 'visibility', 'visibility--authorized')
+      expect(badge.classes).to include('badge', 'visibility', 'visibility--authenticated')
     end
   end
 
@@ -36,7 +36,7 @@ RSpec.describe VisibilityBadgeComponent, type: :component do
       expect(image.attributes['src'].value).to match(/visibility-private/)
       expect(image.classes).to contain_exactly('visibility')
       expect(badge.text).to include('Restricted')
-      expect(badge.classes).to include('badge', 'visibility', 'visibility--private')
+      expect(badge.classes).to include('badge', 'visibility', 'visibility--restricted')
     end
   end
 end

--- a/spec/controllers/api/v1/ingest_controller_spec.rb
+++ b/spec/controllers/api/v1/ingest_controller_spec.rb
@@ -87,7 +87,27 @@ RSpec.describe Api::V1::IngestController, type: :controller do
         expect(response.body).to eq(
           '{' \
             '"message":"Unable to complete the request",' \
-            "\"errors\":[\"Versions title can't be blank\",\"Versions creator aliases can't be blank\"]" \
+            "\"errors\":[\"Versions title can't be blank\"]" \
+          '}'
+        )
+      end
+    end
+
+    context 'when the work cannot be published' do
+      before do
+        post :create, params: {
+          metadata: { title: FactoryBotHelpers.work_title },
+          depositor: user.access_id,
+          content: [{ file: fixture_file_upload(File.join(fixture_path, 'image.png')) }]
+        }
+      end
+
+      it 'saves the work with errors' do
+        expect(response).to be_created
+        expect(response.body).to eq(
+          '{' \
+            '"message":"Work was created but cannot be published",' \
+            "\"errors\":[\"Creator can't be blank\"]" \
           '}'
         )
       end

--- a/spec/controllers/api/v1/ingest_controller_spec.rb
+++ b/spec/controllers/api/v1/ingest_controller_spec.rb
@@ -92,5 +92,26 @@ RSpec.describe Api::V1::IngestController, type: :controller do
         )
       end
     end
+
+    context 'when there is an unexpected error' do
+      before do
+        allow(controller).to receive(:create).and_raise(NoMethodError, 'well, this is unexpected!')
+        post :create, params: {
+          metadata: { title: FactoryBotHelpers.work_title, creator_aliases_attributes: [creator_alias] },
+          depositor: user.access_id,
+          content: [{ file: fixture_file_upload(File.join(fixture_path, 'image.png')) }]
+        }
+      end
+
+      it 'reports the error' do
+        expect(response.status).to eq(500)
+        expect(response.body).to eq(
+          '{' \
+            "\"message\":\"We're sorry, but something went wrong\"," \
+            '"errors":["NoMethodError","well, this is unexpected!"]' \
+          '}'
+        )
+      end
+    end
   end
 end

--- a/spec/models/permissions_spec.rb
+++ b/spec/models/permissions_spec.rb
@@ -407,6 +407,16 @@ RSpec.describe Permissions do
 
       its(:read_groups) { is_expected.to contain_exactly(group1, group2, Group.authorized_agent) }
     end
+
+    context 'with a private resource' do
+      let(:resource) { build(:work, visibility: Permissions::Visibility::PRIVATE) }
+
+      its(:read_groups) { is_expected.to contain_exactly(group1, group2) }
+
+      specify 'there is no nil access control from the null visibility agent' do
+        expect(resource.access_controls.length).to eq(2)
+      end
+    end
   end
 
   describe '#grant_edit_access' do

--- a/spec/models/permissions_spec.rb
+++ b/spec/models/permissions_spec.rb
@@ -27,10 +27,10 @@ RSpec.describe Permissions do
 
   describe Permissions::Visibility do
     specify { expect(Permissions::Visibility::OPEN).to eq('open') }
-    specify { expect(Permissions::Visibility::AUTHORIZED).to eq('authorized') }
-    specify { expect(Permissions::Visibility::PRIVATE).to eq('private') }
+    specify { expect(Permissions::Visibility::AUTHORIZED).to eq('authenticated') }
+    specify { expect(Permissions::Visibility::PRIVATE).to eq('restricted') }
     specify { expect(described_class.default).to eq('open') }
-    specify { expect(described_class.all).to contain_exactly('open', 'authorized', 'private') }
+    specify { expect(described_class.all).to contain_exactly('open', 'authenticated', 'restricted') }
   end
 
   describe '#grant_open_access' do


### PR DESCRIPTION
Works that have missing metadata or private visibility, are not migrating correctly. We need to save draft works or have the application return sensible 500 errors if something really goes wrong.

Fixes #200 and #201 