### PR TITLE
Support for Scholarsphere-3 URLs

### DIFF
--- a/app/controllers/legacy_urls_controller.rb
+++ b/app/controllers/legacy_urls_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class LegacyUrlsController < ApplicationController
+  # Handles legacy urls from Scholarsphere v3
+  def v3
+    uuid = LegacyIdentifier.find_uuid(version: 3, old_id: params[:id])
+    redirect_to resource_path(uuid)
+  end
+end

--- a/app/models/legacy_identifier.rb
+++ b/app/models/legacy_identifier.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class LegacyIdentifier < ApplicationRecord
+  belongs_to :resource, polymorphic: true
+
+  def self.find_uuid(version:, old_id:)
+    legacy_id = find_by(version: version, old_id: old_id)
+
+    legacy_id&.resource&.uuid ||
+      raise(ActiveRecord::RecordNotFound)
+  end
+end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -14,6 +14,10 @@ class Work < ApplicationRecord
            inverse_of: 'work',
            dependent: :destroy
 
+  has_many :legacy_identifiers,
+           as: :resource,
+           dependent: :destroy
+
   accepts_nested_attributes_for :versions
 
   module Types

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,4 +71,7 @@ Rails.application.routes.draw do
       resources :ingest, only: [:create]
     end
   end
+
+  # Legacy URL support
+  get '/concern/generic_works/:id', to: 'legacy_urls#v3'
 end

--- a/db/migrate/20200224164256_create_legacy_identifiers.rb
+++ b/db/migrate/20200224164256_create_legacy_identifiers.rb
@@ -1,0 +1,13 @@
+class CreateLegacyIdentifiers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :legacy_identifiers do |t|
+      t.integer :version
+      t.string :old_id
+      t.references :resource, polymorphic: true, null: false
+
+      t.timestamps
+    end
+
+    add_index :legacy_identifiers, %i[version old_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_07_155145) do
+ActiveRecord::Schema.define(version: 2020_02_24_164256) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,6 +73,17 @@ ActiveRecord::Schema.define(version: 2020_02_07_155145) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["name"], name: "index_groups_on_name"
+  end
+
+  create_table "legacy_identifiers", force: :cascade do |t|
+    t.integer "version"
+    t.string "old_id"
+    t.string "resource_type", null: false
+    t.bigint "resource_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["resource_type", "resource_id"], name: "index_legacy_identifiers_on_resource_type_and_resource_id"
+    t.index ["version", "old_id"], name: "index_legacy_identifiers_on_version_and_old_id", unique: true
   end
 
   create_table "searches", id: :serial, force: :cascade do |t|

--- a/spec/factories/legacy_identifiers.rb
+++ b/spec/factories/legacy_identifiers.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :legacy_identifier do
+    version { 1 }
+    sequence(:old_id) { |n| format('old-id-%<n>06d', n: n) }
+    with_work_version
+
+    trait :with_work_version do
+      association :resource, factory: :work_version
+    end
+
+    trait :with_work do
+      association :resource, factory: :work
+    end
+  end
+end

--- a/spec/models/legacy_identifier_spec.rb
+++ b/spec/models/legacy_identifier_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LegacyIdentifier, type: :model do
+  describe 'table' do
+    it { is_expected.to have_db_column(:version).of_type(:integer) }
+    it { is_expected.to have_db_column(:old_id).of_type(:string) }
+    it { is_expected.to have_db_column(:resource_type).of_type(:string) }
+    it { is_expected.to have_db_column(:resource_id).of_type(:integer) }
+
+    it { is_expected.to have_db_index([:resource_type, :resource_id]) }
+    it { is_expected.to have_db_index([:version, :old_id]) }
+  end
+
+  describe 'factory' do
+    it { is_expected.to have_valid_factory(:legacy_identifier) }
+  end
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:resource) }
+  end
+
+  describe '.find_uuid' do
+    let(:work_version) { create :work_version }
+
+    context 'when the ID can be found' do
+      before do
+        create :legacy_identifier,
+               version: 1,
+               old_id: 'old-123',
+               resource: work_version
+      end
+
+      it 'returns the UUID of the associated resource' do
+        expect(described_class.find_uuid(version: 1, old_id: 'old-123'))
+          .to eq work_version.uuid
+      end
+    end
+
+    context 'when the ID cannot be found' do
+      it do
+        expect {
+          described_class.find_uuid(version: 1, old_id: 'does not exist')
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Work, type: :model do
     it { is_expected.to belong_to(:depositor).class_name('User').with_foreign_key(:depositor_id) }
     it { is_expected.to have_many(:access_controls) }
     it { is_expected.to have_many(:versions).class_name('WorkVersion').inverse_of('work') }
+    it { is_expected.to have_many(:legacy_identifiers) }
 
     it { is_expected.to accept_nested_attributes_for(:versions) }
   end

--- a/spec/request/legacy_urls_spec.rb
+++ b/spec/request/legacy_urls_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LegacyUrlsController, type: :request do
+  let(:resource) { create :work_version }
+
+  describe 'Scholarsphere v3 legacy URLs' do
+    before do
+      create :legacy_identifier,
+             version: 3,
+             old_id: 'old-v3-id-123',
+             resource: resource
+    end
+
+    it do
+      get '/concern/generic_works/old-v3-id-123'
+      expect(response).to redirect_to resource_path(resource.uuid)
+    end
+
+    context 'when given a nonexistent id' do
+      it do
+        expect {
+          get '/concern/generic_works/doesnt-exist'
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context 'when given an ID to a scholarsphere-2 record' do
+      before do
+        create :legacy_identifier,
+               version: 2,
+               old_id: 'old-v2-id-222',
+               resource: resource
+      end
+
+      it do
+        expect {
+          get '/concern/generic_works/doesnt-exist'
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Here's a sketch for how to support old URLs with a minimum of coupling:

* `LegacyIdentifer` model contains a version number (which version of ScholarSphere this ID came from), an `old_id` string (e.g. the NOID), and a polymorphic ActiveRecord association to the corresponding thing in SS-4
* All old _routes_ are handled in `config/routes.rb` and a controller that uses the above model

### Open Questions
* Do we need support for files? That could get tricky and make this fall apart.

Closes #166 