### PR TITLE
Create legacy identifiers for migrated works

### DIFF
--- a/app/controllers/api/v1/ingest_controller.rb
+++ b/app/controllers/api/v1/ingest_controller.rb
@@ -85,6 +85,7 @@ module Api::V1
             :subtitle,
             :rights,
             :version_name,
+            :noid,
             keyword: [],
             description: [],
             resource_type: [],

--- a/app/services/publish_new_work.rb
+++ b/app/services/publish_new_work.rb
@@ -18,6 +18,7 @@ class PublishNewWork
   # @return [Work]
   def self.call(metadata:, depositor:, content:, permissions: {})
     user = UserRegistrationService.call(uid: depositor)
+    noid = metadata.delete(:noid)
 
     params = {
       work_type: metadata.delete(:work_type) { Work::Types::DATASET },
@@ -27,6 +28,12 @@ class PublishNewWork
     }
 
     work = Work.build_with_empty_version(params)
+    if noid.present?
+      work.legacy_identifiers.find_or_initialize_by(
+        version: 3,
+        old_id: noid
+      )
+    end
     UpdatePermissionsService.call(resource: work, permissions: permissions, create_agents: true)
     work_version = work.versions.first
 


### PR DESCRIPTION
Creates legacy identifiers using the NOIDs from works migrated from Scholarsphere 3.

Related to #193 