### PR TITLE
Promote and destroy files asynchronously

### DIFF
--- a/app/jobs/shrine/destruction_job.rb
+++ b/app/jobs/shrine/destruction_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Shrine::DestructionJob < ApplicationJob
+  queue_as :shrine
+
+  def perform(data:)
+    attacher = FileUploader::Attacher.from_data(data)
+    attacher.destroy
+  end
+end

--- a/app/jobs/shrine/promotion_job.rb
+++ b/app/jobs/shrine/promotion_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Shrine::PromotionJob < ApplicationJob
+  queue_as :shrine
+
+  def perform(record:, name:, file_data:)
+    attacher = Shrine::Attacher.retrieve(model: record, name: name.to_sym, file: file_data)
+    attacher.atomic_promote
+  rescue Shrine::AttachmentChanged, ActiveRecord::RecordNotFound
+    # attachment has changed or record has been deleted, nothing to do
+  end
+end

--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -1,4 +1,19 @@
 # frozen_string_literal: true
 
 class FileUploader < Shrine
+  plugin :backgrounding
+
+  Attacher.promote_block do
+    Shrine::PromotionJob.perform_later(
+      record: record,
+      name: name.to_s,
+      file_data: file_data
+    )
+  end
+
+  Attacher.destroy_block do
+    Shrine::DestructionJob.perform_later(
+      data: data
+    )
+  end
 end

--- a/spec/jobs/shrine/destruction_job_spec.rb
+++ b/spec/jobs/shrine/destruction_job_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Shrine::DestructionJob, type: :job do
+  let(:mock_attacher) { instance_spy(FileUploader::Attacher) }
+
+  before do
+    allow(FileUploader::Attacher).to receive(:from_data).with('data').and_return(mock_attacher)
+  end
+
+  it 'deletes file data' do
+    described_class.perform_now(data: 'data')
+    expect(mock_attacher).to have_received(:destroy)
+  end
+end

--- a/spec/jobs/shrine/promotion_job_spec.rb
+++ b/spec/jobs/shrine/promotion_job_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Shrine::PromotionJob, type: :job do
+  let(:record) { build(:file_resource) }
+  let(:name) { 'file' }
+  let(:file_data) { { id: SecureRandom.uuid, storage: 'cache' } }
+
+  context 'with valid input' do
+    let(:mock_attacher) { instance_spy(FileUploader::Attacher) }
+
+    before { allow(Shrine::Attacher).to receive(:retrieve).and_return(mock_attacher) }
+
+    it 'promotes a file from cache to storage' do
+      described_class.perform_now(record: record, name: name, file_data: file_data)
+      expect(mock_attacher).to have_received(:atomic_promote)
+    end
+  end
+
+  context 'when the attachment has changed' do
+    before { allow(Shrine::Attacher).to receive(:retrieve).and_raise(Shrine::AttachmentChanged) }
+
+    it 'returns nil' do
+      expect(described_class.perform_now(record: record, name: name, file_data: file_data)).to be_nil
+    end
+  end
+
+  context 'when the record is not found' do
+    before { allow(Shrine::Attacher).to receive(:retrieve).and_raise(ActiveRecord::RecordNotFound) }
+
+    it 'returns nil' do
+      expect(described_class.perform_now(record: record, name: name, file_data: file_data)).to be_nil
+    end
+  end
+
+  context 'when an unexpected error occurs' do
+    before { allow(Shrine::Attacher).to receive(:retrieve).and_raise(StandardError) }
+
+    it 'returns nil' do
+      expect {
+        described_class.perform_now(record: record, name: name, file_data: file_data)
+      }.to raise_error(StandardError)
+    end
+  end
+end


### PR DESCRIPTION
Adds jobs for promoting files from cache to store, as well as deleting files from storage.

Fixes #217 