### PR TITLE
I#110 api auth

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -49,6 +49,11 @@ Rails/OutputSafety:
   Exclude:
     - 'app/components/work_version_metadata_component.rb'
 
+# Offense count: 1
+Rails/SkipsModelValidations:
+  Exclude:
+    - 'app/models/api_token.rb'
+
 Style/CollectionMethods:
   Exclude:
     - 'app/models/work_version.rb'

--- a/app/controllers/api/v1/rest_controller.rb
+++ b/app/controllers/api/v1/rest_controller.rb
@@ -4,6 +4,26 @@ module Api
   module V1
     class RestController < ActionController::Base
       skip_forgery_protection
+      before_action :authenticate_request!
+
+      private
+
+        def authenticate_request!
+          if api_token
+            api_token.record_usage
+          else
+            render json: { message: I18n.t('api.errors.not_authorized'), code: 401 }, status: 401 unless api_token
+          end
+        end
+
+        def api_token
+          @api_token ||= ApiToken.find_by(token: api_key_header)
+        end
+
+        def api_key_header
+          request.headers['HTTP_X_API_KEY'].presence ||
+            request.headers['X_API_KEY']
+        end
     end
   end
 end

--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ApiToken < ApplicationRecord
+  before_create :set_token
+
+  validates :app_name,
+            :admin_email,
+            presence: true
+
+  def record_usage
+    update_column(:last_used_at, Time.zone.now)
+  end
+
+  private
+
+    def set_token
+      self.token ||= SecureRandom.hex(48)
+    end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,9 @@ en:
             title:
               different_extension: does not have the same filename extension as %{original}
 
+  api:
+    errors:
+      not_authorized: "401: Request not authorized. Please provide a valid API key for access."
   dashboard:
     profiles:
       edit:

--- a/db/migrate/20200304200754_create_api_tokens.rb
+++ b/db/migrate/20200304200754_create_api_tokens.rb
@@ -1,0 +1,14 @@
+class CreateApiTokens < ActiveRecord::Migration[6.0]
+  def change
+    create_table :api_tokens do |t|
+      t.string :token
+      t.string :app_name
+      t.string :admin_email
+      t.datetime :last_used_at
+
+      t.timestamps
+    end
+
+    add_index :api_tokens, :token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_24_164256) do
+ActiveRecord::Schema.define(version: 2020_03_04_200754) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,16 @@ ActiveRecord::Schema.define(version: 2020_02_24_164256) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["agent_type", "agent_id"], name: "index_access_controls_on_agent_type_and_agent_id"
     t.index ["resource_type", "resource_id"], name: "index_access_controls_on_resource_type_and_resource_id"
+  end
+
+  create_table "api_tokens", force: :cascade do |t|
+    t.string "token"
+    t.string "app_name"
+    t.string "admin_email"
+    t.datetime "last_used_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["token"], name: "index_api_tokens_on_token", unique: true
   end
 
   create_table "bookmarks", id: :serial, force: :cascade do |t|

--- a/spec/controllers/api/v1/ingest_controller_spec.rb
+++ b/spec/controllers/api/v1/ingest_controller_spec.rb
@@ -6,6 +6,7 @@ require 'rails_helper'
 # feature test to ensure end-to-end functionality of our ingest API.
 
 RSpec.describe Api::V1::IngestController, type: :controller do
+  let(:api_token) { create(:api_token).token }
   let(:user) { create(:user) }
   let(:creator_alias) do
     {
@@ -18,6 +19,8 @@ RSpec.describe Api::V1::IngestController, type: :controller do
       }
     }
   end
+
+  before { request.headers[:'X-API-Key'] = api_token }
 
   describe 'POST #create' do
     context 'with valid input' do

--- a/spec/factories/api_tokens.rb
+++ b/spec/factories/api_tokens.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :api_token do
+    token { nil } # Typically generated in an after_initialize
+    app_name { 'My Client Application' }
+    admin_email { 'admin@client.app' }
+  end
+end

--- a/spec/models/api_token_spec.rb
+++ b/spec/models/api_token_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApiToken, type: :model do
+  describe 'table' do
+    it { is_expected.to have_db_column(:token).of_type(:string) }
+    it { is_expected.to have_db_column(:app_name).of_type(:string) }
+    it { is_expected.to have_db_column(:admin_email).of_type(:string) }
+    it { is_expected.to have_db_column(:last_used_at).of_type(:datetime) }
+    it { is_expected.to have_db_column(:created_at).of_type(:datetime) }
+    it { is_expected.to have_db_column(:updated_at).of_type(:datetime) }
+
+    it { is_expected.to have_db_index(:token).unique(true) }
+  end
+
+  describe 'factory' do
+    it { is_expected.to have_valid_factory(:api_token) }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:app_name) }
+    it { is_expected.to validate_presence_of(:admin_email) }
+  end
+
+  describe 'creating a new token' do
+    let(:new_token) { build :api_token, token: nil }
+
+    it 'sets a value for the token' do
+      new_token.save!
+      expect(new_token.token.length).to eq 96
+    end
+  end
+
+  describe '#record_usage' do
+    let(:token) { create :api_token }
+
+    it 'touches last_used_at in the database' do
+      expect {
+        token.record_usage
+      }.to(change {
+        token.reload.last_used_at
+      })
+    end
+  end
+end


### PR DESCRIPTION
Adds blanket all-or-nothing auth to API calls via a token provided in 'X-API-KEY' header.

Adam, you will need to go into the Rails console, and generate yourself a new API key to continue with migration. It will look like this:

```ruby
ApiToken.create(app_name: 'ScholarSphere 3 Migration', admin_email: 'agw420@psu.edu').token
```

Closes #110 