### PR TITLE
Define embargoes on works and how the affect downloading

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -6,6 +6,7 @@ class SearchBuilder < Blacklight::SearchBuilder
   self.default_processor_chain += %i(
     restrict_search_to_works
     apply_gated_discovery
+    exclude_embargoed_works
     log_solr_parameters
   )
 
@@ -23,6 +24,13 @@ class SearchBuilder < Blacklight::SearchBuilder
 
   def log_solr_parameters(solr_parameters)
     Rails.logger.debug("Solr parameters: #{solr_parameters.inspect}")
+  end
+
+  def exclude_embargoed_works(solr_parameters)
+    return if current_user.admin?
+
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] << '-embargoed_until_dtsi:[NOW TO *]'
   end
 
   private

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -73,6 +73,12 @@ class Work < ApplicationRecord
     document_builder.generate(resource: self)
   end
 
+  def embargoed?
+    return false if embargoed_until.blank?
+
+    embargoed_until > DateTime.now
+  end
+
   private
 
     def document_builder

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -145,7 +145,7 @@ class WorkVersion < ApplicationRecord
     WorkIndexer.call(work, commit: true)
   end
 
-  delegate :depositor, :visibility, to: :work
+  delegate :depositor, :visibility, :embargoed?, to: :work
 
   private
 

--- a/app/policies/file_version_membership_policy.rb
+++ b/app/policies/file_version_membership_policy.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class FileVersionMembershipPolicy < ApplicationPolicy
+  def download?
+    return true if edit?
+    return download_published_version? if work_version.published?
+
+    false
+  end
+
+  private
+
+    # @todo There's a bug in the permissions because a depositor should have edit access by default
+    def edit?
+      work_version.work.edit_access?(user) || work_version.depositor == user
+    end
+
+    def download_published_version?
+      return false if work_version.embargoed?
+
+      work_version.work.read_access? user
+    end
+
+    def work_version
+      @work_version ||= record.work_version
+    end
+end

--- a/db/migrate/20200303184207_add_embargo_to_works.rb
+++ b/db/migrate/20200303184207_add_embargo_to_works.rb
@@ -1,0 +1,5 @@
+class AddEmbargoToWorks < ActiveRecord::Migration[6.0]
+  def change
+    add_column :works, :embargoed_until, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -168,6 +168,7 @@ ActiveRecord::Schema.define(version: 2020_03_04_200754) do
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "uuid", default: -> { "uuid_generate_v4()" }
     t.string "doi"
+    t.datetime "embargoed_until"
     t.index ["depositor_id"], name: "index_works_on_depositor_id"
   end
 

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -51,4 +51,8 @@ FactoryBot.define do
       work.access_controls.destroy_all
     end
   end
+
+  trait(:with_authorized_access) do
+    visibility { Permissions::Visibility::AUTHORIZED }
+  end
 end

--- a/spec/features/discovery_search_spec.rb
+++ b/spec/features/discovery_search_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 RSpec.describe 'Searching discoverable resources' do
   let!(:public_work) { create(:work, has_draft: false) }
   let!(:authorized_work) { create(:work, visibility: Permissions::Visibility::AUTHORIZED, has_draft: false) }
+  let!(:current_embargoed_work) { create(:work, has_draft: false, embargoed_until: (DateTime.now + 6.days)) }
+  let!(:previous_embargoed_work) { create(:work, has_draft: false, embargoed_until: (DateTime.now - 6.days)) }
 
   context 'with a public user' do
     it 'searches only public works' do
@@ -12,6 +14,8 @@ RSpec.describe 'Searching discoverable resources' do
       click_button('Search')
 
       expect(page).to have_content(public_work.latest_published_version.title)
+      expect(page).to have_content(previous_embargoed_work.latest_published_version.title)
+      expect(page).not_to have_content(current_embargoed_work.latest_published_version.title)
       expect(page).not_to have_content(authorized_work.latest_published_version.title)
     end
   end
@@ -24,6 +28,8 @@ RSpec.describe 'Searching discoverable resources' do
       click_button('Search')
 
       expect(page).to have_content(public_work.latest_published_version.title)
+      expect(page).to have_content(previous_embargoed_work.latest_published_version.title)
+      expect(page).not_to have_content(current_embargoed_work.latest_published_version.title)
       expect(page).to have_content(authorized_work.latest_published_version.title)
     end
   end

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe SearchBuilder do
       is_expected.to include(
         :restrict_search_to_works,
         :apply_gated_discovery,
+        :exclude_embargoed_works,
         :log_solr_parameters
       )
     end
@@ -48,6 +49,14 @@ RSpec.describe SearchBuilder do
 
       it 'shows all Works' do
         expect(parameters['fq']).to contain_exactly('model_ssi:Work')
+      end
+    end
+
+    context 'with an embargoed work' do
+      it 'excludes works whose embargo date is in the future' do
+        expect(parameters['fq']).to include(
+          '-embargoed_until_dtsi:[NOW TO *]'
+        )
       end
     end
   end

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -124,6 +124,7 @@ RSpec.describe WorkVersion, type: :model do
   end
 
   it { is_expected.to delegate_method(:depositor).to(:work) }
+  it { is_expected.to delegate_method(:embargoed?).to(:work) }
 
   describe '#uuid' do
     subject(:work_version) { create(:work_version) }

--- a/spec/policies/file_version_membership_policy_spec.rb
+++ b/spec/policies/file_version_membership_policy_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FileVersionMembershipPolicy, type: :policy do
+  subject { described_class }
+
+  let(:file_version) { build(:file_version_membership, work_version: work_version) }
+
+  permissions :download? do
+    context 'with a public user' do
+      let(:user) { User.guest }
+
+      context 'with a published, publicly readable work' do
+        let(:work_version) { build(:work_version, :published) }
+
+        it { is_expected.to permit(user, file_version) }
+      end
+
+      context 'with a publicly discoverable work' do
+        let(:v1) { build(:work_version, :published) }
+        let(:work) { create(:work, :with_authorized_access, discover_groups: [Group.public_agent], versions: [v1]) }
+        let(:work_version) { work.versions[0] }
+
+        it { is_expected.not_to permit(user, file_version) }
+      end
+
+      context 'with a Penn State work' do
+        let(:work) { create(:work, :with_authorized_access, has_draft: false) }
+        let(:work_version) { work.versions[0] }
+
+        it { is_expected.not_to permit(user, file_version) }
+      end
+
+      context 'with an embargoed public work' do
+        let(:work) { create(:work, embargoed_until: (DateTime.now + 6.days), has_draft: false) }
+        let(:work_version) { work.versions[0] }
+
+        it { is_expected.not_to permit(user, file_version) }
+      end
+
+      context 'with a draft work' do
+        let(:work_version) { build(:work_version) }
+
+        it { is_expected.not_to permit(user, file_version) }
+      end
+    end
+
+    context 'with an authenticated user' do
+      let(:me) { build(:user) }
+      let(:someone_else) { build(:user) }
+
+      context 'with a published, publicly readable work' do
+        let(:work) { create(:work, has_draft: false, depositor: someone_else) }
+        let(:work_version) { work.versions[0] }
+
+        it { is_expected.to permit(me, file_version) }
+      end
+
+      context 'with a Penn State work' do
+        let(:work) { create(:work, :with_authorized_access, has_draft: false, depositor: someone_else) }
+        let(:work_version) { work.versions[0] }
+
+        it { is_expected.to permit(me, file_version) }
+      end
+
+      context 'with a draft version I deposited' do
+        let(:work) { create(:work, depositor: me) }
+        let(:work_version) { work.versions[0] }
+
+        it { is_expected.to permit(me, file_version) }
+      end
+
+      context 'with a draft version I did NOT deposit' do
+        let(:work) { build(:work, depositor: someone_else) }
+        let(:work_version) { work.versions[0] }
+
+        it { is_expected.not_to permit(me, file_version) }
+      end
+
+      context 'with an embargoed public work' do
+        let(:work) { create(:work, has_draft: false, depositor: someone_else, embargoed_until: (DateTime.now + 6.days)) }
+        let(:work_version) { work.versions[0] }
+
+        it { is_expected.not_to permit(me, file_version) }
+      end
+
+      context 'with an embargoed work I deposited' do
+        let(:work) { create(:work, has_draft: false, depositor: me, embargoed_until: (DateTime.now + 6.days)) }
+        let(:work_version) { work.versions[0] }
+
+        it { is_expected.to permit(me, file_version) }
+      end
+
+      context 'with an embargoed work editable by me' do
+        let(:work) do
+          create :work,
+                 has_draft: false,
+                 depositor: someone_else,
+                 embargoed_until: (DateTime.now + 6.days),
+                 edit_users: [me]
+        end
+        let(:work_version) { work.versions[0] }
+
+        it { is_expected.to permit(me, file_version) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Creates an `embargoed_until` field on the work to determine if a work is under an embargo until the given date. This affects searching for works. A policy for governing downloading files also restricts downloading files that aren't under embargo, but permits it in other cases.

Related to #216 
Fixes #120 