### PR TITLE
Download files from S3

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class DownloadsController < ApplicationController
+  def content
+    work_version = WorkVersion.find_by!(uuid: params[:resource_id])
+    file = work_version.file_version_memberships.find(params[:id])
+    authorize(file)
+    redirect_to s3_presigned_url(file)
+  end
+
+  private
+
+    def s3_presigned_url(file)
+      file.file_resource.file_url(
+        expires_in: ENV.fetch('DOWNLOAD_URL_TTL', 6),
+        response_content_disposition: ContentDisposition.inline(file.title)
+      )
+    end
+end

--- a/app/policies/file_version_membership_policy.rb
+++ b/app/policies/file_version_membership_policy.rb
@@ -8,6 +8,10 @@ class FileVersionMembershipPolicy < ApplicationPolicy
     false
   end
 
+  def content?
+    download?
+  end
+
   private
 
     # @todo There's a bug in the permissions because a depositor should have edit access by default

--- a/app/views/shared/_work_version_files.html.erb
+++ b/app/views/shared/_work_version_files.html.erb
@@ -10,7 +10,7 @@
     <tbody>
       <% work_version.file_version_memberships.includes(:file_resource).each do |file| %>
       <tr>
-        <td><%= file.title %></td>
+        <td><%= link_to file.title, resource_download_path(file.id, resource_id: work_version.uuid) %></td>
         <td><%= number_to_human_size file.size %></td>
         <td><%= file.mime_type %></td>
       </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,9 @@ Rails.application.routes.draw do
   end
   concern :exportable, Blacklight::Routes::Exportable.new
 
-  resources :resources, only: [:show]
+  resources :resources, only: [:show] do
+    get 'downloads/:id', to: 'downloads#content', as: :download
+  end
 
   resources :bookmarks do
     concerns :exportable

--- a/config/samples/application.yml
+++ b/config/samples/application.yml
@@ -72,6 +72,9 @@ DEFAULT_URL_HOST: "localhost:3000"
 # Username used to connect to the geonames api (https://sws.geonames.org)
 # GEONAMES_USER: "scholarsphere_test"
 
+# Time to live for presigned download links
+DOWNLOAD_URL_TTL: 6
+
 development:
   POSTGRES_DB: "scholarsphere_4_development"
   OAUTH_APP_ID: ""

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DownloadsController, type: :controller do
+  describe 'GET #content' do
+    context 'when requesting a valid file from a work version' do
+      let(:work_version) { create(:work_version, :published, :with_files, file_count: 2) }
+
+      it 'redirects to a presigned S3 url' do
+        get :content, params: { resource_id: work_version.uuid, id: work_version.file_version_memberships[0].id }
+        expect(response).to be_redirect
+      end
+    end
+
+    context 'when requesting a non-existent file from a work version' do
+      let(:work_version) { create(:work_version, :published, :with_files) }
+
+      it do
+        expect {
+          get :content, params: { resource_id: work_version.uuid, id: 99 }
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context 'when requesting an unkown uuid' do
+      it do
+        expect {
+          get :content, params: { resource_id: 'not-a-valid-uuid', id: 1 }
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context 'when requesting a file from an unauthorized draft version' do
+      let(:work_version) { create(:work_version, :with_files) }
+
+      it do
+        expect {
+          get :content, params: { resource_id: work_version.uuid, id: work_version.file_version_memberships[0].id }
+        }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+
+    context 'when requesting a file from a work' do
+      let(:work) { create(:work, has_draft: false) }
+
+      it do
+        expect {
+          get :content, params: { resource_id: work.uuid, id: 1 }
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Uses the ResourcesController to download a given file from a work version. Specifying a work will result in a 404 since technically the files are attached to the work version and not the work.

We _could_ get fancy and return the files from the latest published version when specifying a work, or alternatively redirect to the work's display page.

## URLs

We're using the current resources controller which displays works and work versions:

`https://scholarpshere/resources/xxxxxxxx-yyyy-zzzz-vvvv-aaaaaaaa/content/1`

Other options include:

* `https://scholarpshere/resources/xxxxxxxx-yyyy-zzzz-vvvv-aaaaaaaa`
    * the resources controller would make the determination if the uuid was a Work, WorkVersion, or file resource and respond accordingly.

* `https://scholarpshere/resources/xxxxxxxx-yyyy-zzzz-vvvv-aaaaaaaa/files/1/download`
    * more RESTful
    * allows for a future `/files` and `/files/1` to list files and show individual ones
