### PR TITLE
Migrate embargoes from Scholarsphere 3

### DIFF
--- a/app/controllers/api/v1/ingest_controller.rb
+++ b/app/controllers/api/v1/ingest_controller.rb
@@ -81,6 +81,7 @@ module Api::V1
           .permit(
             :work_type,
             :visibility,
+            :embargoed_until,
             :title,
             :subtitle,
             :rights,

--- a/app/policies/dashboard/work_version_policy.rb
+++ b/app/policies/dashboard/work_version_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Dashboard::WorkVersionPolicy < ApplicationPolicy
+class Dashboard::WorkVersionPolicy < WorkVersionPolicy
   class Scope < Scope
     def resolve
       scope

--- a/app/policies/file_version_membership_policy.rb
+++ b/app/policies/file_version_membership_policy.rb
@@ -2,30 +2,14 @@
 
 class FileVersionMembershipPolicy < ApplicationPolicy
   def download?
-    return true if edit?
-    return download_published_version? if work_version.published?
-
-    false
+    Pundit.policy(user, work_version).download?
   end
 
   def content?
     download?
   end
 
-  private
-
-    # @todo There's a bug in the permissions because a depositor should have edit access by default
-    def edit?
-      work_version.work.edit_access?(user) || work_version.depositor == user
-    end
-
-    def download_published_version?
-      return false if work_version.embargoed?
-
-      work_version.work.read_access? user
-    end
-
-    def work_version
-      @work_version ||= record.work_version
-    end
+  def work_version
+    @work_version ||= record.work_version
+  end
 end

--- a/app/policies/work_version_policy.rb
+++ b/app/policies/work_version_policy.rb
@@ -13,4 +13,24 @@ class WorkVersionPolicy < ApplicationPolicy
   def show?
     record.work.read_access? user
   end
+
+  def download?
+    return true if editable?
+    return download_published_version? if record.published?
+
+    false
+  end
+
+  private
+
+    # @todo There's a bug in the permissions because a depositor should have edit access by default
+    def editable?
+      record.work.edit_access?(user) || record.depositor == user
+    end
+
+    def download_published_version?
+      return false if record.embargoed?
+
+      record.work.read_access? user
+    end
 end

--- a/app/services/publish_new_work.rb
+++ b/app/services/publish_new_work.rb
@@ -23,6 +23,7 @@ class PublishNewWork
     params = {
       work_type: metadata.delete(:work_type) { Work::Types::DATASET },
       visibility: metadata.delete(:visibility) { Permissions::Visibility::OPEN },
+      embargoed_until: metadata.delete(:embargoed_until),
       depositor: user,
       versions_attributes: [metadata.to_hash]
     }

--- a/app/views/shared/_work_version_files.html.erb
+++ b/app/views/shared/_work_version_files.html.erb
@@ -1,4 +1,4 @@
-<% if work_version.file_resources.present? %>
+<% if policy(work_version).download? %>
   <table class="table table-striped">
     <thead>
       <tr>

--- a/spec/policies/dashboard/work_version_policy_spec.rb
+++ b/spec/policies/dashboard/work_version_policy_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe Dashboard::WorkVersionPolicy, type: :policy do
   let(:depositor) { instance_double('User', 'depositor') }
   let(:other_user) { instance_double('User', 'another user') }
 
+  it_behaves_like 'a downloadable work version'
+
   permissions '.scope' do
     let(:scoped_versions) { described_class::Scope.new(user, WorkVersion).resolve }
 

--- a/spec/policies/file_version_membership_policy_spec.rb
+++ b/spec/policies/file_version_membership_policy_spec.rb
@@ -3,107 +3,17 @@
 require 'rails_helper'
 
 RSpec.describe FileVersionMembershipPolicy, type: :policy do
-  subject { described_class }
+  let(:user) { instance_double 'User' }
+  let(:file_version_membership) { instance_double 'FileVersionMembership', work_version: work_version }
+  let(:work_version) { instance_double 'WorkVersion' }
+  let(:mock_policy) { instance_spy 'WorkVersionPolicy' }
 
-  let(:file_version) { build(:file_version_membership, work_version: work_version) }
+  describe 'download?' do
+    before { allow(Pundit).to receive(:policy).with(user, work_version).and_return(mock_policy) }
 
-  permissions :download? do
-    context 'with a public user' do
-      let(:user) { User.guest }
-
-      context 'with a published, publicly readable work' do
-        let(:work_version) { build(:work_version, :published) }
-
-        it { is_expected.to permit(user, file_version) }
-      end
-
-      context 'with a publicly discoverable work' do
-        let(:v1) { build(:work_version, :published) }
-        let(:work) { create(:work, :with_authorized_access, discover_groups: [Group.public_agent], versions: [v1]) }
-        let(:work_version) { work.versions[0] }
-
-        it { is_expected.not_to permit(user, file_version) }
-      end
-
-      context 'with a Penn State work' do
-        let(:work) { create(:work, :with_authorized_access, has_draft: false) }
-        let(:work_version) { work.versions[0] }
-
-        it { is_expected.not_to permit(user, file_version) }
-      end
-
-      context 'with an embargoed public work' do
-        let(:work) { create(:work, embargoed_until: (DateTime.now + 6.days), has_draft: false) }
-        let(:work_version) { work.versions[0] }
-
-        it { is_expected.not_to permit(user, file_version) }
-      end
-
-      context 'with a draft work' do
-        let(:work_version) { build(:work_version) }
-
-        it { is_expected.not_to permit(user, file_version) }
-      end
-    end
-
-    context 'with an authenticated user' do
-      let(:me) { build(:user) }
-      let(:someone_else) { build(:user) }
-
-      context 'with a published, publicly readable work' do
-        let(:work) { create(:work, has_draft: false, depositor: someone_else) }
-        let(:work_version) { work.versions[0] }
-
-        it { is_expected.to permit(me, file_version) }
-      end
-
-      context 'with a Penn State work' do
-        let(:work) { create(:work, :with_authorized_access, has_draft: false, depositor: someone_else) }
-        let(:work_version) { work.versions[0] }
-
-        it { is_expected.to permit(me, file_version) }
-      end
-
-      context 'with a draft version I deposited' do
-        let(:work) { create(:work, depositor: me) }
-        let(:work_version) { work.versions[0] }
-
-        it { is_expected.to permit(me, file_version) }
-      end
-
-      context 'with a draft version I did NOT deposit' do
-        let(:work) { build(:work, depositor: someone_else) }
-        let(:work_version) { work.versions[0] }
-
-        it { is_expected.not_to permit(me, file_version) }
-      end
-
-      context 'with an embargoed public work' do
-        let(:work) { create(:work, has_draft: false, depositor: someone_else, embargoed_until: (DateTime.now + 6.days)) }
-        let(:work_version) { work.versions[0] }
-
-        it { is_expected.not_to permit(me, file_version) }
-      end
-
-      context 'with an embargoed work I deposited' do
-        let(:work) { create(:work, has_draft: false, depositor: me, embargoed_until: (DateTime.now + 6.days)) }
-        let(:work_version) { work.versions[0] }
-
-        it { is_expected.to permit(me, file_version) }
-      end
-
-      context 'with an embargoed work editable by me' do
-        let(:work) do
-          create :work,
-                 has_draft: false,
-                 depositor: someone_else,
-                 embargoed_until: (DateTime.now + 6.days),
-                 edit_users: [me]
-        end
-        let(:work_version) { work.versions[0] }
-
-        it { is_expected.to permit(me, file_version) }
-      end
+    it 'delegates to WorkVersionPolicy#download?' do
+      described_class.new(user, file_version_membership).download?
+      expect(mock_policy).to have_received(:download?)
     end
   end
 end

--- a/spec/support/shared/a_downloadable_work_version.rb
+++ b/spec/support/shared/a_downloadable_work_version.rb
@@ -1,25 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
-RSpec.describe WorkVersionPolicy, type: :policy do
-  subject { described_class }
-
-  let(:user) { instance_double 'User' }
-  let(:work) { instance_double 'Work' }
-  let(:work_version) { instance_double 'WorkVersion', work: work }
-
-  describe '#show?' do
-    it 'delegates to Work#read_access?' do
-      allow(work).to receive(:read_access?)
-        .with(user).and_return(:whatever_read_access_returns)
-
-      expect(described_class.new(user, work_version).show?).to eq :whatever_read_access_returns
-    end
-  end
-
-  it_behaves_like 'a downloadable work version'
-
+RSpec.shared_examples 'a downloadable work version' do
   permissions :download? do
     context 'with a public user' do
       let(:user) { User.guest }


### PR DESCRIPTION
This ensures we can migrate embargoed works from Scholarsphere and have them display properly, with additional information about when the embargo expires.