### PR TITLE
Files are optional in the ingest API

### DIFF
--- a/app/controllers/api/v1/ingest_controller.rb
+++ b/app/controllers/api/v1/ingest_controller.rb
@@ -116,7 +116,7 @@ module Api::V1
       end
 
       def content_params
-        params.require(:content).map do |content_parameter|
+        params.fetch(:content, []).map do |content_parameter|
           content_parameter.permit(:file)
         end
       end


### PR DESCRIPTION
Some works migrating from Scholarsphere may not have files, or have files that are missing. We should still save them as draft works.