### PR TITLE
Person authority

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,7 @@ module Scholarsphere
   class Application < Rails::Application
     require 'scholarsphere/redis_config'
     require 'json_log_formatter'
+    require 'qa/authorities/persons'
 
     config.generators { |generator| generator.test_framework :rspec }
     # Initialize configuration defaults for originally generated Rails version.

--- a/lib/penn_state.rb
+++ b/lib/penn_state.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module PennState
+end

--- a/lib/penn_state/search_service.rb
+++ b/lib/penn_state/search_service.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'penn_state'
+
+module PennState::SearchService
+  require 'penn_state/search_service/client'
+  require 'penn_state/search_service/person'
+  require 'penn_state/search_service/atomic_link'
+end

--- a/lib/penn_state/search_service/atomic_link.rb
+++ b/lib/penn_state/search_service/atomic_link.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module PennState::SearchService
+  class AtomicLink < OpenStruct
+    def to_s
+      href
+    end
+  end
+end

--- a/lib/penn_state/search_service/client.rb
+++ b/lib/penn_state/search_service/client.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# @abstract Client for querying Penn State's identity API: https://identity.apps.psu.edu/search-service/resources
+module PennState::SearchService
+  class Client
+    class Error < StandardError; end
+
+    attr_reader :base_url
+
+    # @param [String] base_url
+    def initialize(base_url: '/search-service/resources')
+      @base_url = base_url
+    end
+
+    # @param [Hash] args of options to pass to the endpoint
+    # @option args [String] :text to search for
+    def search(**args)
+      process_response connection.get("#{base_url}/people", args)
+    end
+
+    private
+
+      # @return Array<HashWithIndifferentAccess>
+      def process_response(response)
+        raise Error.new(response.body) unless response.success?
+
+        JSON.parse(response.body).map { |result| Person.new(result) }
+      rescue JSON::ParserError
+        []
+      end
+
+      def connection
+        @connection ||= Faraday.new(url: endpoint) do |conn|
+          conn.adapter :net_http
+        end
+      end
+
+      def endpoint
+        @endpoint ||= ENV.fetch('IDENTITY_ENDPOINT', 'https://identity.apps.psu.edu')
+      end
+  end
+end

--- a/lib/penn_state/search_service/person.rb
+++ b/lib/penn_state/search_service/person.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module PennState::SearchService
+  class Person
+    attr_reader :data
+
+    # @param [Hash] data parsed from the json reponse from the API
+    def initialize(data = {})
+      @data = data
+    end
+
+    def psu_id
+      data['psuid']
+    end
+
+    def user_id
+      data['userid']
+    end
+
+    def cpr_id
+      data['cprid']
+    end
+
+    def given_name
+      data['givenName']
+    end
+
+    def middle_name
+      data['middleName']
+    end
+
+    def family_name
+      data['familyName']
+    end
+    alias :surname :family_name
+
+    def honorific_suffix
+      data['honorificSuffix']
+    end
+
+    def preferred_given_name
+      data['preferredGivenName']
+    end
+
+    def preferred_middle_name
+      data['preferredMiddleName']
+    end
+
+    def preferred_family_name
+      data['preferredFamilyName']
+    end
+
+    def preferred_honorific_suffix
+      data['preferredHonorificSuffix']
+    end
+
+    def active?
+      data['active'] == 'true'
+    end
+
+    def conf_hold?
+      data['confHold'] == 'true'
+    end
+
+    def university_email
+      data['universityEmail']
+    end
+
+    def other_email
+      data['otherEmail']
+    end
+
+    def affiliation
+      data.fetch('affiliation', [])
+    end
+
+    def display_name
+      data['displayName']
+    end
+
+    def link
+      AtomicLink.new(data['link'])
+    end
+  end
+end

--- a/lib/qa/authorities/persons.rb
+++ b/lib/qa/authorities/persons.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'penn_state/search_service'
+
+module Qa
+  module Authorities
+    class Persons < Base
+      attr_reader :term
+
+      def search(term)
+        @term = term
+
+        persons.map do |person|
+          formatted_response(person)
+        end
+      end
+
+      private
+
+        # @return Array<Creator, PennState::SearchService::Person>
+        # @note if the same person is in both sources, prefer the Creator over the PennState::SearchService::Person
+        def persons
+          (creators + identities).reject do |person|
+            person.is_a?(PennState::SearchService::Person) && creator_ids.include?(person.user_id)
+          end
+        end
+
+        def creators
+          @creators ||= Creator.where('surname ILIKE :q OR given_name ILIKE :q OR psu_id ILIKE :q', q: "%#{term}%")
+        end
+
+        # @note using Set enables faster searching for a given id instead of iterating over the entire array.
+        def creator_ids
+          @creator_ids ||= Set.new(creators.map(&:psu_id))
+        end
+
+        def identities
+          @identities ||= PennState::SearchService::Client.new.search(text: term)
+        end
+
+        def formatted_response(result)
+          case result
+          when Creator
+            formatted_creator(result)
+          when PennState::SearchService::Person
+            formatted_person(result)
+          else
+            raise NotImplementedError, "#{result.class} is not a valid person"
+          end
+        end
+
+        def formatted_creator(result)
+          {
+            given_name: result.given_name,
+            surname: result.surname,
+            psu_id: result.psu_id,
+            email: result.email,
+            orcid: result.orcid,
+            default_alias: result.default_alias,
+            source: 'scholarsphere'
+          }
+        end
+
+        def formatted_person(result)
+          {
+            given_name: result.given_name,
+            surname: result.surname,
+            psu_id: result.user_id,
+            email: result.university_email,
+            orcid: '',
+            default_alias: result.display_name,
+            source: 'penn state'
+          }
+        end
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/PennState_SearchService_Client/_search/when_an_error_occurs_with_the_connection/raises_an_error.yml
+++ b/spec/fixtures/vcr_cassettes/PennState_SearchService_Client/_search/when_an_error_occurs_with_the_connection/raises_an_error.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://identity.apps.psu.edu/bad_endpoint/people?text=asdf
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Tue, 07 Apr 2020 13:35:50 GMT
+      Content-Length:
+      - '19'
+    body:
+      encoding: UTF-8
+      string: '404 page not found
+
+        '
+    http_version: 
+  recorded_at: Tue, 07 Apr 2020 13:35:50 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/PennState_SearchService_Client/_search/when_no_results_are_found/returns_an_empty_set.yml
+++ b/spec/fixtures/vcr_cassettes/PennState_SearchService_Client/_search/when_no_results_are_found/returns_an_empty_set.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://identity.apps.psu.edu/search-service/resources/people?text=asdf
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '2'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/vnd-psu.edu-v1+json
+      Date:
+      - Tue, 07 Apr 2020 13:35:49 GMT
+      Server:
+      - istio-envoy
+      Set-Cookie:
+      - JSESSIONID=Ar59B6EhHezILcKBMLITsACeovkB9EWLRuDJjBoF.search-service-84d47874cb-k4g7m;
+        path=/search-service
+      Uniqueid:
+      - 2e581033-b5f2-4c94-b19c-03ca214ec0f9
+      Vary:
+      - Accept-Encoding
+      X-Content-Security-Policy:
+      - frame-ancestors 'none'
+      X-Envoy-Decorator-Operation:
+      - search-service.swe-production.svc.cluster.local:8080/*
+      X-Envoy-Upstream-Service-Time:
+      - '10'
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2418f6b3-60e4-4f4b-95c2-d31dc112037c
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Tue, 07 Apr 2020 13:35:49 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/PennState_SearchService_Client/_search/with_a_sucessful_result/returns_a_first_and_last_name.yml
+++ b/spec/fixtures/vcr_cassettes/PennState_SearchService_Client/_search/with_a_sucessful_result/returns_a_first_and_last_name.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://identity.apps.psu.edu/search-service/resources/people?text=wead
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/vnd-psu.edu-v1+json
+      Date:
+      - Tue, 07 Apr 2020 13:35:49 GMT
+      Server:
+      - istio-envoy
+      Set-Cookie:
+      - JSESSIONID=ZJmPHDpdn-d9oF89dt8e1_-qAfUWfkUz527tCPvy.search-service-84d47874cb-k4g7m;
+        path=/search-service
+      Uniqueid:
+      - 47d307c7-7a4f-438b-a399-77337099f6be
+      Vary:
+      - Accept-Encoding
+      X-Content-Security-Policy:
+      - frame-ancestors 'none'
+      X-Envoy-Decorator-Operation:
+      - search-service.swe-production.svc.cluster.local:8080/*
+      X-Envoy-Upstream-Service-Time:
+      - '13'
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f81ea6a7-5530-43c3-8ac4-7595680e6b6c
+      Content-Length:
+      - '333'
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"userid":"agw13","cprid":"2784093","givenName":"Adam","middleName":"Garner","familyName":"Wead","preferredGivenName":"Adam","preferredFamilyName":"Wead","active":true,"confHold":false,"universityEmail":"agw13@psu.edu","affiliation":["STAFF"],"displayName":"Adam
+        Wead","link":{"href":"https://dev.apps.psu.edu/cpr/resources/2784093"}},{"userid":"azw166","cprid":"6559108","givenName":"Amy","familyName":"Weader","active":true,"confHold":false,"universityEmail":"azw166@psu.edu","affiliation":[""],"displayName":"Amy
+        Weader","link":{"href":"https://dev.apps.psu.edu/cpr/resources/6559108"}},{"userid":"naw5384","cprid":"7363729","givenName":"Nathan","middleName":"Andrew","familyName":"Weader","active":true,"confHold":false,"universityEmail":"naw5384@psu.edu","affiliation":[""],"displayName":"Nathan
+        Andrew Weader","link":{"href":"https://dev.apps.psu.edu/cpr/resources/7363729"}}]'
+    http_version: 
+  recorded_at: Tue, 07 Apr 2020 13:35:49 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/PennState_SearchService_Client/_search/with_unsupported_parameters/returns_an_empty_set.yml
+++ b/spec/fixtures/vcr_cassettes/PennState_SearchService_Client/_search/with_unsupported_parameters/returns_an_empty_set.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://identity.apps.psu.edu/search-service/resources/people?bogus=bam!
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '2'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/vnd-psu.edu-v1+json
+      Date:
+      - Tue, 07 Apr 2020 13:35:49 GMT
+      Server:
+      - istio-envoy
+      Set-Cookie:
+      - JSESSIONID=GjLk53ZHGRiL7ewsWfyikvRGN-ec1YSM_JpxJ85_.search-service-84d47874cb-hzzvk;
+        path=/search-service
+      Uniqueid:
+      - 32af89fd-a880-4733-96a5-ce67c55a5b3b
+      Vary:
+      - Accept-Encoding
+      X-Content-Security-Policy:
+      - frame-ancestors 'none'
+      X-Envoy-Decorator-Operation:
+      - search-service.swe-production.svc.cluster.local:8080/*
+      X-Envoy-Upstream-Service-Time:
+      - '8'
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fdf56522-8a2b-41b4-9051-d742be3578e9
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Tue, 07 Apr 2020 13:35:49 GMT
+recorded_with: VCR 5.0.0

--- a/spec/integration/qa/terms_controller_spec.rb
+++ b/spec/integration/qa/terms_controller_spec.rb
@@ -5,13 +5,23 @@ require 'rails_helper'
 RSpec.describe Qa::TermsController, type: :controller, skip: ci_build? do
   before { @routes = Qa::Engine.routes }
 
-  context 'when searching geonames' do
+  describe 'GET #search' do
     let(:search_results) { JSON.parse(response.body) }
 
-    before { get :search, params: { q: 'oslo', vocab: 'geonames' } }
+    context 'when searching geonames' do
+      before { get :search, params: { q: 'oslo', vocab: 'geonames' } }
 
-    it 'returns a set of search results as JSON' do
-      expect(search_results).to include('id' => 'http://sws.geonames.org/3143244/', 'label' => 'Oslo, Oslo, Norway')
+      it 'returns a set of search results as JSON' do
+        expect(search_results).to include('id' => 'http://sws.geonames.org/3143244/', 'label' => 'Oslo, Oslo, Norway')
+      end
+    end
+
+    context 'when searching persons' do
+      before { get :search, params: { q: 'daniel cough', vocab: 'persons' } }
+
+      it 'returns a set of search results as JSON' do
+        expect(search_results.first).to include('default_alias' => 'Daniel M Coughlin')
+      end
     end
   end
 end

--- a/spec/lib/penn_state/search_service/atomic_link_spec.rb
+++ b/spec/lib/penn_state/search_service/atomic_link_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'penn_state/search_service'
+
+RSpec.describe PennState::SearchService::AtomicLink do
+  it { is_expected.to be_a(OpenStruct) }
+
+  context 'when the link is nil' do
+    subject { described_class.new }
+
+    its(:href) { is_expected.to be_nil }
+    its(:rel) { is_expected.to be_nil }
+    its(:title) { is_expected.to be_nil }
+    its(:type) { is_expected.to be_nil }
+  end
+
+  context 'when a link is present' do
+    subject(:link) do
+      described_class.new(
+        'href' => 'http://something.com',
+        'rel' => 'relative',
+        'title' => 'Link Title',
+        'type' => 'link type'
+      )
+    end
+
+    its(:href) { is_expected.to eq('http://something.com') }
+    its(:rel) { is_expected.to eq('relative') }
+    its(:title) { is_expected.to eq('Link Title') }
+    its(:type) { is_expected.to eq('link type') }
+
+    it 'displays the link' do
+      expect(link.to_s).to eq('http://something.com')
+    end
+  end
+end

--- a/spec/lib/penn_state/search_service/client_spec.rb
+++ b/spec/lib/penn_state/search_service/client_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'support/vcr'
+require 'penn_state/search_service'
+
+RSpec.describe PennState::SearchService::Client do
+  let(:client) { described_class.new }
+
+  describe '#search', :vcr do
+    context 'with a sucessful result' do
+      let(:results) { client.search(text: 'wead') }
+
+      it 'returns a first and last name' do
+        expect(results.map(&:given_name)).to include('Adam')
+        expect(results.map(&:family_name)).to include('Wead')
+      end
+    end
+
+    context 'when no results are found' do
+      let(:result) { client.search(text: 'asdf') }
+
+      it 'returns an empty set' do
+        expect(result).to be_empty
+      end
+    end
+
+    context 'with unsupported parameters' do
+      let(:result) { client.search(bogus: 'bam!') }
+
+      it 'returns an empty set' do
+        expect(result).to be_empty
+      end
+    end
+
+    context 'with an unparsable response' do
+      let(:mock_connection) { instance_spy('Faraday::Connection') }
+      let(:mock_response) { instance_spy('Faraday::Response', body: 'this is not JSON') }
+      let(:result) { client.search(text: 'asdf') }
+
+      before do
+        allow(client).to receive(:connection).and_return(mock_connection)
+        allow(mock_connection).to receive(:get).and_return(mock_response)
+      end
+
+      it 'returns an empty set' do
+        expect(result).to be_empty
+      end
+    end
+
+    context 'when an error occurs with the connection' do
+      let(:client) { described_class.new(base_url: 'bad_endpoint') }
+      let(:result) { client.search(text: 'asdf') }
+
+      it 'raises an error' do
+        expect {
+          result
+        }.to raise_error(
+          PennState::SearchService::Client::Error,
+          /404 page not found/
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/penn_state/search_service/person_spec.rb
+++ b/spec/lib/penn_state/search_service/person_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'penn_state/search_service'
+
+RSpec.describe PennState::SearchService::Person do
+  describe '#psu_id' do
+    subject { described_class.new('psuid' => 'abc123') }
+
+    its(:psu_id) { is_expected.to eq('abc123') }
+  end
+
+  describe '#user_id' do
+    subject { described_class.new('userid' => 'abc123') }
+
+    its(:user_id) { is_expected.to eq('abc123') }
+  end
+
+  describe '#cpr_id' do
+    subject { described_class.new('cprid' => 'abc123') }
+
+    its(:cpr_id) { is_expected.to eq('abc123') }
+  end
+
+  describe '#given_name' do
+    subject { described_class.new('givenName' => 'abc123') }
+
+    its(:given_name) { is_expected.to eq('abc123') }
+  end
+
+  describe '#middle_name' do
+    subject { described_class.new('middleName' => 'abc123') }
+
+    its(:middle_name) { is_expected.to eq('abc123') }
+  end
+
+  describe '#family_name' do
+    subject { described_class.new('familyName' => 'abc123') }
+
+    its(:family_name) { is_expected.to eq('abc123') }
+  end
+
+  describe '#honorific_suffix' do
+    subject { described_class.new('honorificSuffix' => 'abc123') }
+
+    its(:honorific_suffix) { is_expected.to eq('abc123') }
+  end
+
+  describe '#preferred_given_name' do
+    subject { described_class.new('preferredGivenName' => 'abc123') }
+
+    its(:preferred_given_name) { is_expected.to eq('abc123') }
+  end
+
+  describe '#preferred_middle_name' do
+    subject { described_class.new('preferredMiddleName' => 'abc123') }
+
+    its(:preferred_middle_name) { is_expected.to eq('abc123') }
+  end
+
+  describe '#preferred_family_name' do
+    subject { described_class.new('preferredFamilyName' => 'abc123') }
+
+    its(:preferred_family_name) { is_expected.to eq('abc123') }
+  end
+
+  describe '#preferred_honorific_suffix' do
+    subject { described_class.new('preferredHonorificSuffix' => 'abc123') }
+
+    its(:preferred_honorific_suffix) { is_expected.to eq('abc123') }
+  end
+
+  describe '#university_email' do
+    subject { described_class.new('universityEmail' => 'abc123') }
+
+    its(:university_email) { is_expected.to eq('abc123') }
+  end
+
+  describe '#other_email' do
+    subject { described_class.new('otherEmail' => 'abc123') }
+
+    its(:other_email) { is_expected.to eq('abc123') }
+  end
+
+  describe '#display_name' do
+    subject { described_class.new('displayName' => 'abc123') }
+
+    its(:display_name) { is_expected.to eq('abc123') }
+  end
+
+  describe 'active?' do
+    context 'when the person is active' do
+      subject { described_class.new('active' => 'true') }
+
+      it { is_expected.to be_active }
+    end
+
+    context 'when the person is NOT active' do
+      subject { described_class.new('active' => 'false') }
+
+      it { is_expected.not_to be_active }
+    end
+  end
+
+  describe 'conf_hold?' do
+    context 'when there is a conf hold' do
+      subject { described_class.new('confHold' => 'true') }
+
+      it { is_expected.to be_conf_hold }
+    end
+
+    context 'when there is NOT a conf hold' do
+      subject { described_class.new('confHold' => 'false') }
+
+      it { is_expected.not_to be_conf_hold }
+    end
+  end
+
+  describe '#affiliation' do
+    context 'when there is an affiliation' do
+      subject { described_class.new('affiliation' => ['some affiliation']) }
+
+      its(:affiliation) { is_expected.to eq(['some affiliation']) }
+    end
+
+    context 'when there is NO affiliation' do
+      its(:affiliation) { is_expected.to be_empty }
+    end
+  end
+
+  describe '#link' do
+    its(:link) { is_expected.to be_an(PennState::SearchService::AtomicLink) }
+  end
+end

--- a/spec/lib/qa/authorities/persons_spec.rb
+++ b/spec/lib/qa/authorities/persons_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Qa::Authorities::Persons, type: :authority do
+  let(:authority) { described_class.new }
+  let(:mock_client) { instance_spy('PennState::SearchService::Client') }
+
+  describe '#search' do
+    subject(:results) { authority.search(search_term) }
+
+    before do
+      allow(PennState::SearchService::Client).to receive(:new).and_return(mock_client)
+      allow(mock_client).to receive(:search).and_return(mock_identity_response)
+    end
+
+    context 'with results only from our existing creators' do
+      let(:formatted_result) do
+        {
+          given_name: creator.given_name,
+          surname: creator.surname,
+          psu_id: creator.psu_id,
+          default_alias: creator.default_alias,
+          email: creator.email,
+          orcid: creator.orcid,
+          source: 'scholarsphere'
+        }
+      end
+
+      let(:mock_identity_response) { [] }
+
+      context 'when searching by surname (case insensitive)' do
+        let!(:creator) { create(:creator) }
+        let(:search_term) { creator.surname.slice(0..3).downcase }
+
+        it { is_expected.to include(formatted_result) }
+      end
+
+      context 'when searching by given name (case insensitive)' do
+        let!(:creator) { create(:creator) }
+        let(:search_term) { creator.given_name.slice(0..3).downcase }
+
+        it { is_expected.to include(formatted_result) }
+      end
+
+      context 'when searching by Penn State ID (case insensitive)' do
+        let!(:creator) { create(:creator) }
+        let(:search_term) { creator.psu_id.capitalize }
+
+        it { is_expected.to include(formatted_result) }
+      end
+
+      context 'when no results are returned' do
+        let(:search_term) { 'nothing' }
+
+        it { is_expected.to be_empty }
+      end
+    end
+
+    context "with results from Penn State's identity service" do
+      let(:formatted_result) do
+        {
+          given_name: creator.given_name,
+          surname: creator.surname,
+          psu_id: creator.psu_id,
+          default_alias: creator.default_alias,
+          email: creator.email,
+          orcid: '',
+          source: 'penn state'
+        }
+      end
+
+      let(:mock_identity_response) do
+        [
+          PennState::SearchService::Person.new(
+            'givenName' => creator.given_name,
+            'familyName' => creator.surname,
+            'userid' => creator.psu_id,
+            'displayName' => creator.default_alias,
+            'universityEmail' => creator.email
+          )
+        ]
+      end
+
+      let(:creator) { build(:creator) }
+      let(:search_term) { 'search query' }
+
+      it { is_expected.to include(formatted_result) }
+    end
+
+    context 'with an unsupported person type' do
+      let(:user) { build(:user) }
+      let(:mock_identity_response) { [user] }
+
+      it 'raises an error' do
+        expect {
+          authority.search(user.given_name)
+        }.to raise_error(NotImplementedError, 'User is not a valid person')
+      end
+    end
+
+    context 'when idential records exist from both sources' do
+      let!(:creator) { create(:creator) }
+      let(:search_term) { creator.surname.slice(0..3) }
+
+      let(:mock_identity_response) do
+        [
+          PennState::SearchService::Person.new(
+            'givenName' => creator.given_name,
+            'familyName' => creator.surname,
+            'userid' => creator.psu_id,
+            'displayName' => creator.default_alias,
+            'universityEmail' => creator.email
+          )
+        ]
+      end
+
+      it 'prefers the creator record over the Penn State record' do
+        expect(results.count).to eq(1)
+        expect(results.first[:source]).to eq('scholarsphere')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #180 

Using Questioning Authority, we create a Person authority that can be used to find available creators for a work. The authority searches our own database for creator records as well as Penn State's identity management API.

For a given search string, a set of results are returned as a hash containing given name, surname, and additional relevant information such as the user's Penn State ID, email, and OrcID, if available.

Included in this commit is the Identity::Client which connects to Penn State's identity service and returns a set of person records matching the search query.

## Integration with Questioning Authority

To use this with QA, the Persons authority is wired into the `Qa::Authorities` module namespace and can be accessed via the `Qa::TermController`, ex:

    /authorities/search/persons?q=wead

This will return a set of results in json consumable by our UI.