### PR TITLE
Rename JSONFormatter to JSONLogFormatter

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,7 +25,7 @@ Bundler.require(*Rails.groups)
 module Scholarsphere
   class Application < Rails::Application
     require 'scholarsphere/redis_config'
-    require 'json_formatter'
+    require 'json_log_formatter'
 
     config.generators { |generator| generator.test_framework :rspec }
     # Initialize configuration defaults for originally generated Rails version.
@@ -43,7 +43,7 @@ module Scholarsphere
 
     if ENV['RAILS_LOG_JSON'].present?
       config.lograge.formatter = Lograge::Formatters::Json.new
-      config.log_formatter = JSONFormatter.new
+      config.log_formatter = JSONLogFormatter.new
     else
       config.log_formatter = ::Logger::Formatter.new
     end

--- a/lib/json_log_formatter.rb
+++ b/lib/json_log_formatter.rb
@@ -2,7 +2,7 @@
 
 require 'json'
 
-class JSONFormatter
+class JSONLogFormatter
   def parse_message(message)
     JSON.parse(message)
   rescue JSON::ParserError, TypeError

--- a/spec/lib/json_log_formatter_spec.rb
+++ b/spec/lib/json_log_formatter_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'json_formatter'
+require 'json_log_formatter'
 
-RSpec.describe JSONFormatter do
+RSpec.describe JSONLogFormatter do
   describe '#parse_message' do
     it 'acccepts a string' do
       # json = described_class.new


### PR DESCRIPTION
I think `JSONFormatter` is too generic of a name, especially at the top level namespace. This app can and will format many things as JSON, so this is the simplest fix I could think of to clamp things down a little bit.