### PR TITLE
Fix Blacklight's search API

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,7 @@ AllCops:
 Metrics/BlockLength:
   Exclude:
     - 'app/controllers/catalog_controller.rb'
+    - 'app/views/catalog/index.json.jbuilder'
     - 'config/routes.rb'
     - 'spec/**/*'
 

--- a/app/views/catalog/index.json.jbuilder
+++ b/app/views/catalog/index.json.jbuilder
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+# @note overrides the Blacklight jbuilder because we're not using polymorphic_urls for SolrDocument.
+# There's probably a better way to do this that uses the database-backed record instead of Solr.
+json.links do
+  json.self url_for(search_state.to_h.merge(only_path: false))
+  json.prev url_for(search_state.to_h.merge(only_path: false, page: @response.prev_page.to_s)) if @response.prev_page
+  json.next url_for(search_state.to_h.merge(only_path: false, page: @response.next_page.to_s)) if @response.next_page
+  json.last url_for(search_state.to_h.merge(only_path: false, page: @response.total_pages.to_s))
+end
+
+json.meta do
+  json.pages @presenter.pagination_info
+end
+
+json.data do
+  json.array! @presenter.documents do |document|
+    doc_presenter = index_presenter(document)
+    document_url = resource_url(url_for_document(document))
+    json.id document.id
+    json.type doc_presenter.display_type.first
+    json.attributes do
+      doc_presenter.fields_to_render.each do |field_name, field, field_presenter|
+        json.partial! 'field', field: field,
+                               field_name: field_name,
+                               document_url: document_url,
+                               doc_presenter: doc_presenter,
+                               field_presenter: field_presenter,
+                               view_type: 'index'
+      end
+    end
+
+    json.links do
+      json.self document_url
+    end
+  end
+end
+
+json.included do
+  json.array! @presenter.search_facets do |facet|
+    json.type 'facet'
+    json.id facet.name
+    json.attributes do
+      facet_config = facet_configuration_for_field(facet.name)
+      json.label facet_field_label(facet_config.key)
+      json.items do
+        json.array! facet.items do |item|
+          json.id
+          json.attributes do
+            json.label item.label
+            json.value item.value
+            json.hits item.hits
+          end
+          json.links do
+            if facet_in_params?(facet.name, item.value)
+              json.remove search_action_path(search_state.remove_facet_params(facet.name, item.value))
+            else
+              json.self path_for_facet(facet.name, item.value, only_path: false)
+            end
+          end
+        end
+      end
+    end
+    json.links do
+      json.self search_facet_path(id: facet.name, only_path: false)
+    end
+  end
+
+  json.array! search_fields do |(label, key)|
+    json.type 'search_field'
+    json.id key
+    json.attributes do
+      json.label label
+    end
+    json.links do
+      json.self url_for(search_state.to_h.merge(search_field: key, only_path: false))
+    end
+  end
+
+  json.array! active_sort_fields do |key, field|
+    json.type 'sort'
+    json.id key
+    json.attributes do
+      json.label field.label
+    end
+    json.links do
+      json.self url_for(search_state.to_h.merge(sort: key, only_path: false))
+    end
+  end
+end

--- a/spec/features/discovery_search_spec.rb
+++ b/spec/features/discovery_search_spec.rb
@@ -33,4 +33,19 @@ RSpec.describe 'Searching discoverable resources' do
       expect(page).to have_content(authorized_work.latest_published_version.title)
     end
   end
+
+  context 'when searching via the Blacklight API' do
+    let(:results) { JSON.parse(page.body) }
+
+    it 'returns search results in json' do
+      visit search_catalog_path(format: :json)
+
+      expect(
+        results['data'].map { |record| record['id'] }
+      ).to contain_exactly(
+        public_work.uuid,
+        previous_embargoed_work.uuid
+      )
+    end
+  end
 end


### PR DESCRIPTION
Returning search results in json was broken because we've moved away from SolrDocument and we weren't testing the integration endpoint.

We're now testing json responses from the CatalogController and overriding the jbuilder file to make it work for now, but there's a better solution down the road.