### PR TITLE
Return 303 for migrated works

### DIFF
--- a/app/controllers/api/v1/ingest_controller.rb
+++ b/app/controllers/api/v1/ingest_controller.rb
@@ -11,6 +11,8 @@ module Api::V1
       end
     end
 
+    before_action :return_migrated_work
+
     def create
       if work.errors.any?
         render json: unprocessable_entity_response, status: :unprocessable_entity
@@ -20,6 +22,14 @@ module Api::V1
     end
 
     private
+
+      def return_migrated_work
+        ids = LegacyIdentifier.where(old_id: metadata_params['noid'], version: 3, resource_type: 'Work')
+        return if ids.empty?
+
+        work = Work.find(ids.first.resource_id)
+        render json: { message: 'Work has already been migrated', url: resource_path(work.uuid) }, status: 303
+      end
 
       def success_response
         if work.latest_version.published?

--- a/app/services/publish_new_work.rb
+++ b/app/services/publish_new_work.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# @abstract Used in conjuction with our REST API, this service publishes a new work with complete metadata and content.
-# It is encumbent upon the caller to provied the required metadata and binary content. There are three possible outcomes
+# @abstract Used in conjunction with our REST API, this service publishes a new work with complete metadata and content.
+# It is incumbent upon the caller to provide the required metadata and binary content. Here are the possible outcomes:
 # for the work:
 # 1. A work has valid metadata and can be published
 #      * a new, persisted work is returned in a published state

--- a/spec/controllers/api/v1/ingest_controller_spec.rb
+++ b/spec/controllers/api/v1/ingest_controller_spec.rb
@@ -137,6 +137,25 @@ RSpec.describe Api::V1::IngestController, type: :controller do
       end
     end
 
+    context 'when a work with the same noid already exists' do
+      let(:legacy_identifier) { create(:legacy_identifier, :with_work, version: 3) }
+
+      before do
+        post :create, params: {
+          metadata: { title: FactoryBotHelpers.work_title, noid: legacy_identifier.old_id },
+          depositor: user.access_id,
+          content: [{ file: fixture_file_upload(File.join(fixture_path, 'image.png')) }]
+        }
+      end
+
+      it 'returns the url of the previously migrated work' do
+        expect(response.status).to eq(303)
+        expect(response.body).to eq(
+          "{\"message\":\"Work has already been migrated\",\"url\":\"/resources/#{legacy_identifier.resource.uuid}\"}"
+        )
+      end
+    end
+
     context 'when there is an unexpected error' do
       before do
         allow(controller).to receive(:create).and_raise(NoMethodError, 'well, this is unexpected!')


### PR DESCRIPTION
We look for the noid of the work being migrated, and if it's already present, we return the url of the existing already-migrated work.