### PR TITLE
Ensure argument type is correct

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -12,7 +12,7 @@ class DownloadsController < ApplicationController
 
     def s3_presigned_url(file)
       file.file_resource.file_url(
-        expires_in: ENV.fetch('DOWNLOAD_URL_TTL', 6),
+        expires_in: ENV.fetch('DOWNLOAD_URL_TTL', 6).to_i,
         response_content_disposition: ContentDisposition.inline(file.title)
       )
     end


### PR DESCRIPTION
With a new, clean installation in my development environment, I had one failing test caused by an argument error from somewhere down in shrine. This is the apparent fix.