### PR TITLE
Initial crack at Collections

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -54,6 +54,7 @@ RSpec/SubjectStub:
 Rails/OutputSafety:
   Exclude:
     - 'app/components/work_version_metadata_component.rb'
+    - 'app/components/collection_metadata_component.rb'
 
 # Offense count: 1
 # Configuration parameters: Blacklist, Whitelist.

--- a/app/components/collection_metadata_component.html.erb
+++ b/app/components/collection_metadata_component.html.erb
@@ -1,0 +1,6 @@
+<dl class="row dl-invert document-metadata">
+  <% attributes.each do |attr, label, value| %>
+    <dt class="<%= css_class attr %> col-md-3"><%= label %></dt>
+    <dd class="<%= css_class attr %> col-md-9"><%= value %></dd>
+  <% end %>
+</dl>

--- a/app/components/collection_metadata_component.rb
+++ b/app/components/collection_metadata_component.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# @todo: this is a great candidate for refactoring with WorkVersionMetadataComponent
+
+require 'action_view/component'
+
+class CollectionMetadataComponent < ActionView::Component::Base
+  attr_reader :collection
+
+  validates :collection,
+            presence: true
+
+  # A list of Collection's attributes that you'd like rendered, in the order
+  # that you want them to appear.
+  ATTRIBUTES = [
+    :title,
+    :subtitle,
+    :creator_aliases,
+    :description,
+    :keyword,
+    :resource_type,
+    :contributor,
+    :publisher,
+    :published_date,
+    :subject,
+    :language,
+    :identifier,
+    :based_near,
+    :related_url,
+    :source,
+    :created_at
+  ].freeze
+
+  def initialize(collection:)
+    @collection = collection
+  end
+
+  private
+
+    def attributes
+      ATTRIBUTES
+        .map do |attr|
+          label = format_label(attr)
+          value = format_value(collection.send(attr))
+          [attr, label, value]
+        end
+        .reject { |_attr, _label, val| val.blank? || val.empty? }
+    end
+
+    def format_label(attr)
+      Collection.human_attribute_name(attr)
+    end
+
+    def format_value(value)
+      if value.is_a? Enumerable
+        value
+          .map { |member| format_value(member) }
+          .compact
+          .map { |member| %(<span class="multiple-member">#{member}</span>) }
+          .join('; ')
+          .html_safe
+      elsif value.respond_to?(:strftime) # Date/Time/DateTime/TimeWithZone etc
+        value.to_formatted_s(:long)
+      elsif value.is_a? CollectionCreation
+        value.alias
+      else
+        value.to_s
+      end
+    end
+
+    def css_class(attr)
+      "collection-#{attr.to_s.gsub('_', '-')}"
+    end
+end

--- a/app/controllers/dashboard/collections_controller.rb
+++ b/app/controllers/dashboard/collections_controller.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+module Dashboard
+  class CollectionsController < BaseController
+    def index
+      @collections = policy_scope(Collection).includes(works: :versions)
+    end
+
+    def new
+      @collection = new_collection
+      @works = load_users_works
+      @collection.build_creator_alias(actor: current_user.actor)
+    end
+
+    def create
+      @collection = new_collection(collection_params)
+
+      respond_to do |format|
+        if @collection.save
+          format.html do
+            redirect_to dashboard_collections_path,
+                        notice: 'Collection was successfully created.'
+          end
+          format.json { render :show, status: :created, location: @collection }
+        else
+          format.html { render :new }
+          format.json { render json: @collection.errors, status: :unprocessable_entity }
+        end
+      end
+    end
+
+    def show
+      @collection = policy_scope(Collection).includes(works: :versions).find(params[:id])
+      authorize(@collection)
+    end
+
+    def edit
+      @collection = policy_scope(Collection).find(params[:id])
+      authorize(@collection)
+
+      @works = load_users_works
+      @collection.build_creator_alias(actor: current_user.actor)
+    end
+
+    def update
+      @collection = policy_scope(Collection).find(params[:id])
+      authorize(@collection)
+
+      @collection.attributes = collection_params
+
+      respond_to do |format|
+        if @collection.save
+          format.html do
+            redirect_to dashboard_collection_path(@collection),
+                        notice: 'Collection was successfully updated.'
+          end
+          format.json { render :show, status: :ok, location: @collection }
+        else
+          format.html { render :edit }
+          format.json { render json: @collection.errors, status: :unprocessable_entity }
+        end
+      end
+    end
+
+    def destroy
+      @collection = policy_scope(Collection).find(params[:id])
+      authorize(@collection)
+      @collection.destroy
+      respond_to do |format|
+        format.html { redirect_to dashboard_collections_url, notice: 'Collection was successfully destroyed.' }
+        format.json { head :no_content }
+      end
+    end
+
+    private
+
+      def new_collection(attrs = {})
+        current_user.actor.deposited_collections.build(attrs)
+      end
+
+      def load_users_works
+        current_user.works.includes(:versions)
+      end
+
+      def collection_params
+        params
+          .require(:collection)
+          .permit(
+            :title,
+            :subtitle,
+            work_ids: [],
+            keyword: [],
+            description: [],
+            resource_type: [],
+            contributor: [],
+            publisher: [],
+            published_date: [],
+            subject: [],
+            language: [],
+            identifier: [],
+            based_near: [],
+            related_url: [],
+            source: [],
+            creator_aliases_attributes: [
+              :id,
+              :actor_id,
+              :_destroy,
+              :alias,
+              actor_attributes: [
+                :id,
+                :email,
+                :given_name,
+                :surname,
+                :psu_id
+              ]
+            ]
+          )
+      end
+  end
+end

--- a/app/models/actor.rb
+++ b/app/models/actor.rb
@@ -25,6 +25,14 @@ class Actor < ApplicationRecord
            through: :work_version_creations,
            inverse_of: :actors
 
+  has_many :collection_creations,
+           dependent: :restrict_with_exception,
+           inverse_of: :actor
+
+  has_many :collections,
+           through: :collection_creations,
+           inverse_of: :actors
+
   validates :surname,
             presence: true
 

--- a/app/models/actor.rb
+++ b/app/models/actor.rb
@@ -25,6 +25,12 @@ class Actor < ApplicationRecord
            through: :work_version_creations,
            inverse_of: :actors
 
+  has_many :deposited_collections,
+           class_name: 'Collection',
+           foreign_key: 'depositor_id',
+           inverse_of: 'depositor',
+           dependent: :restrict_with_exception
+
   has_many :collection_creations,
            dependent: :restrict_with_exception,
            inverse_of: :actor

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class Collection < ApplicationRecord
+  jsonb_accessor :metadata,
+                 title: :string,
+                 subtitle: :string,
+                 keyword: [:string, array: true, default: []],
+                 description: [:string, array: true, default: []],
+                 resource_type: [:string, array: true, default: []],
+                 contributor: [:string, array: true, default: []],
+                 publisher: [:string, array: true, default: []],
+                 published_date: [:string, array: true, default: []],
+                 subject: [:string, array: true, default: []],
+                 language: [:string, array: true, default: []],
+                 identifier: [:string, array: true, default: []],
+                 based_near: [:string, array: true, default: []],
+                 related_url: [:string, array: true, default: []],
+                 source: [:string, array: true, default: []]
+
+  belongs_to :depositor,
+             class_name: 'Actor',
+             foreign_key: 'depositor_id',
+             inverse_of: 'deposited_works'
+
+  has_many :legacy_identifiers,
+           as: :resource,
+           dependent: :destroy
+
+  has_many :collection_work_memberships,
+           dependent: :destroy
+
+  has_many :works,
+           through: :collection_work_memberships,
+           inverse_of: :collection
+
+  has_many :creator_aliases,
+           class_name: 'CollectionCreation',
+           inverse_of: :collection,
+           dependent: :destroy
+
+  has_many :creators,
+           source: :actor,
+           through: :creator_aliases,
+           inverse_of: :collections
+
+  accepts_nested_attributes_for :creator_aliases,
+                                reject_if: :all_blank,
+                                allow_destroy: true
+end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -31,7 +31,7 @@ class Collection < ApplicationRecord
 
   has_many :works,
            through: :collection_work_memberships,
-           inverse_of: :collection
+           inverse_of: :collections
 
   has_many :creator_aliases,
            class_name: 'CollectionCreation',
@@ -43,7 +43,20 @@ class Collection < ApplicationRecord
            through: :creator_aliases,
            inverse_of: :collections
 
+  validates :title,
+            presence: true
+
   accepts_nested_attributes_for :creator_aliases,
                                 reject_if: :all_blank,
                                 allow_destroy: true
+
+  def build_creator_alias(actor:)
+    existing_creator_alias = creator_aliases.find { |ca| ca.actor == actor }
+    return existing_creator_alias if existing_creator_alias.present?
+
+    creator_aliases.build(
+      alias: actor.default_alias,
+      actor: actor
+    )
+  end
 end

--- a/app/models/collection_creation.rb
+++ b/app/models/collection_creation.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CollectionCreation < ApplicationRecord
+  belongs_to :collection,
+             inverse_of: :creator_aliases
+
+  belongs_to :actor,
+             inverse_of: :collection_creations
+
+  accepts_nested_attributes_for :actor
+
+  validates :alias,
+            presence: true
+
+  def alias
+    super.presence || actor&.default_alias
+  end
+end

--- a/app/models/collection_work_membership.rb
+++ b/app/models/collection_work_membership.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class CollectionWorkMembership < ApplicationRecord
+  belongs_to :collection
+  belongs_to :work
+end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -24,6 +24,13 @@ class Work < ApplicationRecord
            as: :resource,
            dependent: :destroy
 
+  has_many :collection_work_memberships,
+           dependent: :destroy
+
+  has_many :collections,
+           through: :collection_work_memberships,
+           inverse_of: :work
+
   accepts_nested_attributes_for :versions
 
   module Types

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -29,7 +29,7 @@ class Work < ApplicationRecord
 
   has_many :collections,
            through: :collection_work_memberships,
-           inverse_of: :work
+           inverse_of: :works
 
   accepts_nested_attributes_for :versions
 

--- a/app/policies/dashboard/collection_policy.rb
+++ b/app/policies/dashboard/collection_policy.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class Dashboard::CollectionPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope.where(depositor: user.actor)
+    end
+  end
+
+  def show?
+    owner?
+  end
+
+  alias_method :edit?, :show?
+  alias_method :update?, :show?
+  alias_method :destroy?, :show?
+
+  private
+
+    def owner?
+      record.depositor == user.actor
+    end
+end

--- a/app/views/dashboard/collections/_creator_alias_fields.html.erb
+++ b/app/views/dashboard/collections/_creator_alias_fields.html.erb
@@ -1,0 +1,46 @@
+<div class="nested-fields card mb-3">
+  <div class="card-header">
+    <%= t 'dashboard.collections.edit.creator' %>
+    <%= link_to_remove_association t('dashboard.collections.edit.remove_creator'),
+                                   f,
+                                   class: 'btn btn-outline-danger btn-sm float-sm-right' %>
+  </div>
+  <div class="card-body">
+    <%= f.hidden_field :actor_id %>
+
+    <div class="form-group required">
+      <%= f.label :alias %>
+      <%= f.text_field :alias, class: 'form-control', required: true %>
+    </div>
+
+    <%= f.fields_for :actor do |actor_fields| %>
+      <%- readonly = actor_fields.object.psu_id.present? %>
+
+      <div class="form-group">
+        <%= actor_fields.label :email %>
+        <%= actor_fields.text_field :email, class: 'form-control', readonly: readonly %>
+      </div>
+
+      <div class="row">
+        <div class="col">
+          <div class="form-group">
+            <%= actor_fields.label :given_name %>
+            <%= actor_fields.text_field :given_name, class: 'form-control', readonly: readonly %>
+          </div>
+        </div>
+        <div class="col">
+          <div class="form-group required">
+            <%= actor_fields.label :surname %>
+            <%= actor_fields.text_field :surname, class: 'form-control', readonly: readonly, required: true %>
+          </div>
+        </div>
+        <div class="col">
+          <div class="form-group">
+            <%= actor_fields.label :psu_id %>
+            <%= actor_fields.text_field :psu_id, class: 'form-control', readonly: readonly %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/dashboard/collections/_form.html.erb
+++ b/app/views/dashboard/collections/_form.html.erb
@@ -1,0 +1,57 @@
+<% form_url = @collection.persisted? ? dashboard_collection_path(@collection) : dashboard_collections_path -%>
+<%= form_with(model: @collection, url: form_url, local: true) do |form| %>
+<% if form.object.errors.any? %>
+<div id="error_explanation">
+    <h2><%= t('dashboard.collections.edit.error_message', error: pluralize(form.object.errors.count, 'error')) %></h2>
+
+    <ul>
+        <% form.object.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+        <% end %>
+    </ul>
+</div>
+<% end %>
+
+<%= render 'form_fields/text', form: form, attribute: :title %>
+<%= render 'form_fields/text', form: form, attribute: :subtitle %>
+
+<div id="creator_aliases" class="mb-3">
+    <%= form.fields_for :creator_aliases do |creator_alias| %>
+    <%= render 'creator_alias_fields', f: creator_alias %>
+    <% end %>
+    <div class="links">
+        <%= link_to_add_association t('dashboard.collections.edit.add_creator'),
+                                    form,
+                                    :creator_aliases,
+                                    # Ensure the associated Creator object exists, so its fields are rendered
+                                    wrap_object: ->(creator_alias) { creator_alias.tap(&:build_actor) },
+                                    class: 'btn btn-outline-success btn-sm' %>
+    </div>
+</div>
+
+<%= render 'form_fields/multi_text', form: form, attribute: :keyword %>
+<%= render 'form_fields/multi_text_area', form: form, attribute: :description %>
+<%= render 'form_fields/multi_text', form: form, attribute: :resource_type %>
+<%= render 'form_fields/multi_text', form: form, attribute: :contributor %>
+<%= render 'form_fields/multi_text', form: form, attribute: :publisher %>
+<%= render 'form_fields/multi_text', form: form, attribute: :published_date %>
+<%= render 'form_fields/multi_text', form: form, attribute: :subject %>
+<%= render 'form_fields/multi_text', form: form, attribute: :language %>
+<%= render 'form_fields/multi_text', form: form, attribute: :identifier %>
+<%= render 'form_fields/multi_text', form: form, attribute: :based_near %>
+<%= render 'form_fields/multi_text', form: form, attribute: :related_url %>
+<%= render 'form_fields/multi_text', form: form, attribute: :source %>
+
+<h3><%= t('dashboard.collections.works') %></h3>
+<%= form.collection_check_boxes :work_ids, works, :id, ->(w) { w.latest_version.title } do |builder| %>
+  <div class="form-check">
+    <%= builder.check_box class: 'form-check-input' %>
+    <%= builder.label class: 'form-check-label' %>
+  </div>
+<% end %>
+
+<div class="actions">
+    <%= form.submit class: 'btn btn-primary' %>
+    <%= link_to 'Cancel', dashboard_collections_path, class: 'btn btn-text' %>
+</div>
+<% end %>

--- a/app/views/dashboard/collections/_index_collection.html.erb
+++ b/app/views/dashboard/collections/_index_collection.html.erb
@@ -1,0 +1,29 @@
+<div class="collection-list__collection row">
+  <div class="collection__metadata col">
+    <h3>
+      <%= index_collection.title %>
+    </h3>
+    <div class="collection__work-list">
+      <% index_collection.works.each do |work| %>
+        <div class="collection__work"><%= work.latest_version.title %></div>
+      <% end %>
+    </div>
+  </div>
+  <div class="collection__actions col-lg-3 col-sm-5">
+    <% if policy(index_collection).show? %>
+      <%= link_to t('dashboard.collections.index.show'),
+                  dashboard_collection_path(index_collection) %>
+    <% end %>
+    <% if policy(index_collection).edit? %>
+      <%= link_to t('dashboard.collections.index.edit'),
+                  edit_dashboard_collection_path(index_collection) %>
+    <% end %>
+    <% if policy(index_collection).destroy? %>
+      <%= link_to t('dashboard.collections.index.delete'),
+                  dashboard_collection_path(index_collection),
+                  method: :delete,
+                  data: { confirm: t('dashboard.collections.index.delete_confirm') },
+                  class: 'text-danger' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/dashboard/collections/edit.html.erb
+++ b/app/views/dashboard/collections/edit.html.erb
@@ -1,0 +1,15 @@
+<%# TODO extract this to a smart partial/helper/presenter %>
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><%= link_to t('dashboard.collections.index.heading'), dashboard_collections_path %></li>
+    <li class="breadcrumb-item active" aria-current="page"><%= t('dashboard.collections.edit.breadcrumb', title: truncate(@collection.title, escape: false)) %></li>
+  </ol>
+</nav>
+
+<h1><%= t('dashboard.collections.edit.heading', title: @collection.title) %></h1>
+
+<div class="row">
+  <div class="col-sm-8">
+    <%= render 'form', collection: @collection, works: @works %>
+  </div>
+</div>

--- a/app/views/dashboard/collections/index.html.erb
+++ b/app/views/dashboard/collections/index.html.erb
@@ -1,0 +1,6 @@
+<h1><%= t('dashboard.collections.index.heading') %></h1>
+<%= link_to t('dashboard.collections.index.new'), new_dashboard_collection_path, class: 'btn btn-large btn-success' %>
+
+<div class="collection-list">
+  <%= render partial: 'index_collection', collection: @collections %>
+</div>

--- a/app/views/dashboard/collections/new.html.erb
+++ b/app/views/dashboard/collections/new.html.erb
@@ -1,0 +1,15 @@
+<%# TODO extract this to a smart partial/helper/presenter %>
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><%= link_to t('dashboard.collections.index.heading'), dashboard_collections_path %></li>
+    <li class="breadcrumb-item active" aria-current="page"><%= t('dashboard.collections.new.heading') %></li>
+  </ol>
+</nav>
+
+<h1><%= t('dashboard.collections.new.heading') %></h1>
+
+<div class="row">
+  <div class="col-sm-8">
+    <%= render 'form', collection: @collection, works: @works %>
+  </div>
+</div>

--- a/app/views/dashboard/collections/show.html.erb
+++ b/app/views/dashboard/collections/show.html.erb
@@ -1,0 +1,21 @@
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><%= link_to t('dashboard.collections.index.heading'), dashboard_collections_path %></li>
+    <li class="breadcrumb-item active" aria-current="page"><%= truncate @collection.title %></li>
+  </ol>
+</nav>
+
+<h1>
+  <%= @collection.title %>
+</h1>
+
+<div class="row">
+  <div class="col-sm-7">
+    <%= render CollectionMetadataComponent, collection: @collection %>
+
+    <h2><%= t('dashboard.collections.works') %></h2>
+    <% @collection.works.each do |work| %>
+      <div class="collection__work"><%= work.latest_version.title %></div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/shared/_user_util_links.html.erb
+++ b/app/views/shared/_user_util_links.html.erb
@@ -19,6 +19,7 @@
         <div class="dropdown-menu" aria-labelledby="navbarDropdown">
           <%= link_to 'Profile', edit_dashboard_profile_path, class: 'dropdown-item' %>
           <%= link_to 'Works', dashboard_works_path, class: 'dropdown-item' %>
+          <%= link_to 'Collections', dashboard_collections_path, class: 'dropdown-item' %>
         </div>
       </li>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,23 @@ en:
         psu_id: PSU ID
         default_alias: Display Name
         orcid: ORCiD
+      collection_creation:
+        alias: Display Name
+      collection:
+        subtitle: Subtitle
+        keyword: Keywords
+        description: Description
+        creator_aliases: Creator
+        resource_type: Resource Type
+        contributor: Contributor
+        publisher: Publisher
+        published_date: Published Date
+        subject: Subject
+        language: Language
+        identifier: Identifier
+        based_near: Based Near
+        related_url: Related URL
+        source: Source
       work_version_creation:
         alias: Display Name
       work_version:
@@ -41,6 +58,25 @@ en:
     edit_message: "You have permission to access the files during the embargo."
     link_text: "Public link"
   dashboard:
+    collections:
+      index:
+        heading: "Your Collections"
+        new: "New Collection"
+        delete_confirm: "Are you sure you want to delete this collection? This cannot be undone."
+        delete: "Delete"
+        edit: "Edit"
+        show: "Show"
+      new:
+        heading: "Create A New Collection"
+        error_message: "%{error} prohibited this collection from being saved:"
+      edit:
+        heading: Edit %{title}
+        add_creator: 'Add another Creator'
+        breadcrumb: Edit %{title}
+        creator: Creator
+        error_message: "%{error} prohibited this collection from being saved:"
+        remove_creator: 'Remove'
+      works: 'Works'
     profiles:
       edit:
         heading: "Edit Profile"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,8 @@ Rails.application.routes.draw do
 
       get 'history', to: 'work_histories#show'
     end
+
+    resources :collections
   end
 
   namespace :api do

--- a/db/migrate/20200415181552_create_collections.rb
+++ b/db/migrate/20200415181552_create_collections.rb
@@ -1,0 +1,12 @@
+class CreateCollections < ActiveRecord::Migration[6.0]
+  def change
+    create_table :collections do |t|
+      t.references :depositor, null: false, foreign_key: { to_table: :actors }
+      t.uuid :uuid
+      t.string :doi
+      t.jsonb :metadata
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200415184149_create_collection_work_memberships.rb
+++ b/db/migrate/20200415184149_create_collection_work_memberships.rb
@@ -1,0 +1,11 @@
+class CreateCollectionWorkMemberships < ActiveRecord::Migration[6.0]
+  def change
+    create_table :collection_work_memberships do |t|
+      t.references :collection, null: false, foreign_key: true
+      t.references :work, null: false, foreign_key: true
+      t.integer :position
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200415185641_create_collection_creations.rb
+++ b/db/migrate/20200415185641_create_collection_creations.rb
@@ -1,0 +1,11 @@
+class CreateCollectionCreations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :collection_creations do |t|
+      t.references :collection, null: false, foreign_key: true
+      t.references :actor, null: false, foreign_key: true
+      t.string :alias
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_09_145829) do
+ActiveRecord::Schema.define(version: 2020_04_15_185641) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,6 +60,36 @@ ActiveRecord::Schema.define(version: 2020_04_09_145829) do
     t.datetime "updated_at", null: false
     t.index ["document_id"], name: "index_bookmarks_on_document_id"
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
+  end
+
+  create_table "collection_creations", force: :cascade do |t|
+    t.bigint "collection_id", null: false
+    t.bigint "actor_id", null: false
+    t.string "alias"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["actor_id"], name: "index_collection_creations_on_actor_id"
+    t.index ["collection_id"], name: "index_collection_creations_on_collection_id"
+  end
+
+  create_table "collection_work_memberships", force: :cascade do |t|
+    t.bigint "collection_id", null: false
+    t.bigint "work_id", null: false
+    t.integer "position"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["collection_id"], name: "index_collection_work_memberships_on_collection_id"
+    t.index ["work_id"], name: "index_collection_work_memberships_on_work_id"
+  end
+
+  create_table "collections", force: :cascade do |t|
+    t.bigint "depositor_id", null: false
+    t.uuid "uuid"
+    t.string "doi"
+    t.jsonb "metadata"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["depositor_id"], name: "index_collections_on_depositor_id"
   end
 
   create_table "file_resources", force: :cascade do |t|
@@ -174,6 +204,11 @@ ActiveRecord::Schema.define(version: 2020_04_09_145829) do
     t.index ["proxy_id"], name: "index_works_on_proxy_id"
   end
 
+  add_foreign_key "collection_creations", "actors"
+  add_foreign_key "collection_creations", "collections"
+  add_foreign_key "collection_work_memberships", "collections"
+  add_foreign_key "collection_work_memberships", "works"
+  add_foreign_key "collections", "actors", column: "depositor_id"
   add_foreign_key "file_version_memberships", "file_resources"
   add_foreign_key "file_version_memberships", "work_versions"
   add_foreign_key "user_group_memberships", "groups"

--- a/spec/components/collection_metadata_component_spec.rb
+++ b/spec/components/collection_metadata_component_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CollectionMetadataComponent, type: :component do
+  let(:result) { render_inline(described_class, collection: collection) }
+
+  describe 'rendering' do
+    let(:collection) { Collection.new(
+      subtitle: 'My subtitle',
+      created_at: Time.zone.parse('2020-01-15 16:07'),
+      keyword: %w(one two),
+      description: nil,
+      subject: []
+    ) }
+
+    it 'renders a string with label' do
+      expect(result.css('dt.collection-subtitle').text).to eq 'Subtitle'
+      expect(result.css('dd.collection-subtitle').text).to eq 'My subtitle'
+    end
+
+    it 'renders a date with a nice format' do
+      expect(result.css('dd.collection-created-at').text).to eq 'January 15, 2020 16:07'
+    end
+
+    it 'renders a multi-value field' do
+      expect(result.css('dd.collection-keyword .multiple-member').map(&:text))
+        .to contain_exactly('one', 'two')
+
+      expect(result.css('dd.collection-keyword').text).to include('; ')
+    end
+
+    it 'does not render any fields that are empty' do
+      expect(result.css('dd.collection-description')).to be_empty
+      expect(result.css('dd.collection-subject')).to be_empty
+    end
+  end
+
+  describe 'fully loaded' do
+    let(:collection) { build_stubbed :collection, :with_complete_metadata, :with_creators }
+
+    it 'renders every field' do
+      # Titles
+      expect(result.css('dt.collection-title')).to be_present
+      expect(result.css('dt.collection-subtitle')).to be_present
+      expect(result.css('dt.collection-description')).to be_present
+      expect(result.css('dt.collection-keyword')).to be_present
+      expect(result.css('dt.collection-resource-type')).to be_present
+      expect(result.css('dt.collection-contributor')).to be_present
+      expect(result.css('dt.collection-publisher')).to be_present
+      expect(result.css('dt.collection-published-date')).to be_present
+      expect(result.css('dt.collection-subject')).to be_present
+      expect(result.css('dt.collection-language')).to be_present
+      expect(result.css('dt.collection-identifier')).to be_present
+      expect(result.css('dt.collection-based-near')).to be_present
+      expect(result.css('dt.collection-related-url')).to be_present
+      expect(result.css('dt.collection-source')).to be_present
+      expect(result.css('dt.collection-created-at')).to be_present
+      expect(result.css('dt.collection-creator-aliases')).to be_present
+
+      # Test that the fields have the correct values. Please note that some of
+      # the more exotic field type (multiples, dates, iso8601 strings) are only
+      # rudimentarily tested here, because they're unit-tested in detail above.
+      expect(result.css('dd.collection-title').text).to eq collection[:title]
+      expect(result.css('dd.collection-subtitle').text).to eq collection[:subtitle]
+      expect(result.css('dd.collection-creator-aliases').text).to include collection.creator_aliases.map(&:alias).first
+      expect(result.css('dd.collection-description').text).to include collection[:description].first
+      expect(result.css('dd.collection-keyword').text).to include collection[:keyword].first
+      expect(result.css('dd.collection-resource-type').text).to include collection[:resource_type].first
+      expect(result.css('dd.collection-contributor').text).to include collection[:contributor].first
+      expect(result.css('dd.collection-publisher').text).to include collection[:publisher].first
+      expect(result.css('dd.collection-published-date').text)
+        .to include Time.zone.parse(collection[:published_date].first).year.to_s
+      expect(result.css('dd.collection-subject').text).to include collection[:subject].first
+      expect(result.css('dd.collection-language').text).to include collection[:language].first
+      expect(result.css('dd.collection-identifier').text).to include collection[:identifier].first
+      expect(result.css('dd.collection-based-near').text).to include collection[:based_near].first
+      expect(result.css('dd.collection-related-url').text).to include collection[:related_url].first
+      expect(result.css('dd.collection-source').text).to include collection[:source].first
+      expect(result.css('dd.collection-created-at').text).to include collection[:created_at].year.to_s
+    end
+  end
+end

--- a/spec/controllers/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/dashboard/collections_controller_spec.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Dashboard::CollectionsController, type: :controller do
+  let(:valid_attributes) {
+    {
+      'title' => 'My Collection',
+      'visibility' => Permissions::Visibility.default
+    }
+  }
+
+  let(:invalid_attributes) {
+    {
+      'title' => ''
+    }
+  }
+
+  let(:user) { collection.depositor.user }
+  let(:collection) { create :collection }
+
+  describe 'GET #index' do
+    context 'when signed in' do
+      before do
+        collection # Ensure collection is created
+        log_in user
+      end
+
+      it 'returns a success response' do
+        get :index
+        expect(response).to be_successful
+      end
+
+      it 'shows only my collections' do
+        _someone_elses_collection = create :collection
+        get :index
+        expect(assigns(:collections).map(&:id)).to contain_exactly(collection.id)
+      end
+    end
+
+    context 'when not signed in' do
+      subject { response }
+
+      before { get :index }
+
+      it { is_expected.to redirect_to new_user_session_path }
+    end
+  end
+
+  describe 'GET #new' do
+    context 'when signed in' do
+      before do
+        log_in user
+        get :new
+      end
+
+      it 'returns a success response' do
+        expect(response).to be_successful
+      end
+
+      it 'builds a collection' do
+        expect(assigns(:collection)).to be_a Collection
+        expect(assigns(:collection).depositor).to eq user.actor
+      end
+    end
+
+    context 'when not signed in' do
+      subject { response }
+
+      before { get :new }
+
+      it { is_expected.to redirect_to new_user_session_path }
+    end
+  end
+
+  describe 'POST #create' do
+    context 'when signed in' do
+      before { sign_in user }
+
+      context 'with valid params' do
+        it 'creates a new Collection for the current user' do
+          expect {
+            post :create, params: { collection: valid_attributes }
+          }.to change { user.actor.deposited_collections.count }.by(1)
+        end
+
+        it 'redirects to the created collection' do
+          post :create, params: { collection: valid_attributes }
+          expect(response).to redirect_to(dashboard_collections_path) # WIP
+        end
+      end
+
+      context 'with invalid params' do
+        it "returns a success response (i.e. to display the 'new' template)" do
+          post :create, params: { collection: invalid_attributes }
+          expect(response).to be_successful
+        end
+      end
+    end
+
+    context 'when not signed in' do
+      subject { response }
+
+      before { post :create, params: { collection: valid_attributes } }
+
+      it { is_expected.to redirect_to new_user_session_path }
+    end
+  end
+
+  describe 'GET #show' do
+    let(:perform_request) { get :show, params: { id: collection.to_param } }
+
+    it_behaves_like 'an authorized dashboard controller'
+
+    context 'when signed in' do
+      before { sign_in user }
+
+      context 'when requesting a version of my own work' do
+        it 'returns a success response' do
+          perform_request
+          expect(response).to be_successful
+        end
+      end
+    end
+  end
+
+  describe 'GET #edit' do
+    let(:perform_request) { get :edit, params: { id: collection.to_param } }
+
+    it_behaves_like 'an authorized dashboard controller'
+
+    context 'when signed in' do
+      before { sign_in user }
+
+      it 'returns a success response' do
+        perform_request
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe 'PATCH #update' do
+    let(:invalid_attributes) { { 'title' => '' } }
+    let(:valid_attributes) { { 'title' => 'My Edited Title' } }
+    let(:attributes) { valid_attributes }
+    let(:perform_request) { patch :update, params: { id: collection.to_param, collection: attributes } }
+
+    it_behaves_like 'an authorized dashboard controller'
+
+    context 'when signed in' do
+      before { sign_in user }
+
+      context 'with valid attributes' do
+        let(:attributes) { valid_attributes }
+
+        before { perform_request }
+
+        its(:response) { is_expected.to redirect_to dashboard_collection_path(collection) }
+      end
+
+      context 'with invalid attributes' do
+        let(:attributes) { invalid_attributes }
+
+        before { perform_request }
+
+        it { is_expected.to render_template(:edit) }
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    let(:someone_elses_collection) { create :collection }
+
+    context 'when signed in' do
+      before { sign_in user }
+
+      context 'when the user owns the collection' do
+        it 'destroys the requested collection' do
+          expect {
+            delete :destroy, params: { id: collection.to_param }
+          }.to change(Collection, :count).by(-1)
+        end
+
+        it 'redirects to the collections list' do
+          delete :destroy, params: { id: collection.to_param }
+          expect(response).to redirect_to(dashboard_collections_url)
+        end
+      end
+
+      context 'when the user does not own the collection' do
+        it '404s' do
+          expect {
+            delete :destroy, params: { id: someone_elses_collection.to_param }
+          }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+    end
+
+    context 'when not signed in' do
+      subject { response }
+
+      before { delete :destroy, params: { id: collection.to_param } }
+
+      it { is_expected.to redirect_to new_user_session_path }
+    end
+  end
+end

--- a/spec/factories/collection_creations.rb
+++ b/spec/factories/collection_creations.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :collection_creation do
+    collection
+    actor
+    add_attribute(:alias) { Faker::Name.name } # `alias` is a reserved keyword
+  end
+end

--- a/spec/factories/collection_work_memberships.rb
+++ b/spec/factories/collection_work_memberships.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :collection_work_membership do
+    collection
+    work
+    position { nil }
+  end
+end

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :collection do
+    association :depositor, :with_user, factory: :actor
+
+    # Postgres does this for us, but for testing, we can do it here to save having to call create/reload.
+    uuid { SecureRandom.uuid }
+
+    title { generate(:work_title) }
+
+    trait :with_complete_metadata do
+      title { generate(:work_title) }
+      subtitle { FactoryBotHelpers.work_title }
+      keyword { Faker::Science.element }
+      description { Faker::Lorem.paragraph }
+      resource_type { Faker::House.furniture }
+      contributor { Faker::Artist.name }
+      publisher { Faker::Book.publisher }
+      published_date { Faker::Date.between(from: 2.years.ago, to: Date.today).iso8601 }
+      subject { Faker::Book.genre }
+
+      language { Faker::Nation.language }
+      identifier { Faker::Number.leading_zero_number(digits: 10) }
+      based_near { FactoryBotHelpers.fancy_geo_location }
+      related_url { Faker::Internet.url }
+      source { Faker::SlackEmoji.emoji }
+    end
+  end
+end

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -9,22 +9,41 @@ FactoryBot.define do
 
     title { generate(:work_title) }
 
+    trait :with_creators do
+      transient do
+        creator_count { 1 }
+      end
+
+      after(:build, :stub) do |collection, evaluator|
+        actors = build_list(:actor, evaluator.creator_count)
+
+        actors.each do |actor|
+          # Alias "Pat Doe" to "Dr. Pat Doe"
+          creator_alias = "#{Faker::Name.prefix} #{actor.given_name} #{actor.surname}"
+          collection.creator_aliases.build(
+            actor: actor,
+            alias: creator_alias
+          )
+        end
+      end
+    end
+
     trait :with_complete_metadata do
       title { generate(:work_title) }
       subtitle { FactoryBotHelpers.work_title }
-      keyword { Faker::Science.element }
-      description { Faker::Lorem.paragraph }
-      resource_type { Faker::House.furniture }
-      contributor { Faker::Artist.name }
-      publisher { Faker::Book.publisher }
-      published_date { Faker::Date.between(from: 2.years.ago, to: Date.today).iso8601 }
-      subject { Faker::Book.genre }
+      keyword { [Faker::Science.element] }
+      description { [Faker::Lorem.paragraph] }
+      resource_type { [Faker::House.furniture] }
+      contributor { [Faker::Artist.name] }
+      publisher { [Faker::Book.publisher] }
+      published_date { [Faker::Date.between(from: 2.years.ago, to: Date.today).iso8601] }
+      subject { [Faker::Book.genre] }
 
-      language { Faker::Nation.language }
-      identifier { Faker::Number.leading_zero_number(digits: 10) }
-      based_near { FactoryBotHelpers.fancy_geo_location }
-      related_url { Faker::Internet.url }
-      source { Faker::SlackEmoji.emoji }
+      language { [Faker::Nation.language] }
+      identifier { [Faker::Number.leading_zero_number(digits: 10)] }
+      based_near { [FactoryBotHelpers.fancy_geo_location] }
+      related_url { [Faker::Internet.url] }
+      source { [Faker::SlackEmoji.emoji] }
     end
   end
 end

--- a/spec/features/dashboard/collection_management_spec.rb
+++ b/spec/features/dashboard/collection_management_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Creating and managing a collection' do
+  let(:user) { create :user }
+
+  let(:existing_collection) { create :collection, :with_complete_metadata, depositor: user.actor, works: [user_work_1] }
+
+  let(:metadata) { attributes_for :collection, :with_complete_metadata }
+  let(:updated_metadata) { attributes_for :collection, :with_complete_metadata }
+
+  let!(:user_work_1) { create :work, has_draft: false, depositor: user.actor }
+  let!(:user_work_2) { create :work, has_draft: false, depositor: user.actor }
+  let!(:other_work) { create :work }
+
+  it 'creates a collection', with_user: :user, js: true do
+    visit(dashboard_collections_path)
+    click_on('New Collection')
+
+    fill_in('Title', with: metadata[:title])
+
+    # Select some works for this collection
+    expect(page).to have_unchecked_field(user_work_1.latest_version.title)
+    expect(page).to have_unchecked_field(user_work_2.latest_version.title)
+    expect(page).not_to have_unchecked_field(other_work.latest_version.title)
+    expect(page).not_to have_checked_field(other_work.latest_version.title)
+    check user_work_1.latest_version.title
+
+    fill_in('Subtitle', with: metadata[:subtitle])
+    fill_in('Keywords', with: metadata[:keyword].first)
+    fill_in('Description', with: metadata[:description].first)
+    fill_in('Resource Type', with: metadata[:resource_type].first)
+    fill_in('Contributor', with: metadata[:contributor].first)
+    fill_in('Publisher', with: metadata[:publisher].first)
+    fill_in('Published Date', with: metadata[:published_date].first)
+    fill_in('Subject', with: metadata[:subject].first)
+    fill_in('Language', with: metadata[:language].first)
+    fill_in('Identifier', with: metadata[:identifier].first)
+    fill_in('Based Near', with: metadata[:based_near].first)
+    fill_in('Related URL', with: metadata[:related_url].first)
+    fill_in('Source', with: metadata[:source].first)
+
+    # Ensure one creator is pre-filled with the User's Actor
+    within('#creator_aliases') do
+      actor = user.reload.actor
+      expect(find_field('Display Name').value).to eq actor.default_alias
+      expect(find_field('Email').value).to eq actor.email
+      expect(find_field('Given name').value).to eq actor.given_name
+      expect(find_field('Surname').value).to eq actor.surname
+      expect(find_field('PSU ID').value).to eq actor.psu_id
+    end
+
+    # Rename "my" creator
+    within('#creator_aliases .nested-fields:nth-of-type(1)') do
+      fill_in('Display Name', with: 'MY EDITED CREATOR NAME')
+    end
+
+    retry_click { click_link('Add another Creator') }
+
+    # Add another creator
+    within('#creator_aliases .nested-fields:nth-of-type(2)') do
+      fill_in('Display Name', with: 'Dr. Second Creator, PhD.')
+      fill_in('Email', with: '2nd.creator@example.com')
+      fill_in('Given name', with: 'Second')
+      fill_in('Surname', with: 'Creator')
+    end
+
+    click_button 'Create Collection'
+
+    # Ensure record was saved to the db correctly
+    user.actor.deposited_collections.last.tap do |collection|
+      # Metadata
+      expect(collection.title).to eq metadata[:title]
+      expect(collection.subtitle).to eq metadata[:subtitle]
+      expect(collection.keyword).to eq [metadata[:keyword].first]
+      expect(collection.description).to eq [metadata[:description].first]
+      expect(collection.resource_type).to eq [metadata[:resource_type].first]
+      expect(collection.contributor).to eq [metadata[:contributor].first]
+      expect(collection.publisher).to eq [metadata[:publisher].first]
+      expect(collection.published_date).to eq [metadata[:published_date].first]
+      expect(collection.subject).to eq [metadata[:subject].first]
+      expect(collection.language).to eq [metadata[:language].first]
+      expect(collection.identifier).to eq [metadata[:identifier].first]
+      expect(collection.based_near).to eq [metadata[:based_near].first]
+      expect(collection.related_url).to eq [metadata[:related_url].first]
+      expect(collection.source).to eq [metadata[:source].first]
+
+      # Creators
+      expect(collection.creator_aliases.map(&:alias))
+        .to contain_exactly('MY EDITED CREATOR NAME', 'Dr. Second Creator, PhD.')
+
+      # Works
+      expect(collection.works).to contain_exactly(user_work_1)
+    end
+  end
+
+  it 'shows a collection', with_user: :user do
+    existing_collection # pop this into existence
+    visit dashboard_collections_path
+
+    expect(page).to have_content(existing_collection.title)
+
+    click_link('Show')
+
+    expect(page).to have_content(existing_collection.title)
+    expect(page).to have_content(existing_collection.subtitle)
+    expect(page).to have_content(user_work_1.latest_version.title)
+  end
+
+  it 'edits a collection', with_user: :user do
+    existing_collection # pop this into existence
+    visit dashboard_collections_path
+
+    expect(page).to have_content(existing_collection.title)
+
+    click_link('Edit')
+
+    fill_in('Title', with: updated_metadata[:title])
+    uncheck user_work_1.latest_version.title
+    check user_work_2.latest_version.title
+    click_button 'Update Collection'
+
+    # Ensure record was saved to the db correctly
+    existing_collection.reload
+    expect(existing_collection.title).to eq updated_metadata[:title]
+
+    # Works
+    expect(existing_collection.works).to contain_exactly(user_work_2)
+  end
+
+  it 'deletes a collection', with_user: :user do
+    existing_collection # pop this into existence
+    visit dashboard_collections_path
+
+    expect(page).to have_content(existing_collection.title)
+
+    click_link('Delete')
+
+    expect { existing_collection.reload }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+end

--- a/spec/models/actor_spec.rb
+++ b/spec/models/actor_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe Actor, type: :model do
     it { is_expected.to have_one(:user) }
     it { is_expected.to have_many(:work_version_creations) }
     it { is_expected.to have_many(:work_versions).through(:work_version_creations) }
+    it { is_expected.to have_many(:collection_creations) }
+    it { is_expected.to have_many(:collections).through(:collection_creations) }
     it { is_expected.to have_many(:deposited_works).class_name('Work').inverse_of(:depositor) }
     it { is_expected.to have_many(:proxy_deposited_works).class_name('Work').inverse_of(:proxy_depositor) }
   end

--- a/spec/models/actor_spec.rb
+++ b/spec/models/actor_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Actor, type: :model do
     it { is_expected.to have_many(:collections).through(:collection_creations) }
     it { is_expected.to have_many(:deposited_works).class_name('Work').inverse_of(:depositor) }
     it { is_expected.to have_many(:proxy_deposited_works).class_name('Work').inverse_of(:proxy_depositor) }
+    it { is_expected.to have_many(:deposited_collections).class_name('Collection').inverse_of(:depositor) }
   end
 
   describe 'validations' do

--- a/spec/models/collection_creation_spec.rb
+++ b/spec/models/collection_creation_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CollectionCreation, type: :model do
+  describe 'table' do
+    it { is_expected.to have_db_column(:collection_id) }
+    it { is_expected.to have_db_column(:actor_id) }
+    it { is_expected.to have_db_column(:alias).of_type(:string) }
+    it { is_expected.to have_db_column(:created_at).of_type(:datetime) }
+    it { is_expected.to have_db_column(:updated_at).of_type(:datetime) }
+
+    it { is_expected.to have_db_index(:collection_id) }
+    it { is_expected.to have_db_index(:actor_id) }
+  end
+
+  describe 'factory' do
+    it { is_expected.to have_valid_factory(:collection_creation) }
+  end
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:collection) }
+    it { is_expected.to belong_to(:actor) }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:alias) }
+  end
+
+  describe 'initialization' do
+    let(:actor) { build :actor, default_alias: 'Actor Default Alias' }
+    let(:collection) { build :collection }
+
+    context 'when an alias is not provided' do
+      subject(:creation) { described_class.new actor: actor, collection: collection }
+
+      it 'initializes itself with the given Actor#default_alias' do
+        creation.save!
+        expect(creation.reload.alias).to eq 'Actor Default Alias'
+      end
+    end
+
+    context 'when an alias is provided' do
+      subject(:creation) { described_class.new alias: 'Provided Alias', actor: actor, collection: collection }
+
+      it 'uses the provided alias' do
+        creation.save!
+        expect(creation.reload.alias).to eq 'Provided Alias'
+      end
+    end
+  end
+end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -39,4 +39,35 @@ RSpec.describe Collection, type: :model do
     it { is_expected.to have_many(:creator_aliases) }
     it { is_expected.to have_many(:creators).through(:creator_aliases) }
   end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:title) }
+  end
+
+  describe '#build_creator_alias' do
+    let(:actor) { build_stubbed :actor }
+    let(:collection) { build_stubbed :collection }
+
+    it 'builds a creator_alias for the given Actor but does not persist it' do
+      expect {
+        collection.build_creator_alias(actor: actor)
+      }.to change {
+        collection.creator_aliases.length
+      }.by(1)
+
+      collection.creator_aliases.first.tap do |creator_alias|
+        expect(creator_alias).not_to be_persisted
+        expect(creator_alias.actor).to eq actor
+        expect(creator_alias.alias).to eq actor.default_alias
+      end
+    end
+
+    it 'is idempotent' do
+      expect {
+        2.times { collection.build_creator_alias(actor: actor) }
+      }.to change {
+        collection.creator_aliases.length
+      }.by(1)
+    end
+  end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Collection, type: :model do
+  describe 'table' do
+    it { is_expected.to have_db_column(:depositor_id) }
+    it { is_expected.to have_db_column(:metadata).of_type(:jsonb) }
+    it { is_expected.to have_db_column(:uuid).of_type(:uuid) }
+    it { is_expected.to have_db_column(:doi).of_type(:string) }
+    it { is_expected.to have_jsonb_accessor(:title).of_type(:string) }
+    it { is_expected.to have_jsonb_accessor(:subtitle).of_type(:string) }
+    it { is_expected.to have_jsonb_accessor(:keyword).of_type(:string).is_array.with_default([]) }
+    it { is_expected.to have_jsonb_accessor(:description).of_type(:string).is_array.with_default([]) }
+    it { is_expected.to have_jsonb_accessor(:resource_type).of_type(:string).is_array.with_default([]) }
+    it { is_expected.to have_jsonb_accessor(:contributor).of_type(:string).is_array.with_default([]) }
+    it { is_expected.to have_jsonb_accessor(:publisher).of_type(:string).is_array.with_default([]) }
+    it { is_expected.to have_jsonb_accessor(:published_date).of_type(:string).is_array.with_default([]) }
+    it { is_expected.to have_jsonb_accessor(:subject).of_type(:string).is_array.with_default([]) }
+    it { is_expected.to have_jsonb_accessor(:language).of_type(:string).is_array.with_default([]) }
+    it { is_expected.to have_jsonb_accessor(:identifier).of_type(:string).is_array.with_default([]) }
+    it { is_expected.to have_jsonb_accessor(:based_near).of_type(:string).is_array.with_default([]) }
+    it { is_expected.to have_jsonb_accessor(:related_url).of_type(:string).is_array.with_default([]) }
+    it { is_expected.to have_jsonb_accessor(:source).of_type(:string).is_array.with_default([]) }
+
+    it { is_expected.to have_db_index(:depositor_id) }
+  end
+
+  describe 'factory' do
+    it { is_expected.to have_valid_factory(:collection) }
+    it { is_expected.to have_valid_factory(:collection, :with_complete_metadata) }
+  end
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:depositor).class_name('Actor').with_foreign_key(:depositor_id).inverse_of(:deposited_works) }
+    it { is_expected.to have_many(:legacy_identifiers) }
+    it { is_expected.to have_many(:collection_work_memberships) }
+    it { is_expected.to have_many(:works).through(:collection_work_memberships) }
+    it { is_expected.to have_many(:creator_aliases) }
+    it { is_expected.to have_many(:creators).through(:creator_aliases) }
+  end
+end

--- a/spec/models/collection_work_membership_spec.rb
+++ b/spec/models/collection_work_membership_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CollectionWorkMembership, type: :model do
+  describe 'table' do
+    it { is_expected.to have_db_column(:collection_id) }
+    it { is_expected.to have_db_column(:work_id) }
+    it { is_expected.to have_db_column(:position).of_type(:integer) }
+    it { is_expected.to have_db_column(:created_at).of_type(:datetime) }
+    it { is_expected.to have_db_column(:updated_at).of_type(:datetime) }
+
+    it { is_expected.to have_db_index(:collection_id) }
+    it { is_expected.to have_db_index(:work_id) }
+  end
+
+  describe 'factory' do
+    it { is_expected.to have_valid_factory(:collection_work_membership) }
+  end
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:collection) }
+    it { is_expected.to belong_to(:work) }
+  end
+end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe Work, type: :model do
     it { is_expected.to have_many(:access_controls) }
     it { is_expected.to have_many(:versions).class_name('WorkVersion').inverse_of('work') }
     it { is_expected.to have_many(:legacy_identifiers) }
+    it { is_expected.to have_many(:collection_work_memberships) }
+    it { is_expected.to have_many(:collections).through(:collection_work_memberships) }
 
     it { is_expected.to accept_nested_attributes_for(:versions) }
   end

--- a/spec/policies/dashboard/collection_policy_spec.rb
+++ b/spec/policies/dashboard/collection_policy_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Dashboard::CollectionPolicy, type: :policy do
+  subject(:policy) { described_class }
+
+  let(:user) { create :user }
+  let(:other_user) { create :user }
+
+  let!(:my_collection) { create :collection, depositor: user.actor }
+
+  permissions '.scope' do
+    let(:scoped_collections) { described_class::Scope.new(user, Collection).resolve }
+
+    before do
+      create :collection, depositor: other_user.actor
+    end
+
+    it 'only finds my collections' do
+      expect(scoped_collections).to match_array([my_collection])
+    end
+  end
+
+  permissions :show?, :edit?, :update?, :destroy? do
+    it { is_expected.to permit(user, my_collection) }
+    it { is_expected.not_to permit(other_user, my_collection) }
+  end
+end


### PR DESCRIPTION
Quickest complete implementation for collections that I could muster. The idea here was to make the UI fully functional, but not sink a lot of time into it because Peter will be overhauling it.

### Create a collection
Once logged in, in the top-right corner you can visit your collections dashboard page. This page is separate from the works dashboard at the moment, because combining the two (with pagination anyways) may require powering this list from solr.

* Click the big "New Collection" button.
* Fill out metadata.
* Select the checkboxes next to works you want to go in the collection

The works shown in the checkbox list are _only your own works._ That is, you can only create a collection of your own works. There are no "teeth" behind this rule, it is not enforced at the model layer, this is merely a UI decision that I made. For example, migration can still proceed and create collections with arbitrary works attached to them, there are no business rules preventing this. We can tweak this later by changing the UI. I also imagine a better interface for doing this, such as a type-ahead box similar to how Creators will work. But again, this was the simplest thing I could come up with that gets the job done and gets things into the database.

Closes #253 
Closes #254 
Closes #255 
Closes #256  