### PR TITLE
Collection resource

### DIFF
--- a/app/components/work_version_metadata_component.rb
+++ b/app/components/work_version_metadata_component.rb
@@ -3,7 +3,8 @@
 require 'action_view/component'
 
 class WorkVersionMetadataComponent < ActionView::Component::Base
-  attr_reader :work_version
+  attr_reader :work_version,
+              :mini
 
   validates :work_version,
             presence: true
@@ -31,14 +32,25 @@ class WorkVersionMetadataComponent < ActionView::Component::Base
     :created_at
   ].freeze
 
-  def initialize(work_version:)
+  MINI_ATTRIBUTES = [
+    :title,
+    :creator_aliases,
+    :created_at
+  ].freeze
+
+  def initialize(work_version:, mini: false)
     @work_version = work_version
+    @mini = mini
   end
 
   private
 
+    def attributes_list
+      mini ? MINI_ATTRIBUTES : ATTRIBUTES
+    end
+
     def attributes
-      ATTRIBUTES
+      attributes_list
         .map do |attr|
           label = format_label(attr)
           value = format_value(work_version.send(attr))

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -8,10 +8,10 @@ class ResourcesController < ApplicationController
 
   private
 
-    # @todo probably a good idea to make this into a ResourceFinder class
     def find_resource(uuid)
       Work.where(uuid: uuid).first ||
         WorkVersion.where(uuid: uuid).first ||
+        Collection.where(uuid: uuid).first ||
         raise(ActiveRecord::RecordNotFound)
     end
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -50,6 +50,32 @@ class Collection < ApplicationRecord
                                 reject_if: :all_blank,
                                 allow_destroy: true
 
+  # Fields that can contain multiple values automatically remove blank values
+  %i[
+    keyword
+    description
+    resource_type
+    contributor
+    publisher
+    published_date
+    subject
+    language
+    identifier
+    based_near
+    related_url
+    source
+  ].each do |array_field|
+    define_method "#{array_field}=" do |vals|
+      super(strip_blanks_from_array(vals))
+    end
+  end
+
+  %i[subtitle].each do |field|
+    define_method "#{field}=" do |val|
+      super(val.presence)
+    end
+  end
+
   def build_creator_alias(actor:)
     existing_creator_alias = creator_aliases.find { |ca| ca.actor == actor }
     return existing_creator_alias if existing_creator_alias.present?
@@ -59,4 +85,10 @@ class Collection < ApplicationRecord
       actor: actor
     )
   end
+
+  private
+
+    def strip_blanks_from_array(arr)
+      Array.wrap(arr).reject(&:blank?)
+    end
 end

--- a/app/policies/collection_policy.rb
+++ b/app/policies/collection_policy.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# @note this is a policy used by the public-facing side of the app. The
+# Dashboard (where users work on their own stuff) has a different policy. At
+# some point we may combine the two, but don't want to prefactor
+class CollectionPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope.all
+    end
+  end
+
+  def show?
+    true
+  end
+end

--- a/app/views/dashboard/collections/show.html.erb
+++ b/app/views/dashboard/collections/show.html.erb
@@ -12,10 +12,6 @@
 <div class="row">
   <div class="col-sm-7">
     <%= render CollectionMetadataComponent, collection: @collection %>
-
-    <h2><%= t('dashboard.collections.works') %></h2>
-    <% @collection.works.each do |work| %>
-      <div class="collection__work"><%= work.latest_version.title %></div>
-    <% end %>
+    <%= render 'shared/collection_works', collection: @collection %>
   </div>
 </div>

--- a/app/views/resources/_collection.html.erb
+++ b/app/views/resources/_collection.html.erb
@@ -1,0 +1,4 @@
+<h1><%= collection.title %></h1>
+
+<%= render CollectionMetadataComponent, collection: collection %>
+<%= render 'shared/collection_works', collection: collection %>

--- a/app/views/shared/_collection_works.html.erb
+++ b/app/views/shared/_collection_works.html.erb
@@ -1,0 +1,13 @@
+<% collection.works.includes(versions: :creator_aliases).each do |work| %>
+  <% work_version = work.latest_published_version -%>
+  <article class="document" itemtype="http://schema.org/Thing">
+    <header class="documentHeader row">
+      <h3 class="index_title document-title-heading col-md-12 ">
+        <%= link_to work_version.title, resource_path(work_version.uuid) %>
+        <%= render VisibilityBadgeComponent, work: work %>
+      </h3>
+    </header>
+
+    <%= render WorkVersionMetadataComponent, work_version: work_version, mini: true %>
+  </article>
+<% end %>

--- a/db/migrate/20200428141801_add_default_to_collections_uuid.rb
+++ b/db/migrate/20200428141801_add_default_to_collections_uuid.rb
@@ -1,0 +1,6 @@
+class AddDefaultToCollectionsUuid < ActiveRecord::Migration[6.0]
+  def change
+    enable_extension 'uuid-ossp'
+    change_column_default :collections, :uuid, from: nil, to: 'uuid_generate_v4()'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_15_185641) do
+ActiveRecord::Schema.define(version: 2020_04_28_141801) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,7 +84,7 @@ ActiveRecord::Schema.define(version: 2020_04_15_185641) do
 
   create_table "collections", force: :cascade do |t|
     t.bigint "depositor_id", null: false
-    t.uuid "uuid"
+    t.uuid "uuid", default: -> { "uuid_generate_v4()" }
     t.string "doi"
     t.jsonb "metadata"
     t.datetime "created_at", precision: 6, null: false

--- a/spec/components/work_version_metadata_component_spec.rb
+++ b/spec/components/work_version_metadata_component_spec.rb
@@ -81,5 +81,31 @@ RSpec.describe WorkVersionMetadataComponent, type: :component do
       expect(result.css('dd.work-version-source').text).to include work_version[:source].first
       expect(result.css('dd.work-version-created-at').text).to include work_version[:created_at].year.to_s
     end
+
+    context 'when mini: true' do
+      let(:result) { render_inline(described_class, work_version: work_version, mini: true) }
+
+      it 'renders just the mini fields' do
+        # Titles
+        expect(result.css('dt.work-version-title')).to be_present
+        expect(result.css('dt.work-version-created-at')).to be_present
+        expect(result.css('dt.work-version-creator-aliases')).to be_present
+        expect(result.css('dt.work-version-subtitle')).not_to be_present
+        expect(result.css('dt.work-version-version-number')).not_to be_present
+        expect(result.css('dt.work-version-description')).not_to be_present
+        expect(result.css('dt.work-version-keyword')).not_to be_present
+        expect(result.css('dt.work-version-rights')).not_to be_present
+        expect(result.css('dt.work-version-resource-type')).not_to be_present
+        expect(result.css('dt.work-version-contributor')).not_to be_present
+        expect(result.css('dt.work-version-publisher')).not_to be_present
+        expect(result.css('dt.work-version-published-date')).not_to be_present
+        expect(result.css('dt.work-version-subject')).not_to be_present
+        expect(result.css('dt.work-version-language')).not_to be_present
+        expect(result.css('dt.work-version-identifier')).not_to be_present
+        expect(result.css('dt.work-version-based-near')).not_to be_present
+        expect(result.css('dt.work-version-related-url')).not_to be_present
+        expect(result.css('dt.work-version-source')).not_to be_present
+      end
+    end
   end
 end

--- a/spec/controllers/resources_controller_spec.rb
+++ b/spec/controllers/resources_controller_spec.rb
@@ -22,6 +22,15 @@ RSpec.describe ResourcesController, type: :controller do
       end
     end
 
+    context 'when requesting a Collection' do
+      let(:collection) { create :collection }
+
+      it 'loads the WorkVersion' do
+        get :show, params: { id: collection.uuid }
+        expect(assigns[:resource]).to eq collection
+      end
+    end
+
     context 'when requesting an unknown uuid' do
       it do
         expect {

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -44,6 +44,25 @@ RSpec.describe Collection, type: :model do
     it { is_expected.to validate_presence_of(:title) }
   end
 
+  describe 'multivalued fields' do
+    it_behaves_like 'a multivalued json field', :keyword
+    it_behaves_like 'a multivalued json field', :description
+    it_behaves_like 'a multivalued json field', :resource_type
+    it_behaves_like 'a multivalued json field', :contributor
+    it_behaves_like 'a multivalued json field', :publisher
+    it_behaves_like 'a multivalued json field', :published_date
+    it_behaves_like 'a multivalued json field', :subject
+    it_behaves_like 'a multivalued json field', :language
+    it_behaves_like 'a multivalued json field', :identifier
+    it_behaves_like 'a multivalued json field', :based_near
+    it_behaves_like 'a multivalued json field', :related_url
+    it_behaves_like 'a multivalued json field', :source
+  end
+
+  describe 'singlevalued fields' do
+    it_behaves_like 'a singlevalued json field', :subtitle
+  end
+
   describe '#build_creator_alias' do
     let(:actor) { build_stubbed :actor }
     let(:collection) { build_stubbed :collection }

--- a/spec/policies/collection_policy_spec.rb
+++ b/spec/policies/collection_policy_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CollectionPolicy, type: :policy do
+  let(:user) { instance_double 'User' }
+  let(:collection) { instance_double 'Collection' }
+
+  describe '#show?' do
+    it 'is always true' do
+      expect(described_class.new(user, collection).show?).to eq true
+    end
+  end
+end


### PR DESCRIPTION
The first commit in this PR includes some model-level housekeeping that I'd forgotten to do when I first modeled Collections.

The next commit creates a public "resource" page for collections.

Also includes an update to the Work Version metadata component: a "mini" version that shows a small amount of essential metadata without rendering out _all_ of it. This is used on the collections page to show a little bit of metadata for each work in that collection.

I tried making this mini version a subclass of `WorkVersionMetadataComponent` but that didn't work out so well, due to the way ActionView Components require an html template that matches the file name, and apparently these are not inheritable. Instead, I made it a little flag that you pass into the component: `mini: true` to trigger this behavior. The full-blown-metadata and the mini-metadata are specified as two different array constants, because you might want a different ordering of the fields between them, or something.

Closes #272 because the polymorphic nature of Legacy Ids means anything with a public resource page and the correct ActiveRecord association (the latter Collection already had) automatically gains legacy url support.
