### PR TITLE
Revert "Bump jquery from 3.4.1 to 3.5.0"

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4610,9 +4610,9 @@ jest-worker@^25.1.0:
     supports-color "^7.0.0"
 
 jquery@>=1.7, jquery@^3.2.1, jquery@^3.4.1:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.0.tgz#9980b97d9e4194611c36530e7dc46a58d7340fc9"
-  integrity sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
 js-base64@^2.1.8:
   version "2.5.1"


### PR DESCRIPTION
This reverts commit 7d9c139425c9d8d80bacf0daf7f617f39b43643b.

The jQuery update breaks Bootstrap features such as the expand/collapse of the catalog search facets.

Once Bootstrap is fixed, then we should be able to re-apply this patch.
See https://github.com/twbs/bootstrap/issues/30692