### PR TITLE
Reference @actor in edit profile page

### DIFF
--- a/app/views/dashboard/profiles/edit.html.erb
+++ b/app/views/dashboard/profiles/edit.html.erb
@@ -1,6 +1,6 @@
 <h1><%= t 'dashboard.profiles.edit.heading' %></h1>
 
-<%= form_with(model: @creator, url: dashboard_profile_path, local: true) do |f| %>
+<%= form_with(model: @actor, url: dashboard_profile_path, local: true) do |f| %>
   <% if f.object.errors.any? %>
     <div id="error_explanation">
       <h2><%= t('dashboard.profiles.edit.error_message', error: pluralize(f.object.errors.count, 'error')) %></h2>

--- a/spec/features/profile_spec.rb
+++ b/spec/features/profile_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Profile', type: :feature, with_user: :user do
+  let(:user) { create(:user) }
+  let(:updated_user) { create(:actor) }
+  let(:updated_display_name) { "Dr. #{updated_user.default_alias}" }
+
+  it 'displays and updates my profile information' do
+    visit edit_dashboard_profile_path
+    expect(page).to have_content('Edit Profile')
+    fill_in 'Display Name', with: updated_display_name
+    fill_in 'Given name', with: updated_user.given_name
+    fill_in 'Surname', with: updated_user.surname
+    fill_in 'Email', with: updated_user.email
+    fill_in 'ORCiD', with: updated_user.orcid
+    click_button 'Save'
+    user.actor.reload
+    expect(user.actor.given_name).to eq(updated_user.given_name)
+    expect(user.actor.surname).to eq(updated_user.surname)
+    expect(user.actor.orcid).to eq(updated_user.orcid)
+    expect(user.actor.psu_id).to eq(user.access_id)
+    within('#navbarDropdown') do
+      expect(page).to have_content(updated_display_name)
+    end
+  end
+end


### PR DESCRIPTION
The edit profile page missed the creator/actor update and was breaking. We're now updating the actor correctly and have added tests to ensure that all fields get properly updated in the future.

Fixes #269