### PR TITLE
Migrating Collections

### DIFF
--- a/app/controllers/api/v1/collections_controller.rb
+++ b/app/controllers/api/v1/collections_controller.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+module Api::V1
+  class CollectionsController < RestController
+    rescue_from StandardError do |exception|
+      if exception.is_a?(ActionController::ParameterMissing)
+        render json: { message: 'Bad request', errors: [exception.message] }, status: :bad_request
+      else
+        render json: { message: "We're sorry, but something went wrong", errors: [exception.class.to_s, exception] },
+               status: :internal_server_error
+      end
+    end
+
+    before_action :return_migrated_collection
+
+    def create
+      if collection.errors.any?
+        render json: unprocessable_entity_response, status: :unprocessable_entity
+      else
+        render json: success_response, status: :ok
+      end
+    end
+
+    private
+
+      def return_migrated_collection
+        ids = LegacyIdentifier.where(old_id: metadata_params['noid'], version: 3, resource_type: 'Collection')
+        return if ids.empty?
+
+        collection = Collection.find(ids.first.resource_id)
+        render json: migrated_response(collection), status: 303
+      end
+
+      def migrated_response(collection)
+        {
+          message: 'Collection has already been migrated',
+          url: resource_path(collection.uuid)
+        }
+      end
+
+      def success_response
+        {
+          message: 'Collection was successfully created',
+          url: resource_path(collection.uuid)
+        }
+      end
+
+      def unprocessable_entity_response
+        {
+          message: 'Unable to complete the request',
+          errors: collection.errors.full_messages
+        }
+      end
+
+      def collection
+        @collection ||= CreateNewCollection.call(
+          metadata: metadata_params.merge!(work_ids: work_ids),
+          depositor: depositor_params,
+          permissions: permission_params
+        )
+      end
+
+      # @note Noids are globally unique in Scholarsphere 3, so limiting this query to collections isn't necessary.
+      def work_ids
+        work_noid_params.map { |noid| LegacyIdentifier.find_by!(old_id: noid).resource_id }
+          .concat(metadata_params.fetch(:work_ids, []))
+          .uniq
+      end
+
+      def metadata_params
+        params
+          .require(:metadata)
+          .permit(
+            :title,
+            :subtitle,
+            :rights,
+            :noid,
+            work_ids: [],
+            keyword: [],
+            description: [],
+            contributor: [],
+            publisher: [],
+            published_date: [],
+            subject: [],
+            language: [],
+            identifier: [],
+            based_near: [],
+            related_url: [],
+            source: [],
+            creator_aliases_attributes: [
+              :alias,
+              actor_attributes: [
+                :email,
+                :given_name,
+                :surname,
+                :psu_id
+              ]
+            ]
+          )
+      end
+
+      def depositor_params
+        params
+          .require(:depositor)
+          .permit(
+            :email,
+            :given_name,
+            :surname,
+            :psu_id
+          )
+      end
+
+      def permission_params
+        params.fetch(:permissions, {})
+          .permit(
+            edit_users: [],
+            edit_groups: [],
+            read_users: [],
+            read_groups: [],
+            discover_users: [],
+            discover_group: []
+          )
+      end
+
+      def work_noid_params
+        params.fetch(:work_noids, [])
+      end
+  end
+end

--- a/app/services/create_new_collection.rb
+++ b/app/services/create_new_collection.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# @abstract Used in conjunction with our REST API, this service creates a new collection.
+# It is incumbent upon the caller to provide the required metadata. Here are the possible outcomes:
+# 1. A collection has valid metadata and all its member works exist (regardless of their state)
+#      * a new, persisted collection is returned
+# 2. A collection has valid metadata, but some of its member works do not exist
+#      * a new, UNPERSISTED collection is returned with errors
+# 3. A collection has invalid metadata
+#      * a new, UNPERSISTED collection is returned with errors
+
+class CreateNewCollection
+  # @param [ActionController::Parameters] metadata
+  # @param [ActionController::Parameters] depositor
+  # @param [ActionController::Parameters] permissions
+  # @return [Collection]
+  def self.call(metadata:, depositor:, permissions: {})
+    noid = metadata.delete(:noid)
+
+    # @todo start a transaction here in case we need to rollback and remove any Actors we've created
+
+    depositor_actor = Actor.find_or_create_by(psu_id: depositor['psu_id']) do |actor|
+      actor.attributes = depositor
+    end
+
+    creator_aliases_attributes = metadata.to_hash.fetch('creator_aliases_attributes', []).map do |attributes|
+      actor_attributes = attributes['actor_attributes']
+      psu_id = actor_attributes['psu_id']
+
+      actor = if psu_id.present?
+                Actor.find_or_create_by(psu_id: psu_id) do |new_actor|
+                  new_actor.attributes = actor_attributes
+                end
+              else
+                Actor.find_or_create_by(actor_attributes)
+              end
+
+      { alias: attributes['alias'], actor: actor }
+    end
+
+    params = metadata.to_hash.merge!(
+      'creator_aliases_attributes' => creator_aliases_attributes,
+      'visibility' => Permissions::Visibility::OPEN,
+      'depositor' => depositor_actor
+    )
+
+    collection = Collection.new(params)
+    if noid.present?
+      collection.legacy_identifiers.find_or_initialize_by(
+        version: 3,
+        old_id: noid
+      )
+    end
+    UpdatePermissionsService.call(resource: collection, permissions: permissions, create_agents: true)
+
+    return collection unless collection.valid?
+
+    collection.save && collection.reload
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :ingest, only: [:create]
+      resources :collections, only: [:create]
     end
   end
 

--- a/db/seeds/development/api_tokens.seeds.rb
+++ b/db/seeds/development/api_tokens.seeds.rb
@@ -1,0 +1,5 @@
+ApiToken.find_or_create_by(
+  token: 'db9c21583ea98d16e42a73d9f78897c1ffc1dffcae781eb17f841cf421bd22b7a1a1228226437c5fdf6b6c9a8f537b17',
+  app_name: 'Client Testing',
+  admin_email: 'testing@psu.edu'
+)

--- a/spec/controllers/api/v1/collections_controller_spec.rb
+++ b/spec/controllers/api/v1/collections_controller_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# @note While this is technically a controller test, because it's testing our REST API, we're really using it as a
+# feature test to ensure end-to-end functionality for migrating collections.
+
+RSpec.describe Api::V1::CollectionsController, type: :controller do
+  let(:api_token) { create(:api_token).token }
+  let(:user) { build(:actor) }
+  let(:creator_alias) do
+    {
+      alias: "#{user.given_name} #{user.surname}",
+      actor_attributes: {
+        email: user.email,
+        given_name: user.given_name,
+        surname: user.surname,
+        psu_id: user.psu_id
+      }
+    }
+  end
+  let(:json_response) { JSON.parse(response.body) }
+  let(:new_collection) { Collection.last }
+
+  before { request.headers[:'X-API-Key'] = api_token }
+
+  describe 'POST #create' do
+    context 'with valid input' do
+      let(:works) do
+        Array.new(3).map do
+          FactoryBot.create(:work, depositor: user)
+        end
+      end
+
+      before do
+        post :create, params: {
+          metadata: {
+            title: FactoryBotHelpers.work_title,
+            work_ids: works.map(&:id),
+            creator_aliases_attributes: [creator_alias]
+          },
+          depositor: { given_name: user.given_name, surname: user.surname, email: user.email, psu_id: user.psu_id }
+        }
+      end
+
+      it 'creates a new collection' do
+        expect(response).to be_ok
+        expect(json_response).to include(
+          'message' => 'Collection was successfully created',
+          'url' => "/resources/#{new_collection.uuid}"
+        )
+      end
+    end
+
+    context 'with a legacy identifiers' do
+      let(:works) do
+        Array.new(3).map do
+          create(:legacy_identifier, :with_work, version: 3)
+        end
+      end
+
+      before do
+        post :create, params: {
+          metadata: {
+            title: FactoryBotHelpers.work_title,
+            creator_aliases_attributes: [creator_alias]
+          },
+          depositor: { given_name: user.given_name, surname: user.surname, email: user.email, psu_id: user.psu_id },
+          work_noids: works.map(&:old_id)
+        }
+      end
+
+      it 'creates a new collection with works using their legacy identifiers' do
+        expect(response).to be_ok
+        expect(json_response).to include(
+          'message' => 'Collection was successfully created',
+          'url' => "/resources/#{new_collection.uuid}"
+        )
+        expect(new_collection.works.count).to eq(3)
+      end
+    end
+
+    context 'with missing parameters' do
+      before do
+        post :create, params: {
+          metadata: { title: FactoryBotHelpers.work_title }
+        }
+      end
+
+      it 'reports the error with the missing parameter' do
+        expect(response).to be_bad_request
+        expect(json_response).to include(
+          'message' => 'Bad request',
+          'errors' => ['param is missing or the value is empty: depositor']
+        )
+      end
+    end
+
+    context 'with missing metadata' do
+      before do
+        post :create, params: {
+          metadata: { title: nil },
+          depositor: { given_name: user.given_name, surname: user.surname, email: user.email, psu_id: user.psu_id }
+        }
+      end
+
+      it 'reports the error' do
+        expect(response.status).to eq(422)
+        expect(json_response).to include(
+          'message' => 'Unable to complete the request',
+          'errors' => ["Title can't be blank"]
+        )
+      end
+    end
+
+    context 'with missing works' do
+      before do
+        post :create, params: {
+          metadata: {
+            title: FactoryBotHelpers.work_title,
+            creator_aliases_attributes: [creator_alias],
+            work_ids: ['idontexist']
+          },
+          depositor: { given_name: user.given_name, surname: user.surname, email: user.email, psu_id: user.psu_id }
+        }
+      end
+
+      it 'reports the error' do
+        expect(response.status).to eq(500)
+        expect(json_response).to include(
+          'message' => "We're sorry, but something went wrong",
+          'errors' => ['ActiveRecord::RecordNotFound', "Couldn't find Work with 'id'=[0]"]
+        )
+      end
+    end
+
+    context 'when a collection with the same noid already exists' do
+      let(:legacy_identifier) { create(:legacy_identifier, :with_collection, version: 3) }
+
+      before do
+        post :create, params: {
+          metadata: { title: FactoryBotHelpers.work_title, noid: legacy_identifier.old_id },
+          depositor: { given_name: user.given_name, surname: user.surname, email: user.email, psu_id: user.psu_id }
+        }
+      end
+
+      it 'returns the url of the previously migrated collection' do
+        expect(response.status).to eq(303)
+        expect(json_response).to include(
+          'message' => 'Collection has already been migrated',
+          'url' => "/resources/#{legacy_identifier.resource.uuid}"
+        )
+      end
+    end
+
+    context 'when there is an unexpected error' do
+      before do
+        allow(controller).to receive(:create).and_raise(NoMethodError, 'well, this is unexpected!')
+        post :create, params: {
+          metadata: { title: FactoryBotHelpers.work_title, creator_aliases_attributes: [creator_alias] },
+          depositor: { given_name: user.given_name, surname: user.surname, email: user.email, psu_id: user.psu_id }
+        }
+      end
+
+      it 'reports the error' do
+        expect(response.status).to eq(500)
+        expect(json_response).to include(
+          'message' => "We're sorry, but something went wrong",
+          'errors' => ['NoMethodError', 'well, this is unexpected!']
+        )
+      end
+    end
+  end
+end

--- a/spec/factories/legacy_identifiers.rb
+++ b/spec/factories/legacy_identifiers.rb
@@ -13,5 +13,9 @@ FactoryBot.define do
     trait :with_work do
       association :resource, factory: :work
     end
+
+    trait :with_collection do
+      association :resource, factory: :collection
+    end
   end
 end

--- a/spec/services/create_new_collection_spec.rb
+++ b/spec/services/create_new_collection_spec.rb
@@ -1,0 +1,213 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# @note This is the main service that migrates existing Scholarsphere 3 collections. It shares a lot simlarities with
+# PublishNewCollection
+
+RSpec.describe CreateNewCollection do
+  let(:user) { build(:user) }
+  let(:collection) { build(:collection, :with_complete_metadata) }
+  let(:work) { create(:work) }
+
+  let(:depositor) do
+    HashWithIndifferentAccess.new(
+      email: user.email,
+      given_name: user.actor.given_name,
+      surname: user.actor.surname,
+      psu_id: user.actor.psu_id
+    )
+  end
+
+  context 'when the depositor is the same as the creator' do
+    let(:new_collection) do
+      described_class.call(
+        metadata: HashWithIndifferentAccess.new(collection.metadata.merge(
+                                                  work_ids: [work.id],
+                                                  creator_aliases_attributes: [
+                                                    {
+                                                      alias: user.name,
+                                                      actor_attributes: {
+                                                        email: user.email,
+                                                        given_name: user.actor.given_name,
+                                                        surname: user.actor.surname,
+                                                        psu_id: user.actor.psu_id
+                                                      }
+                                                    }
+                                                  ]
+                                                )),
+        depositor: depositor
+      )
+    end
+
+    it 'creates an open access collection with complete metadata and one member work' do
+      expect(new_collection).to be_open_access
+      expect(new_collection.metadata).to eq(collection.metadata)
+      expect(new_collection.works).to contain_exactly(work)
+    end
+
+    it 'creates a new Actor record for the depositor' do
+      expect { new_collection }.to change {
+        Actor.where(psu_id: user.actor.psu_id).count
+      }.from(0).to(1)
+    end
+
+    it 'does NOT create a User record for the depositor' do
+      expect { new_collection }.not_to(
+        change { User.where(access_id: user.actor.psu_id).empty? }
+      )
+    end
+  end
+
+  context 'when the actor already exists in the system' do
+    let(:new_collection) do
+      described_class.call(
+        metadata: HashWithIndifferentAccess.new(collection.metadata.merge(
+                                                  work_ids: [work.id],
+                                                  creator_aliases_attributes: [
+                                                    {
+                                                      alias: user.name,
+                                                      actor_attributes: {
+                                                        email: user.email,
+                                                        given_name: user.actor.given_name,
+                                                        surname: user.actor.surname,
+                                                        psu_id: user.actor.psu_id
+                                                      }
+                                                    }
+                                                  ]
+                                                )),
+        depositor: depositor
+      )
+    end
+
+    before { user.save }
+
+    it 'creates a new collection' do
+      expect { new_collection }.to change(Work, :count).by(1)
+    end
+
+    it 'does NOT create an Actor record for the depositor' do
+      expect { new_collection }.not_to(
+        change { Actor.where(psu_id: user.access_id).empty? }
+      )
+    end
+
+    it 'does NOT create a User record for the depositor' do
+      expect { new_collection }.not_to(
+        change { User.where(access_id: user.actor.psu_id).empty? }
+      )
+    end
+  end
+
+  context 'when specifying additional permissions on the collection' do
+    let(:edit_user) { build(:person) }
+    let(:edit_group) { build(:group) }
+    let(:mock_client) { instance_spy('PennState::SearchService::Client') }
+    let(:new_collection) do
+      described_class.call(
+        metadata: HashWithIndifferentAccess.new(collection.metadata.merge(
+                                                  work_ids: [work.id],
+                                                  creator_aliases_attributes: [
+                                                    {
+                                                      alias: user.name,
+                                                      actor_attributes: {
+                                                        email: user.email,
+                                                        given_name: user.actor.given_name,
+                                                        surname: user.actor.surname,
+                                                        psu_id: user.actor.psu_id
+                                                      }
+                                                    }
+                                                  ]
+                                                )),
+        depositor: depositor,
+        permissions: {
+          edit_users: [edit_user.user_id],
+          edit_groups: [edit_group.name]
+        }
+      )
+    end
+
+    # @note Save specific groups and users prior to the test so our expectations reflect the changes that the service
+    # is making, as opposed to the additional changes due to an empty database.
+    before do
+      allow(PennState::SearchService::Client).to receive(:new).and_return(mock_client)
+      allow(mock_client).to receive(:userid).with(edit_user.user_id).and_return(edit_user)
+      user.save
+      Group.public_agent
+      Group.authorized_agent
+    end
+
+    it 'creates a new Group record for the edit group in the permissions parameter' do
+      expect { new_collection }.to change(Group, :count).from(2).to(3)
+    end
+
+    it 'creates a new User record for the edit user in the permissions parameter' do
+      expect { new_collection }.to change {
+        User.where(access_id: edit_user.user_id).count
+      }.from(0).to(1)
+    end
+
+    it 'creates a new Actor record for the edit user in the permissions parameter' do
+      expect { new_collection }.to change {
+        Actor.where(psu_id: edit_user.user_id).count
+      }.from(0).to(1)
+    end
+
+    it 'adds two access controls for the additional permissions, and two more for work and collection visibility' do
+      expect { new_collection }.to change(AccessControl, :count).from(0).to(4)
+    end
+  end
+
+  context 'without a required title' do
+    let(:new_collection) do
+      described_class.call(metadata: {}, depositor: depositor)
+    end
+
+    it 'does NOT save the collection' do
+      expect { new_collection }.not_to change(Work, :count)
+    end
+
+    it 'does NOT create an Actor for the depositor' do
+      pending('Need to implement transactions to rollback any changes to the database when works fail to save')
+      expect { new_collection }.not_to change(Actor, :count).by(1)
+    end
+
+    it 'does NOT create a User record for the depositor' do
+      expect { new_collection }.not_to change(User, :count)
+    end
+
+    it 'returns the collection with errors' do
+      expect(new_collection.errors.full_messages).to contain_exactly("Title can't be blank")
+    end
+  end
+
+  context 'when the collection has a NOID from Scholarpshere 3' do
+    let(:legacy_identifier) { build(:legacy_identifier) }
+
+    let(:new_collection) do
+      described_class.call(
+        metadata: HashWithIndifferentAccess.new(collection.metadata.merge(
+                                                  work_ids: [work.id],
+                                                  creator_aliases_attributes: [
+                                                    {
+                                                      alias: user.name,
+                                                      actor_attributes: {
+                                                        email: user.email,
+                                                        given_name: user.actor.given_name,
+                                                        surname: user.actor.surname,
+                                                        psu_id: user.actor.psu_id
+                                                      }
+                                                    }
+                                                  ],
+                                                  noid: legacy_identifier.old_id
+                                                )),
+        depositor: depositor
+      )
+    end
+
+    it 'creates a new work with a legacy identifier' do
+      expect(new_collection.legacy_identifiers.map(&:old_id)).to contain_exactly(legacy_identifier.old_id)
+      expect(new_collection.legacy_identifiers.map(&:version)).to contain_exactly(3)
+    end
+  end
+end

--- a/tasks/dev.rake
+++ b/tasks/dev.rake
@@ -7,5 +7,6 @@ namespace :dev do
   task clean: 'db:load_config' do
     DatabaseCleaner.clean_with(:truncation)
     Scholarsphere::Cleaner.clean
+    Rake::Task['db:seed:development:api_tokens'].invoke
   end
 end


### PR DESCRIPTION
Enables migrating collections from Scholarsphere 3. It replicates the same kind of pattern used in migrating works, and code is very similar in both places. This might need additional refactoring.