### PR TITLE
Configue DataDog for performance monitoring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,3 +75,7 @@ group :test do
   gem 'webdrivers'
   gem 'webmock'
 end
+
+group :production do
+  gem 'ddtrace', '~> 0.34'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,8 @@ GEM
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
     database_cleaner (1.7.0)
+    ddtrace (0.34.1)
+      msgpack
     debug_inspector (0.0.3)
     deprecation (1.0.0)
       activesupport
@@ -518,6 +520,7 @@ DEPENDENCIES
   capybara
   cocoon
   database_cleaner
+  ddtrace (~> 0.34)
   devise (~> 4.7)
   diffy
   factory_bot_rails

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+if ENV['DD_AGENT_HOST']
+  require 'ddtrace'
+  Datadog.configure do |c|
+    c.use :rails
+    c.use :active_record, orm_service_name: 'scholarsphere-active_record'
+    c.use :faraday, service_name: 'scholarsphere-faraday'
+    c.use :sidekiq, analytics_enabled: true
+    c.use :redis
+    c.tracer env: ENV['DD_ENV']
+  end
+end


### PR DESCRIPTION
Adds the ddtrace gem to use DataDog's APM and access configurations for Faraday, ActiveRecord, and Sidekiq.