### PR TITLE
Update test after ACL inheritance change

### DIFF
--- a/spec/services/create_new_collection_spec.rb
+++ b/spec/services/create_new_collection_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe CreateNewCollection do
     end
 
     it 'adds two access controls for the additional permissions, and two more for work and collection visibility' do
-      expect { new_collection }.to change(AccessControl, :count).from(0).to(4)
+      expect { new_collection }.to change(AccessControl, :count).from(0).to(10)
     end
   end
 


### PR DESCRIPTION
Because the collection tests were added prior to the change in ACL inheritance, this test is now breaking. We're just updating the count to reflect the additional inherited access controls to the collection.