### PR TITLE
Legacy URL support for collections

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,5 +80,9 @@ Rails.application.routes.draw do
   end
 
   # Legacy URL support
+  # Note that collections and works go to the same place. This works because the
+  # legacy IDs are unique noids. It could lead to an extraordinarily unlikely
+  # false positive, but it would never lead to a false negative.
   get '/concern/generic_works/:id', to: 'legacy_urls#v3'
+  get '/collections/:id', to: 'legacy_urls#v3'
 end

--- a/spec/request/legacy_urls_spec.rb
+++ b/spec/request/legacy_urls_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe LegacyUrlsController, type: :request do
-  let(:resource) { create :work_version }
+  describe 'Scholarsphere v3 legacy URLs to a Work/Version' do
+    let(:resource) { create :work_version }
 
-  describe 'Scholarsphere v3 legacy URLs' do
     before do
       create :legacy_identifier,
              version: 3,
@@ -39,6 +39,22 @@ RSpec.describe LegacyUrlsController, type: :request do
           get '/concern/generic_works/doesnt-exist'
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
+    end
+  end
+
+  describe 'Scholarsphere v3 legacy URLs to a Collection' do
+    let(:resource) { create :collection }
+
+    before do
+      create :legacy_identifier,
+             version: 3,
+             old_id: 'old-v3-id-456',
+             resource: resource
+    end
+
+    it do
+      get '/collections/old-v3-id-456'
+      expect(response).to redirect_to resource_path(resource.uuid)
     end
   end
 end


### PR DESCRIPTION
Closes #272

Supposing there is a Work with legacy ID `work-old-123`, and a Collection with legacy ID `col-old-789`, then the following URLs will now resolve and redirect to the appropriate `/resources/:uuid` route:

```
/concern/generic_works/work-old-123  -> redirects to /resources/work-uuid
/collections/col-old-789 -> redirects to /resources/collection-uuid

/concern/generic_works/bad-id-that-doesnt-exist -> 404
/collections/bad-id-that-doesnt-exist -> 404
```

However, due to the way this is implemented, the following URLs will also resolve, and redirect to the correct resources route:
```
/concern/generic_works/col-old-789 -> redirects to /resources/collection-uuid
/collections/work-old-123  -> redirects to /resources/work-uuid
```

The above behavior is not exactly ideal, but given that SS3's public IDs are unique noids, I think this _extremely unlikely_ "false positive" behavior is not worth the extra development time needed to handle it. All correct legacy urls will resolve, and that's what matters.