### PR TITLE
Update RSolr to 2.3.0

### DIFF
--- a/spec/fixtures/vcr_cassettes/Scholarsphere_SolrAdmin/_collection_exists_/when_the_collection_is_NOT_present/1_7_2_1.yml
+++ b/spec/fixtures/vcr_cassettes/Scholarsphere_SolrAdmin/_collection_exists_/when_the_collection_is_NOT_present/1_7_2_1.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: <%= Scholarsphere::SolrConfig.new.url %>/solr/admin/collections?action=LIST
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '120'
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "responseHeader":{
+            "status":0,
+            "QTime":0},
+          "collections":["scholarsphere-dev"]}
+    http_version: 
+  recorded_at: Mon, 18 May 2020 18:54:30 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/Scholarsphere_SolrAdmin/_configset_exists_/when_the_config_set_is_NOT_present/1_4_2_1.yml
+++ b/spec/fixtures/vcr_cassettes/Scholarsphere_SolrAdmin/_configset_exists_/when_the_config_set_is_NOT_present/1_4_2_1.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: <%= Scholarsphere::SolrConfig.new.url %>/solr/admin/configs?action=LIST
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '134'
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "responseHeader":{
+            "status":0,
+            "QTime":1},
+          "configSets":["_default"]}
+    http_version: 
+  recorded_at: Mon, 18 May 2020 18:38:55 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/Scholarsphere_SolrAdmin/_delete_collection/deletes_a_collection.yml
+++ b/spec/fixtures/vcr_cassettes/Scholarsphere_SolrAdmin/_delete_collection/deletes_a_collection.yml
@@ -1,0 +1,31 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: <%= Scholarsphere::SolrConfig.new.url %>/solr/admin/collections?action=DELETE&name=mycollection
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '532'
+    body:
+      encoding: UTF-8
+      string: |
+        {}
+    http_version: 
+  recorded_at: Mon, 18 May 2020 18:55:21 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/Scholarsphere_SolrAdmin/_delete_configset/deletes_a_config_set.yml
+++ b/spec/fixtures/vcr_cassettes/Scholarsphere_SolrAdmin/_delete_configset/deletes_a_config_set.yml
@@ -1,0 +1,31 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: <%= Scholarsphere::SolrConfig.new.url %>/solr/admin/configs?action=DELETE&name=myconfigset
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '676'
+    body:
+      encoding: UTF-8
+      string: |
+        {}
+    http_version: 
+  recorded_at: Mon, 18 May 2020 18:43:11 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/Scholarsphere_SolrAdmin/collection_present.yml
+++ b/spec/fixtures/vcr_cassettes/Scholarsphere_SolrAdmin/collection_present.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: <%= config.url %>/solr/admin/collections?action=LIST
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '120'
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "responseHeader":{
+            "status":0,
+            "QTime":0},
+          "collections":["scholarsphere-dev",
+          "<%= config.collection_name %>"]}
+    http_version: null
+  recorded_at: Tue, 19 May 2020 19:42:15 GMT
+recorded_with: VCR 5.1.0

--- a/spec/fixtures/vcr_cassettes/Scholarsphere_SolrAdmin/config_set_present.yml
+++ b/spec/fixtures/vcr_cassettes/Scholarsphere_SolrAdmin/config_set_present.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: <%= config.url %>/solr/admin/configs?action=LIST
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '134'
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "responseHeader":{
+            "status":0,
+            "QTime":1},
+          "configSets":["_default",
+          "<%= config.configset_name %>"]}
+    http_version: 
+  recorded_at: Mon, 18 May 2020 18:34:55 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/Scholarsphere_SolrAdmin/create_collection_using_defaults.yml
+++ b/spec/fixtures/vcr_cassettes/Scholarsphere_SolrAdmin/create_collection_using_defaults.yml
@@ -1,0 +1,31 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: <%= config.url %>/solr/admin/collections?action=CREATE&collection.configName=<%= config.configset_name %>&name=<%= config.collection_name %>&numShards=<%= config.num_shards %>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '547'
+    body:
+      encoding: UTF-8
+      string: |
+        {}
+    http_version: 
+  recorded_at: Mon, 18 May 2020 18:56:45 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/Scholarsphere_SolrAdmin/modify_collection_using_defaults.yml
+++ b/spec/fixtures/vcr_cassettes/Scholarsphere_SolrAdmin/modify_collection_using_defaults.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: <%= config.url %>/solr/admin/collections?action=MODIFYCOLLECTION&collection=<%= config.collection_name %>&collection.configName=<%= config.configset_name %>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '169'
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "responseHeader":{
+            "status":0,
+            "QTime":170},
+          "success":{
+            "172.19.0.2:8983_solr":{
+              "responseHeader":{
+                "status":0,
+                "QTime":146}}}}
+    http_version: 
+  recorded_at: Mon, 18 May 2020 18:57:35 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/Scholarsphere_SolrAdmin/upload_collection_using_defaults.yml
+++ b/spec/fixtures/vcr_cassettes/Scholarsphere_SolrAdmin/upload_collection_using_defaults.yml
@@ -1,0 +1,33 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: <%= config.url %>/solr/admin/configs?action=UPLOAD&name=<%= config.configset_name %>
+    body:
+      encoding: UTF-8
+      string: zipfile-data
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - octect/stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '331'
+    body:
+      encoding: UTF-8
+      string: |
+        {}
+    http_version: 
+  recorded_at: Mon, 18 May 2020 19:03:03 GMT
+recorded_with: VCR 5.0.0

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -9,4 +9,5 @@ VCR.configure do |c|
   c.allow_http_connections_when_no_cassette = true
   c.ignore_localhost = true
   c.debug_logger = File.open('log/vcr.log', 'w')
+  c.default_cassette_options = { erb: true, update_content_length_header: true }
 end


### PR DESCRIPTION
The update broke our tests for SolrAdmin. Switching over to VCR instead of WebMock fixes this and makes the tests a bit easier to deal with in the future.