### PR TITLE
Make PSU resources discoverable

### DIFF
--- a/app/models/concerns/permissions.rb
+++ b/app/models/concerns/permissions.rb
@@ -78,14 +78,18 @@ module Permissions
 
     revoke_open_access
     grant_read_access(Group.authorized_agent)
+    grant_discover_access(Group.public_agent)
   end
 
   def revoke_authorized_access
     revoke_read_access(Group.authorized_agent)
+    revoke_discover_access(Group.public_agent)
   end
 
   def authorized_access?
-    discover_access?(Group.authorized_agent) && read_access?(Group.authorized_agent)
+    discover_access?(Group.authorized_agent) &&
+      read_access?(Group.authorized_agent) &&
+      discover_access?(Group.public_agent)
   end
 
   def visibility

--- a/app/policies/work_policy.rb
+++ b/app/policies/work_policy.rb
@@ -11,6 +11,6 @@ class WorkPolicy < ApplicationPolicy
   end
 
   def show?
-    record.read_access? user
+    record.discover_access? user
   end
 end

--- a/app/schemas/permissions_schema.rb
+++ b/app/schemas/permissions_schema.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class PermissionsSchema < BaseSchema
-  delegate :discover_users, :discover_groups, :read_users, :read_groups, :visibility, to: :resource
+  delegate :discover_users, :discover_groups, :visibility, to: :resource
 
   def document
     {
-      discover_users_ssim: (discover_users + read_users).map(&:access_id).uniq,
-      discover_groups_ssim: (discover_groups + read_groups).map(&:name).uniq,
+      discover_users_ssim: discover_users.map(&:access_id).uniq,
+      discover_groups_ssim: discover_groups.map(&:name).uniq,
       visibility_ssi: visibility
     }
   end

--- a/spec/features/discovery_search_spec.rb
+++ b/spec/features/discovery_search_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Searching discoverable resources' do
   let!(:authorized_collection) { create(:collection, visibility: Permissions::Visibility::AUTHORIZED) }
 
   context 'with a public user' do
-    it 'searches only public works' do
+    it 'searches public and Penn State works' do
       visit search_catalog_path
       click_button('Search')
 
@@ -20,8 +20,8 @@ RSpec.describe 'Searching discoverable resources' do
       expect(page).to have_content(previous_embargoed_work.latest_published_version.title)
       expect(page).to have_content(public_collection.title)
       expect(page).not_to have_content(current_embargoed_work.latest_published_version.title)
-      expect(page).not_to have_content(authorized_work.latest_published_version.title)
-      expect(page).not_to have_content(authorized_collection.title)
+      expect(page).to have_content(authorized_work.latest_published_version.title)
+      expect(page).to have_content(authorized_collection.title)
     end
   end
 
@@ -52,7 +52,9 @@ RSpec.describe 'Searching discoverable resources' do
       ).to contain_exactly(
         public_work.uuid,
         previous_embargoed_work.uuid,
-        public_collection.uuid
+        public_collection.uuid,
+        authorized_work.uuid,
+        authorized_collection.uuid
       )
     end
   end

--- a/spec/policies/work_policy_spec.rb
+++ b/spec/policies/work_policy_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe WorkPolicy, type: :policy do
 
   describe '#show?' do
     it 'delegates to Work#read_access?' do
-      allow(work).to receive(:read_access?)
-        .with(user).and_return(:whatever_read_access_returns)
+      allow(work).to receive(:discover_access?)
+        .with(user).and_return(:whatever_discover_access_returns)
 
-      expect(described_class.new(user, work).show?).to eq :whatever_read_access_returns
+      expect(described_class.new(user, work).show?).to eq :whatever_discover_access_returns
     end
   end
 end

--- a/spec/support/shared/a_resource_with_permissions.rb
+++ b/spec/support/shared/a_resource_with_permissions.rb
@@ -104,7 +104,8 @@ RSpec.shared_examples 'a resource with permissions' do
         resource.grant_authorized_access
         expect(resource.access_controls).to contain_exactly(
           an_access_control_for(agent: Group.authorized_agent, access_level: AccessControl::Level::READ),
-          an_access_control_for(agent: Group.authorized_agent, access_level: AccessControl::Level::DISCOVER)
+          an_access_control_for(agent: Group.authorized_agent, access_level: AccessControl::Level::DISCOVER),
+          an_access_control_for(agent: Group.public_agent, access_level: AccessControl::Level::DISCOVER)
         )
       end
     end
@@ -115,12 +116,14 @@ RSpec.shared_examples 'a resource with permissions' do
       it 'does not add any duplicate access controls' do
         expect(resource.access_controls).to contain_exactly(
           an_access_control_for(agent: Group.authorized_agent, access_level: AccessControl::Level::READ),
-          an_access_control_for(agent: Group.authorized_agent, access_level: AccessControl::Level::DISCOVER)
+          an_access_control_for(agent: Group.authorized_agent, access_level: AccessControl::Level::DISCOVER),
+          an_access_control_for(agent: Group.public_agent, access_level: AccessControl::Level::DISCOVER)
         )
         resource.grant_authorized_access
         expect(resource.access_controls).to contain_exactly(
           an_access_control_for(agent: Group.authorized_agent, access_level: AccessControl::Level::READ),
-          an_access_control_for(agent: Group.authorized_agent, access_level: AccessControl::Level::DISCOVER)
+          an_access_control_for(agent: Group.authorized_agent, access_level: AccessControl::Level::DISCOVER),
+          an_access_control_for(agent: Group.public_agent, access_level: AccessControl::Level::DISCOVER)
         )
       end
     end
@@ -132,7 +135,8 @@ RSpec.shared_examples 'a resource with permissions' do
     it 'removes authorized access' do
       expect(resource.access_controls).to contain_exactly(
         an_access_control_for(agent: Group.authorized_agent, access_level: AccessControl::Level::READ),
-        an_access_control_for(agent: Group.authorized_agent, access_level: AccessControl::Level::DISCOVER)
+        an_access_control_for(agent: Group.authorized_agent, access_level: AccessControl::Level::DISCOVER),
+        an_access_control_for(agent: Group.public_agent, access_level: AccessControl::Level::DISCOVER)
       )
       resource.revoke_authorized_access
       expect(resource.access_controls).to be_empty
@@ -504,7 +508,10 @@ RSpec.shared_examples 'a resource with permissions' do
       subject(:resource) { authorized_resource }
 
       its(:read_groups) { is_expected.to contain_exactly(group1, group2, Group.authorized_agent) }
-      its(:discover_groups) { is_expected.to contain_exactly(group1, group2, Group.authorized_agent) }
+
+      its(:discover_groups) do
+        is_expected.to contain_exactly(group1, group2, Group.authorized_agent, Group.public_agent)
+      end
     end
 
     context 'with a private resource' do


### PR DESCRIPTION
Grants discover access to the public for resources marked "Penn State Only." This enables non authenticated users to view the metadata for works and collections that have Penn State visibility. Downloading of content is still blocked.

Fixes #289 