### PR TITLE
Add localhost and ngrok to our whitelisted hosts

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,7 @@ Metrics/BlockLength:
     - 'app/views/catalog/index.json.jbuilder'
     - 'config/routes.rb'
     - 'config/environments/production.rb'
+    - 'config/environments/development.rb'
     - 'spec/**/*'
 
 Rails/FilePath:

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,6 +3,10 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Whitelisted hosts
+  config.hosts << 'localhost'
+  config.hosts << /.*ngrok\.io$/
+
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.


### PR DESCRIPTION
This is for development ONLY. Localhost is obvious, but using ngrok allows us to send requests from *anywhere* to our local machine for testing and debugging. Hugely helpful for debugging, demoing, etc.