### PR TITLE
Log API exceptions

### DIFF
--- a/app/controllers/api/v1/collections_controller.rb
+++ b/app/controllers/api/v1/collections_controller.rb
@@ -2,15 +2,6 @@
 
 module Api::V1
   class CollectionsController < RestController
-    rescue_from StandardError do |exception|
-      if exception.is_a?(ActionController::ParameterMissing)
-        render json: { message: 'Bad request', errors: [exception.message] }, status: :bad_request
-      else
-        render json: { message: "We're sorry, but something went wrong", errors: [exception.class.to_s, exception] },
-               status: :internal_server_error
-      end
-    end
-
     before_action :return_migrated_collection
 
     def create

--- a/app/controllers/api/v1/ingest_controller.rb
+++ b/app/controllers/api/v1/ingest_controller.rb
@@ -2,15 +2,6 @@
 
 module Api::V1
   class IngestController < RestController
-    rescue_from StandardError do |exception|
-      if exception.is_a?(ActionController::ParameterMissing)
-        render json: { message: 'Bad request', errors: [exception.message] }, status: :bad_request
-      else
-        render json: { message: "We're sorry, but something went wrong", errors: [exception.class.to_s, exception] },
-               status: :internal_server_error
-      end
-    end
-
     before_action :return_migrated_work
 
     def create

--- a/app/controllers/api/v1/rest_controller.rb
+++ b/app/controllers/api/v1/rest_controller.rb
@@ -2,9 +2,19 @@
 
 module Api
   module V1
-    class RestController < ActionController::Base
-      skip_forgery_protection
+    class RestController < ActionController::API
       before_action :authenticate_request!
+
+      rescue_from StandardError do |exception|
+        logger.error("\n\n\n#{exception.class} (#{exception.message}):\n\n")
+        logger.error(exception.backtrace.join("\n"))
+        if exception.is_a?(ActionController::ParameterMissing)
+          render json: { message: 'Bad request', errors: [exception.message] }, status: :bad_request
+        else
+          render json: { message: "We're sorry, but something went wrong", errors: [exception.class.to_s, exception] },
+                 status: :internal_server_error
+        end
+      end
 
       private
 

--- a/spec/controllers/api/v1/collections_controller_spec.rb
+++ b/spec/controllers/api/v1/collections_controller_spec.rb
@@ -152,23 +152,5 @@ RSpec.describe Api::V1::CollectionsController, type: :controller do
         )
       end
     end
-
-    context 'when there is an unexpected error' do
-      before do
-        allow(controller).to receive(:create).and_raise(NoMethodError, 'well, this is unexpected!')
-        post :create, params: {
-          metadata: { title: FactoryBotHelpers.work_title, creator_aliases_attributes: [creator_alias] },
-          depositor: { given_name: user.given_name, surname: user.surname, email: user.email, psu_id: user.psu_id }
-        }
-      end
-
-      it 'reports the error' do
-        expect(response.status).to eq(500)
-        expect(json_response).to include(
-          'message' => "We're sorry, but something went wrong",
-          'errors' => ['NoMethodError', 'well, this is unexpected!']
-        )
-      end
-    end
   end
 end

--- a/spec/controllers/api/v1/ingest_controller_spec.rb
+++ b/spec/controllers/api/v1/ingest_controller_spec.rb
@@ -155,26 +155,5 @@ RSpec.describe Api::V1::IngestController, type: :controller do
         )
       end
     end
-
-    context 'when there is an unexpected error' do
-      before do
-        allow(controller).to receive(:create).and_raise(NoMethodError, 'well, this is unexpected!')
-        post :create, params: {
-          metadata: { title: FactoryBotHelpers.work_title, creator_aliases_attributes: [creator_alias] },
-          depositor: { given_name: user.given_name, surname: user.surname, email: user.email, psu_id: user.psu_id },
-          content: [{ file: fixture_file_upload(File.join(fixture_path, 'image.png')) }]
-        }
-      end
-
-      it 'reports the error' do
-        expect(response.status).to eq(500)
-        expect(response.body).to eq(
-          '{' \
-            "\"message\":\"We're sorry, but something went wrong\"," \
-            '"errors":["NoMethodError","well, this is unexpected!"]' \
-          '}'
-        )
-      end
-    end
   end
 end


### PR DESCRIPTION
Before rendering our json response, log the exception so that we can track it.

Fixes #319 