### PR TITLE
Manage work types using a string enum

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ group :test do
   gem 'rspec-its'
   gem 'rspec-rails', '~> 4.0.0.beta3'
   gem 'selenium-webdriver'
-  gem 'shoulda-matchers', '~> 3.1'
+  gem 'shoulda-matchers', '~> 4.3'
   gem 'simplecov', require: false
   gem 'vcr'
   gem 'webdrivers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -421,8 +421,8 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     sexp_processor (4.14.1)
-    shoulda-matchers (3.1.3)
-      activesupport (>= 4.0.0)
+    shoulda-matchers (4.3.0)
+      activesupport (>= 4.2.0)
     shrine (3.2.1)
       content_disposition (~> 1.0)
       down (~> 5.1)
@@ -537,7 +537,7 @@ DEPENDENCIES
   scholarsphere-client!
   seedbank
   selenium-webdriver
-  shoulda-matchers (~> 3.1)
+  shoulda-matchers (~> 4.3)
   shrine (~> 3.0)
   sidekiq (~> 6.0)
   simplecov

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -34,10 +34,34 @@ class Work < ApplicationRecord
   accepts_nested_attributes_for :versions
 
   module Types
-    DATASET = 'dataset'
-
     def self.all
-      [DATASET]
+      %w[
+        article
+        audio
+        book
+        capstone_project
+        conference_proceeding
+        dataset
+        dissertation
+        image
+        journal
+        map_or_cartographic_material
+        masters_culminating_experience
+        masters_thesis
+        other
+        part_of_book
+        poster
+        presentation
+        project
+        report
+        research_paper
+        software_or_program_code
+        video
+      ].freeze
+    end
+
+    def self.default
+      'dataset'
     end
 
     def self.display(type)
@@ -51,9 +75,10 @@ class Work < ApplicationRecord
     end
   end
 
+  enum work_type: Types.all.zip(Types.all).to_h
+
   validates :work_type,
-            presence: true,
-            inclusion: { in: Types.all }
+            presence: true
 
   validates :versions,
             presence: true

--- a/app/services/publish_new_work.rb
+++ b/app/services/publish_new_work.rb
@@ -41,7 +41,7 @@ class PublishNewWork
     end
 
     params = {
-      work_type: metadata.delete(:work_type) { Work::Types::DATASET },
+      work_type: metadata.delete(:work_type) { Work::Types.default },
       visibility: metadata.delete(:visibility) { Permissions::Visibility::OPEN },
       embargoed_until: metadata.delete(:embargoed_until),
       depositor: depositor_actor,

--- a/lib/data_cite/metadata.rb
+++ b/lib/data_cite/metadata.rb
@@ -11,7 +11,7 @@ module DataCite
     attr_writer :public_url_source
 
     RESOURCE_TYPES = {
-      Work::Types::DATASET => 'Dataset'
+      'dataset' => 'Dataset'
     }.freeze
 
     def initialize(work_version:, public_identifier:)

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :work do
     association :depositor, :with_user, factory: :actor
-    work_type { Work::Types.all.first }
+    work_type { Work::Types.default }
     visibility { Permissions::Visibility.default }
 
     # Postgres does this for us, but for testing, we can do it here to save having to call create/reload.

--- a/spec/lib/data_cite/metadata_spec.rb
+++ b/spec/lib/data_cite/metadata_spec.rb
@@ -75,9 +75,7 @@ RSpec.describe DataCite::Metadata do
     end
 
     context 'when given variants of the work_type' do
-      context 'when work_type is DATASET' do
-        before { allow(work).to receive(:work_type).and_return(Work::Types::DATASET) }
-
+      context 'with the default work type' do
         it 'maps to the correct resource type' do
           expect(attributes.dig(:types, :resourceTypeGeneral)).to eq 'Dataset'
         end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Work, type: :model do
 
   describe 'associations' do
     it { is_expected.to belong_to(:depositor).class_name('Actor').with_foreign_key(:depositor_id).inverse_of(:deposited_works) }
-    it { is_expected.to belong_to(:proxy_depositor).class_name('Actor').with_foreign_key(:proxy_id).inverse_of(:proxy_deposited_works) }
+    it { is_expected.to belong_to(:proxy_depositor).class_name('Actor').with_foreign_key(:proxy_id).inverse_of(:proxy_deposited_works).optional }
     it { is_expected.to have_many(:access_controls) }
     it { is_expected.to have_many(:versions).class_name('WorkVersion').inverse_of('work') }
     it { is_expected.to have_many(:legacy_identifiers) }
@@ -36,7 +36,7 @@ RSpec.describe Work, type: :model do
   end
 
   describe 'validations' do
-    it { is_expected.to validate_inclusion_of(:work_type).in_array(Work::Types.all) }
+    it { is_expected.to validate_presence_of(:work_type) }
     it { is_expected.to validate_presence_of(:versions) }
   end
 
@@ -46,23 +46,79 @@ RSpec.describe Work, type: :model do
     describe '.all' do
       subject(:all) { types.all }
 
-      it { is_expected.to match_array [types::DATASET] }
+      specify do
+        expect(all).to contain_exactly(
+          'article',
+          'audio',
+          'book',
+          'capstone_project',
+          'conference_proceeding',
+          'dataset',
+          'dissertation',
+          'image',
+          'journal',
+          'map_or_cartographic_material',
+          'masters_culminating_experience',
+          'masters_thesis',
+          'other',
+          'part_of_book',
+          'poster',
+          'presentation',
+          'project',
+          'report',
+          'research_paper',
+          'software_or_program_code',
+          'video'
+        )
+      end
+    end
+
+    describe '.default' do
+      subject { types.default }
+
+      it { is_expected.to eq('dataset') }
     end
 
     describe '.options_for_select_box' do
       subject(:options) { types.options_for_select_box }
 
-      it { is_expected.to eq [['Dataset', types::DATASET]] }
+      it { is_expected.to include(['Dataset', 'dataset'], ['Part Of Book', 'part_of_book']) }
     end
 
     describe '.display' do
       it 'returns a human-readable version of the type' do
-        {
-          types::DATASET => 'Dataset'
-        }.each do |type, expected_output|
-          expect(types.display(type)).to eq expected_output
-        end
+        expect(types.display(types.default)).to eq('Dataset')
       end
+    end
+  end
+
+  describe '#work_type' do
+    specify do
+      expect(described_class.new).to define_enum_for(:work_type)
+        .with_values(
+          article: 'article',
+          audio: 'audio',
+          book: 'book',
+          capstone_project: 'capstone_project',
+          conference_proceeding: 'conference_proceeding',
+          dataset: 'dataset',
+          dissertation: 'dissertation',
+          image: 'image',
+          journal: 'journal',
+          map_or_cartographic_material: 'map_or_cartographic_material',
+          masters_culminating_experience: 'masters_culminating_experience',
+          masters_thesis: 'masters_thesis',
+          other: 'other',
+          part_of_book: 'part_of_book',
+          poster: 'poster',
+          presentation: 'presentation',
+          project: 'project',
+          report: 'report',
+          research_paper: 'research_paper',
+          software_or_program_code: 'software_or_program_code',
+          video: 'video'
+        )
+        .backed_by_column_of_type(:string)
     end
   end
 


### PR DESCRIPTION
Instead of using the standard integer to mark an enum's value, use a actual string. This way the value in the database is more informative, and we get all the bonus parts of the enum feature.