### PR TITLE
Specify UTC timezone for embargo date tests

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -114,7 +114,7 @@ class Work < ApplicationRecord
   def embargoed?
     return false if embargoed_until.blank?
 
-    embargoed_until > DateTime.now
+    embargoed_until > Time.zone.now
   end
 
   private

--- a/spec/components/embargo_detail_component_spec.rb
+++ b/spec/components/embargo_detail_component_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe EmbargoDetailComponent, type: :component do
   let(:content) { render_inline(described_class.new(work_version: work_version)).to_s }
-  let(:embargo_date) { DateTime.now + 6.days }
+  let(:embargo_date) { Time.zone.now + 6.days }
   let(:work) { build(:work, embargoed_until: embargo_date) }
   let(:user) { build(:user) }
   let(:controller_name) { 'application' }

--- a/spec/features/discovery_search_spec.rb
+++ b/spec/features/discovery_search_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 RSpec.describe 'Searching discoverable resources' do
   let!(:public_work) { create(:work, has_draft: false) }
   let!(:authorized_work) { create(:work, visibility: Permissions::Visibility::AUTHORIZED, has_draft: false) }
-  let!(:current_embargoed_work) { create(:work, has_draft: false, embargoed_until: (DateTime.now + 6.days)) }
-  let!(:previous_embargoed_work) { create(:work, has_draft: false, embargoed_until: (DateTime.now - 6.days)) }
+  let!(:current_embargoed_work) { create(:work, has_draft: false, embargoed_until: (Time.zone.now + 6.days)) }
+  let!(:previous_embargoed_work) { create(:work, has_draft: false, embargoed_until: (Time.zone.now - 6.days)) }
 
   let!(:public_collection) { create(:collection, visibility: Permissions::Visibility::OPEN) }
   let!(:authorized_collection) { create(:collection, visibility: Permissions::Visibility::AUTHORIZED) }

--- a/spec/lib/json_log_formatter_spec.rb
+++ b/spec/lib/json_log_formatter_spec.rb
@@ -25,12 +25,12 @@ RSpec.describe JSONLogFormatter do
   describe '#call' do
     it 'returns a json string when passed hash' do
       msg = { "foo": 'bar' }
-      expect(described_class.new.call('INFO', Time.now, 'foo', msg)).to be_a(String)
+      expect(described_class.new.call('INFO', Time.zone.now, 'foo', msg)).to be_a(String)
     end
 
     it 'returns a nested json object when passed a json-encodable string' do
       msg = { "foo": 'bar' }.to_json
-      parsed_message = JSON.parse(described_class.new.call('INFO', Time.now, 'foo', msg))
+      parsed_message = JSON.parse(described_class.new.call('INFO', Time.zone.now, 'foo', msg))
       expect(parsed_message).to have_key('type')
       expect(parsed_message).to have_key('time')
       expect(parsed_message).to have_key('msg')
@@ -39,7 +39,7 @@ RSpec.describe JSONLogFormatter do
 
     it 'retains the message value as msg object when passed a string' do
       msg = 'This thing totally broke'
-      parsed_message = JSON.parse(described_class.new.call('INFO', Time.now, 'foo', msg))
+      parsed_message = JSON.parse(described_class.new.call('INFO', Time.zone.now, 'foo', msg))
       expect(parsed_message['msg']).to eq(msg)
     end
   end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -294,13 +294,13 @@ RSpec.describe Work, type: :model do
     end
 
     context 'with an embargoed public work' do
-      subject { build(:work, has_draft: false, embargoed_until: (DateTime.now + 6.days)) }
+      subject { build(:work, has_draft: false, embargoed_until: (Time.zone.now + 6.days)) }
 
       it { is_expected.to be_embargoed }
     end
 
     context 'with an previously embargoed public work' do
-      subject { build(:work, has_draft: false, embargoed_until: (DateTime.now - 6.months)) }
+      subject { build(:work, has_draft: false, embargoed_until: (Time.zone.now - 6.months)) }
 
       it { is_expected.not_to be_embargoed }
     end

--- a/spec/policies/work_version_policy_spec.rb
+++ b/spec/policies/work_version_policy_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe WorkVersionPolicy, type: :policy do
       end
 
       context 'with an embargoed public work' do
-        let(:work) { create(:work, embargoed_until: (DateTime.now + 6.days), has_draft: false) }
+        let(:work) { create(:work, embargoed_until: (Time.zone.now + 6.days), has_draft: false) }
         let(:work_version) { work.versions[0] }
 
         it { is_expected.not_to permit(user, work_version) }
@@ -92,14 +92,14 @@ RSpec.describe WorkVersionPolicy, type: :policy do
       end
 
       context 'with an embargoed public work' do
-        let(:work) { create(:work, has_draft: false, depositor: someone_else.actor, embargoed_until: (DateTime.now + 6.days)) }
+        let(:work) { create(:work, has_draft: false, depositor: someone_else.actor, embargoed_until: (Time.zone.now + 6.days)) }
         let(:work_version) { work.versions[0] }
 
         it { is_expected.not_to permit(me, work_version) }
       end
 
       context 'with an embargoed work I deposited' do
-        let(:work) { create(:work, has_draft: false, depositor: me.actor, embargoed_until: (DateTime.now + 6.days)) }
+        let(:work) { create(:work, has_draft: false, depositor: me.actor, embargoed_until: (Time.zone.now + 6.days)) }
         let(:work_version) { work.versions[0] }
 
         it { is_expected.to permit(me, work_version) }
@@ -110,7 +110,7 @@ RSpec.describe WorkVersionPolicy, type: :policy do
           create :work,
                  has_draft: false,
                  depositor: someone_else.actor,
-                 embargoed_until: (DateTime.now + 6.days),
+                 embargoed_until: (Time.zone.now + 6.days),
                  edit_users: [me]
         end
         let(:work_version) { work.versions[0] }

--- a/spec/services/publish_new_work_spec.rb
+++ b/spec/services/publish_new_work_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe PublishNewWork do
                                                       }
                                                     }
                                                   ],
-                                                  embargoed_until: (DateTime.now + 2.months)
+                                                  embargoed_until: (Time.zone.now + 2.months)
                                                 )),
         depositor: depositor,
         content: [

--- a/spec/support/shared/a_downloadable_work_version.rb
+++ b/spec/support/shared/a_downloadable_work_version.rb
@@ -27,7 +27,7 @@ RSpec.shared_examples 'a downloadable work version' do
       end
 
       context 'with an embargoed public work' do
-        let(:work) { create(:work, embargoed_until: (DateTime.now + 6.days), has_draft: false) }
+        let(:work) { create(:work, embargoed_until: (Time.zone.now + 6.days), has_draft: false) }
         let(:work_version) { work.versions[0] }
 
         it { is_expected.not_to permit(user, work_version) }
@@ -73,14 +73,14 @@ RSpec.shared_examples 'a downloadable work version' do
       end
 
       context 'with an embargoed public work' do
-        let(:work) { create(:work, has_draft: false, depositor: someone_else.actor, embargoed_until: (DateTime.now + 6.days)) }
+        let(:work) { create(:work, has_draft: false, depositor: someone_else.actor, embargoed_until: (Time.zone.now + 6.days)) }
         let(:work_version) { work.versions[0] }
 
         it { is_expected.not_to permit(me, work_version) }
       end
 
       context 'with an embargoed work I deposited' do
-        let(:work) { create(:work, has_draft: false, depositor: me.actor, embargoed_until: (DateTime.now + 6.days)) }
+        let(:work) { create(:work, has_draft: false, depositor: me.actor, embargoed_until: (Time.zone.now + 6.days)) }
         let(:work_version) { work.versions[0] }
 
         it { is_expected.to permit(me, work_version) }
@@ -91,7 +91,7 @@ RSpec.shared_examples 'a downloadable work version' do
           create :work,
                  has_draft: false,
                  depositor: someone_else.actor,
-                 embargoed_until: (DateTime.now + 6.days),
+                 embargoed_until: (Time.zone.now + 6.days),
                  edit_users: [me]
         end
         let(:work_version) { work.versions[0] }


### PR DESCRIPTION
Because Rails converts to UTC time by default, the times were off by a few hours (Eastern time versus zulu time) and the test would only catch the difference late at night.

Fixes #339 

Question: Do we want to configure the application to store timestamps in local time?