### PR TITLE
Require Lograge sql extension after initialization

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -91,8 +91,11 @@ Rails.application.configure do
   end
 
   if ENV['LOGRAGE_ENABLED'].present?
-    require 'lograge/sql/extension'
     config.lograge.enabled = true
+
+    config.after_initialize do
+      require 'lograge/sql/extension'
+    end
   end
 
   if ENV['RAILS_LOG_JSON'].present?


### PR DESCRIPTION
This fixes a bug introduced in cc9252dbb9503c4143148a6e7e9d18da7ee17ba2 where Rails wouldn't initialize because we were loading the Lograge sql extension at the wrong time, before Rails itself had finished initializing.