### PR TITLE
Display deposited dates instead of creation dates

### DIFF
--- a/app/components/collection_metadata_component.rb
+++ b/app/components/collection_metadata_component.rb
@@ -27,7 +27,7 @@ class CollectionMetadataComponent < ActionView::Component::Base
     :based_near,
     :related_url,
     :source,
-    :created_at
+    :deposited_at
   ].freeze
 
   def initialize(collection:)

--- a/app/components/work_version_metadata_component.rb
+++ b/app/components/work_version_metadata_component.rb
@@ -29,13 +29,13 @@ class WorkVersionMetadataComponent < ActionView::Component::Base
     :based_near,
     :related_url,
     :source,
-    :created_at
+    :deposited_at
   ].freeze
 
   MINI_ATTRIBUTES = [
     :title,
     :creator_aliases,
-    :created_at
+    :deposited_at
   ].freeze
 
   def initialize(work_version:, mini: false)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -114,7 +114,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'aasm_state_tesim', label: 'Status'
     config.add_index_field 'keyword_tesim', label: 'Keywords'
     config.add_index_field 'work_type_ssim', label: 'Work Type'
-    config.add_index_field 'created_at_dtsi', label: 'Date Created'
+    config.add_index_field 'deposited_at_dtsi', label: 'Date Deposited', helper_method: :date_display
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
@@ -136,7 +136,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'source_tesim', label: 'Source'
     config.add_show_field 'version_number_isi', label: 'Version Number'
     config.add_show_field 'version_name_tesim', label: 'Version Name'
-    config.add_show_field 'created_at_dtsi', label: 'Date Created'
+    config.add_show_field 'deposited_at_dtsi', label: 'Date Deposited'
     config.add_show_field 'updated_at_dtsi', label: 'Last Updated'
     config.add_show_field 'creator_aliases_tesim'
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,4 +6,9 @@ module ApplicationHelper
   def new_session_path(*_)
     new_user_session_path
   end
+
+  def date_display(args)
+    Time.zone.parse(args[:document][args[:field]])
+      .to_formatted_s(:long)
+  end
 end

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -157,7 +157,7 @@ class WorkVersion < ApplicationRecord
     WorkIndexer.call(work, commit: true)
   end
 
-  delegate :depositor, :proxy_depositor, :visibility, :embargoed?, :work_type, to: :work
+  delegate :depositor, :proxy_depositor, :visibility, :embargoed?, :work_type, :deposited_at, to: :work
 
   private
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -49,5 +49,7 @@ module Scholarsphere
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    config.time_zone = 'Eastern Time (US & Canada)'
   end
 end

--- a/spec/components/collection_metadata_component_spec.rb
+++ b/spec/components/collection_metadata_component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CollectionMetadataComponent, type: :component do
   describe 'rendering' do
     let(:collection) { Collection.new(
       subtitle: 'My subtitle',
-      created_at: Time.zone.parse('2020-01-15 16:07'),
+      deposited_at: Time.zone.parse('2020-01-15 16:07'),
       keyword: %w(one two),
       description: nil,
       subject: []
@@ -20,7 +20,7 @@ RSpec.describe CollectionMetadataComponent, type: :component do
     end
 
     it 'renders a date with a nice format' do
-      expect(result.css('dd.collection-created-at').text).to eq 'January 15, 2020 16:07'
+      expect(result.css('dd.collection-deposited-at').text).to eq 'January 15, 2020 16:07'
     end
 
     it 'renders a multi-value field' do
@@ -62,7 +62,7 @@ RSpec.describe CollectionMetadataComponent, type: :component do
       expect(result.css('dt.collection-based-near')).to be_present
       expect(result.css('dt.collection-related-url')).to be_present
       expect(result.css('dt.collection-source')).to be_present
-      expect(result.css('dt.collection-created-at')).to be_present
+      expect(result.css('dt.collection-deposited-at')).to be_present
       expect(result.css('dt.collection-creator-aliases')).to be_present
 
       # Test that the fields have the correct values. Please note that some of
@@ -83,7 +83,7 @@ RSpec.describe CollectionMetadataComponent, type: :component do
       expect(result.css('dd.collection-based-near').text).to include collection[:based_near].first
       expect(result.css('dd.collection-related-url').text).to include collection[:related_url].first
       expect(result.css('dd.collection-source').text).to include collection[:source].first
-      expect(result.css('dd.collection-created-at').text).to include collection[:created_at].year.to_s
+      expect(result.css('dd.collection-deposited-at').text).to include collection[:deposited_at].year.to_s
     end
   end
 end

--- a/spec/components/work_version_metadata_component_spec.rb
+++ b/spec/components/work_version_metadata_component_spec.rb
@@ -7,9 +7,10 @@ RSpec.describe WorkVersionMetadataComponent, type: :component do
   let(:result) { render_inline(described_class.new(work_version: decorated_work_version)) }
 
   describe 'rendering' do
+    let(:work) { build_stubbed :work, deposited_at: Time.zone.parse('2020-01-15 16:07') }
     let(:work_version) { build_stubbed :work_version,
+                                       work: work,
                                        subtitle: 'My subtitle',
-                                       created_at: Time.zone.parse('2020-01-15 16:07'),
                                        keyword: %w(one two),
                                        description: nil
     }
@@ -20,7 +21,7 @@ RSpec.describe WorkVersionMetadataComponent, type: :component do
     end
 
     it 'renders a date with a nice format' do
-      expect(result.css('dd.work-version-created-at').text).to eq 'January 15, 2020 16:07'
+      expect(result.css('dd.work-version-deposited-at').text).to eq 'January 15, 2020 16:07'
     end
 
     it 'renders a multi-value field' do
@@ -65,7 +66,7 @@ RSpec.describe WorkVersionMetadataComponent, type: :component do
       expect(result.css('dt.work-version-based-near')).to be_present
       expect(result.css('dt.work-version-related-url')).to be_present
       expect(result.css('dt.work-version-source')).to be_present
-      expect(result.css('dt.work-version-created-at')).to be_present
+      expect(result.css('dt.work-version-deposited-at')).to be_present
       expect(result.css('dt.work-version-creator-aliases')).to be_present
 
       # Test that the fields have the correct values. Please note that some of
@@ -89,7 +90,7 @@ RSpec.describe WorkVersionMetadataComponent, type: :component do
       expect(result.css('dd.work-version-based-near').text).to include work_version[:based_near].first
       expect(result.css('dd.work-version-related-url').text).to include work_version[:related_url].first
       expect(result.css('dd.work-version-source').text).to include work_version[:source].first
-      expect(result.css('dd.work-version-created-at').text).to include work_version[:created_at].year.to_s
+      expect(result.css('dd.work-version-deposited-at').text).to include work_version.deposited_at.year.to_s
     end
 
     context 'when mini: true' do
@@ -98,7 +99,7 @@ RSpec.describe WorkVersionMetadataComponent, type: :component do
       it 'renders just the mini fields' do
         # Titles
         expect(result.css('dt.work-version-title')).to be_present
-        expect(result.css('dt.work-version-created-at')).to be_present
+        expect(result.css('dt.work-version-deposited-at')).to be_present
         expect(result.css('dt.work-version-creator-aliases')).to be_present
         expect(result.css('dt.work-version-subtitle')).not_to be_present
         expect(result.css('dt.work-version-version-number')).not_to be_present

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -55,12 +55,17 @@ RSpec.describe 'Blacklight catalog page' do
     expect(page).to have_blacklight_label('aasm_state_tesim')
     expect(page).to have_blacklight_label('keyword_tesim')
     expect(page).to have_blacklight_label('work_type_ssim')
-    expect(page).to have_blacklight_label('created_at_dtsi')
+    expect(page).to have_blacklight_label('deposited_at_dtsi')
     indexed_resources.each do |resource|
       expect(page).to have_blacklight_field('title_tesim').with(resource.title)
       expect(page).to have_blacklight_field('creator_aliases_tesim').with(resource.creator_aliases.map(&:alias).join(', '))
       expect(page).to have_blacklight_field('keyword_tesim').with(resource.keyword.join(', '))
-      expect(page).to have_blacklight_field('created_at_dtsi').with(/^#{resource.created_at.strftime("%F")}/)
+      expect(page).to have_blacklight_field('deposited_at_dtsi').with(
+        resource
+          .deposited_at
+          .in_time_zone(Rails.configuration.time_zone)
+          .to_formatted_s(:long)
+      )
 
       # The following fields are only valid for WorkVersions, not Collections
       if resource.is_a? WorkVersion

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -140,6 +140,7 @@ RSpec.describe WorkVersion, type: :model do
   it { is_expected.to delegate_method(:proxy_depositor).to(:work) }
   it { is_expected.to delegate_method(:embargoed?).to(:work) }
   it { is_expected.to delegate_method(:work_type).to(:work) }
+  it { is_expected.to delegate_method(:deposited_at).to(:work) }
 
   describe '#uuid' do
     subject(:work_version) { create(:work_version) }

--- a/spec/services/create_new_collection_spec.rb
+++ b/spec/services/create_new_collection_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe CreateNewCollection do
     it 'creates a new collection with the specified deposit date' do
       expect(new_collection.deposited_at.strftime('%Y-%m-%d')).to eq('2017-05-11')
       expect(new_collection.deposited_at).to be_a(ActiveSupport::TimeWithZone)
-      expect(new_collection.deposited_at.zone).to eq('UTC')
+      expect(new_collection.deposited_at.zone).to eq('EDT')
     end
   end
 end

--- a/spec/services/publish_new_work_spec.rb
+++ b/spec/services/publish_new_work_spec.rb
@@ -369,7 +369,7 @@ RSpec.describe PublishNewWork do
       expect(new_work).to be_open_access
       expect(new_work.deposited_at.strftime('%Y-%m-%d')).to eq('2018-02-28')
       expect(new_work.deposited_at).to be_a(ActiveSupport::TimeWithZone)
-      expect(new_work.deposited_at.zone).to eq('UTC')
+      expect(new_work.deposited_at.zone).to eq('EST')
       expect(new_work.versions.count).to eq(1)
       expect(new_work.latest_version).to be_published
       expect(new_work.work_type).to eq('dataset')


### PR DESCRIPTION
Sets the default time zone to Eastern time and ensures that the deposited date is displayed is displayed for search results and resource pages.

Fixes #352 