### PR TITLE
Require access_id instead of email

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,9 +20,9 @@ class User < ApplicationRecord
   has_many :groups,
            through: :user_group_memberships
 
-  validates :email,
+  validates :access_id,
             presence: true,
-            uniqueness: true
+            uniqueness: { case_sensitive: false }
 
   def works
     actor.deposited_works

--- a/db/migrate/20200604125257_move_index_from_email_to_access_id_on_users.rb
+++ b/db/migrate/20200604125257_move_index_from_email_to_access_id_on_users.rb
@@ -1,0 +1,6 @@
+class MoveIndexFromEmailToAccessIdOnUsers < ActiveRecord::Migration[6.0]
+  def change
+    remove_index :users, :email
+    add_index :users, :access_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_29_134223) do
+ActiveRecord::Schema.define(version: 2020_06_04_125257) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -156,8 +156,8 @@ ActiveRecord::Schema.define(version: 2020_05_29_134223) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "actor_id", null: false
+    t.index ["access_id"], name: "index_users_on_access_id", unique: true
     t.index ["actor_id"], name: "index_users_on_actor_id"
-    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
   create_table "versions", force: :cascade do |t|

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_db_column(:uid).of_type(:string) }
     it { is_expected.to have_db_column(:actor_id) }
 
-    it { is_expected.to have_db_index(:email).unique }
+    it { is_expected.to have_db_index(:access_id).unique }
     it { is_expected.to have_db_index(:actor_id) }
   end
 
@@ -32,8 +32,8 @@ RSpec.describe User, type: :model do
   describe 'validations' do
     subject { create :user } # validate_uniqueness_of really wants this, not sure why
 
-    it { is_expected.to validate_presence_of(:email) }
-    it { is_expected.to validate_uniqueness_of(:email).case_insensitive }
+    it { is_expected.to validate_presence_of(:access_id) }
+    it { is_expected.to validate_uniqueness_of(:access_id).case_insensitive }
   end
 
   describe 'Blacklight::User' do


### PR DESCRIPTION
Access ID is the important part of a user's identity, and not the email. Also, there are cases of users without emails. The access id, however, will always be present since it is the user's identifying element.

Fixes #324