### PR TITLE
Return 422 for non-existent work noids

### DIFF
--- a/app/controllers/api/v1/collections_controller.rb
+++ b/app/controllers/api/v1/collections_controller.rb
@@ -45,17 +45,11 @@ module Api::V1
 
       def collection
         @collection ||= CreateNewCollection.call(
-          metadata: metadata_params.merge!(work_ids: work_ids),
+          metadata: metadata_params,
           depositor: depositor_params,
-          permissions: permission_params
+          permissions: permission_params,
+          work_noids: work_noid_params
         )
-      end
-
-      # @note Noids are globally unique in Scholarsphere 3, so limiting this query to collections isn't necessary.
-      def work_ids
-        work_noid_params.map { |noid| LegacyIdentifier.find_by!(old_id: noid).resource_id }
-          .concat(metadata_params.fetch(:work_ids, []))
-          .uniq
       end
 
       def metadata_params

--- a/app/services/create_new_collection.rb
+++ b/app/services/create_new_collection.rb
@@ -13,9 +13,26 @@ class CreateNewCollection
   # @param [ActionController::Parameters] metadata
   # @param [ActionController::Parameters] depositor
   # @param [ActionController::Parameters] permissions
+  # @param [Array<String>] work_noids
   # @return [Collection]
-  def self.call(metadata:, depositor:, permissions: {})
+  def self.call(metadata:, depositor:, permissions: {}, work_noids: [])
     noid = metadata.delete(:noid)
+
+    # Return early if any of the supplied noids don't exist
+    missing_noids = work_noids.reject { |work_noid| LegacyIdentifier.find_by(old_id: work_noid) }
+    if missing_noids.present?
+      collection = Collection.new
+      collection.errors.add(:legacy_identifiers, "#{missing_noids.join(', ')} were not found")
+      return collection
+    end
+
+    # Build a list of work ids from the given noids and merge those will any other supplied work_ids
+    work_ids = begin
+                 work_noids.map { |work_noid| LegacyIdentifier.find_by!(old_id: work_noid).resource_id }
+                   .concat(metadata.fetch(:work_ids, []))
+                   .uniq
+               end
+    metadata[:work_ids] = work_ids
 
     # @todo start a transaction here in case we need to rollback and remove any Actors we've created
 


### PR DESCRIPTION
When migrating collections, it's more helpful to repsond with noids that missing instead of returning the generic 500 "something went wrong" message.

Fixes #323 