### PR TITLE
Adding thesis as a work type

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -57,6 +57,7 @@ class Work < ApplicationRecord
         report
         research_paper
         software_or_program_code
+        thesis
         unspecified
         video
       ].freeze
@@ -64,6 +65,10 @@ class Work < ApplicationRecord
 
     def self.default
       'dataset'
+    end
+
+    def self.thesis
+      'thesis'
     end
 
     def self.unspecified
@@ -75,7 +80,7 @@ class Work < ApplicationRecord
     end
 
     def self.options_for_select_box
-      (all - [unspecified])
+      (all - [unspecified, thesis])
         .sort
         .map { |type| [display(type), type] }
     end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe Work, type: :model do
           'report',
           'research_paper',
           'software_or_program_code',
+          'thesis',
           'unspecified',
           'video'
         )
@@ -80,6 +81,12 @@ RSpec.describe Work, type: :model do
       subject { types.default }
 
       it { is_expected.to eq('dataset') }
+    end
+
+    describe '.thesis' do
+      subject { types.thesis }
+
+      it { is_expected.to eq('thesis') }
     end
 
     describe '.unspecified' do
@@ -126,6 +133,7 @@ RSpec.describe Work, type: :model do
           report: 'report',
           research_paper: 'research_paper',
           software_or_program_code: 'software_or_program_code',
+          thesis: 'thesis',
           unspecified: 'unspecified',
           video: 'video'
         )


### PR DESCRIPTION
The option is only available as an enum so that works will migrate from Scholarsphere 3 and not in the dropdown for new works.

Fixes #360 