### PR TITLE
User.from_omniauth does NOT persist users with incomplete metadata

### DIFF
--- a/app/models/actor.rb
+++ b/app/models/actor.rb
@@ -46,7 +46,12 @@ class Actor < ApplicationRecord
            inverse_of: :creators
 
   validates :surname,
-            presence: true
+            presence: true,
+            unless: -> { validation_context == :from_omniauth }
+
+  validates :psu_id,
+            presence: true,
+            on: :from_omniauth
 
   after_save :reindex_if_default_alias_changed
 

--- a/spec/models/actor_spec.rb
+++ b/spec/models/actor_spec.rb
@@ -33,7 +33,15 @@ RSpec.describe Actor, type: :model do
   end
 
   describe 'validations' do
-    it { is_expected.to validate_presence_of(:surname) }
+    context 'when given no validation context' do
+      it { is_expected.to validate_presence_of(:surname) }
+      it { is_expected.not_to validate_presence_of(:psu_id) }
+    end
+
+    context 'when given the from_omniauth context' do
+      it { is_expected.not_to validate_presence_of(:surname).on(:from_omniauth) }
+      it { is_expected.to validate_presence_of(:psu_id).on(:from_omniauth) }
+    end
   end
 
   describe 'after_save' do


### PR DESCRIPTION
I added a validation context specifically for Actors created via OAuth.

When an Actor is being created from the web ui (think, Creators interface)
* Surname is the only required field

When an Actor is coming in from OAuth
* PSU Access ID is the only required field

Additionally, when an Actor is created from OAuth, I modified User.from_omniauth to update the Actor's email, given_name, and surname _if and only if_ they are blank. That covers the following scenario: 
1. User logs in for the first time ever, but LDAP is behaving strangely, provides incomplete metadata, and an Actor record is created with a bunch of metadata missing.
2. User does _not_ update their profile, so their Actor record continues to have missing metadata.
3. Sometime later, they log in again, this time LDAP has its act together and provides their complete name, email, etc. Their Actor record will be updated for them.

But, imagine that same scenario above, except that in Step 2, the user goes into their profile page and provides that missing metadata. In that case, in Step 3, whatever they've provided will always persist and will never be overwritten by LDAP. So, in short, LDAP's metadata is used to initially populate an Actor record, and LDAP's metadata is used to flesh out any _missing_ metadata, but it will _never_ overwrite an existing value.

Additionally I've wrapped everything in a database transaction, so any errors along the User/Actor/Group creation process will roll back all changes made by this method.

Closes #280 
