### PR TITLE
Run MetadataListener Jobs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,3 +56,7 @@ RSpec/AnyInstance:
 Style/ClassVars:
   Exclude:
     - 'spec/system/active_job_system_spec.rb'
+
+Style/EmptyMethod:
+  Exclude:
+    - 'app/jobs/metadata_listener/job.rb'

--- a/app/controllers/api/v1/files_controller.rb
+++ b/app/controllers/api/v1/files_controller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Api::V1
+  class FilesController < RestController
+    def update
+      if update_metadata
+        render json: updated_response, status: :ok
+      else
+        render json: unprocessable_entity_response, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+      def file_resource
+        @file_resource ||= FileResource.find(params[:id])
+      end
+
+      def update_metadata
+        file_resource.file_attacher.add_metadata(metadata_params)
+        file_resource.file_attacher.write
+        file_resource.save
+      end
+
+      def updated_response
+        {
+          message: 'File was successfully updated'
+        }
+      end
+
+      def unprocessable_entity_response
+        {
+          message: 'Unable to complete the request',
+          errors: file_resource.errors.full_messages
+        }
+      end
+
+      def metadata_params
+        params
+          .require(:metadata)
+          .permit(virus: [:status, :scanned_at])
+      end
+  end
+end

--- a/app/controllers/api/v1/rest_controller.rb
+++ b/app/controllers/api/v1/rest_controller.rb
@@ -10,6 +10,8 @@ module Api
         logger.error(exception.backtrace.join("\n"))
         if exception.is_a?(ActionController::ParameterMissing)
           render json: { message: 'Bad request', errors: [exception.message] }, status: :bad_request
+        elsif exception.is_a?(ActiveRecord::RecordNotFound)
+          render json: { message: 'Record not found' }, status: :not_found
         else
           render json: { message: "We're sorry, but something went wrong", errors: [exception.class.to_s, exception] },
                  status: :internal_server_error

--- a/app/jobs/metadata_listener/job.rb
+++ b/app/jobs/metadata_listener/job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module MetadataListener
+  class Job < ApplicationJob
+    queue_as :metadata
+
+    ## Job is performed by metadata-listener
+    def perform(**args)
+    end
+  end
+end

--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -7,6 +7,27 @@ class ApiToken < ApplicationRecord
             :admin_email,
             presence: true
 
+  class << self
+    # @note Database cleaner and transactional fixtures are causing caching problems so we re-find/create each time but
+    # only in test.
+    def metadata_listener
+      if Rails.env.test?
+        find_or_create_metadata_listener
+      else
+        @metadata_listener ||= find_or_create_metadata_listener
+      end
+    end
+
+    private
+
+      def find_or_create_metadata_listener
+        find_or_create_by(
+          app_name: 'Metadata Listener',
+          admin_email: 'no-reply@scholarsphere.psu.edu'
+        )
+      end
+  end
+
   def record_usage
     update_column(:last_used_at, Time.zone.now)
   end

--- a/app/models/file_version_membership.rb
+++ b/app/models/file_version_membership.rb
@@ -27,6 +27,15 @@ class FileVersionMembership < ApplicationRecord
     }
   )
 
+  # @todo It's probably a better idea to add make our own FileUploader::UploadedFile#virus and delegate to that as we're
+  # doing with size, mime_type, and original_filename.
+  def virus
+    status = file_resource.file_data.dig('metadata', 'virus', 'status')
+    return 'unknown' if status.nil?
+
+    status
+  end
+
   private
 
     def uploader

--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -12,6 +12,14 @@ class FileUploader < Shrine
     ).to_s
   end
 
+  # @note This sets the default metadata when a file is uploaded. Virus information is nil until updated by our external
+  # metadata-listener service.
+  add_metadata do
+    {
+      virus: { status: nil, scanned_at: nil }
+    }
+  end
+
   Attacher.promote_block do
     Shrine::PromotionJob.perform_later(
       record: record,

--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -2,12 +2,31 @@
 
 class FileUploader < Shrine
   plugin :backgrounding
+  plugin :add_metadata
+
+  def self.api_endpoint(record)
+    File.join(
+      "#{Rails.application.routes.default_url_options[:protocol]}://",
+      ENV.fetch('API_URL_HOST', Rails.application.routes.default_url_options[:host]),
+      Rails.application.routes.url_helpers.api_v1_file_path(record.id)
+    ).to_s
+  end
 
   Attacher.promote_block do
     Shrine::PromotionJob.perform_later(
       record: record,
       name: name.to_s,
       file_data: file_data
+    )
+
+    # @note The metadata job is kicked off concurrently with promotion, using the same file in Shrine's cache store.
+    # This is dependent on storage bucket policies keeping those cached files for a period of time after they've been
+    # uploaded. Currently, this is 24 hours, which should be more than enough time unless the backlog of files becomes
+    # large enough that they could wait longer than that.
+    MetadataListener::Job.perform_later(
+      path: [file_data['storage'], file_data['id']].join('/'),
+      endpoint: FileUploader.api_endpoint(record),
+      api_token: ApiToken.metadata_listener.token
     )
   end
 

--- a/app/views/dashboard/file_lists/_uploaded_file_list.html.erb
+++ b/app/views/dashboard/file_lists/_uploaded_file_list.html.erb
@@ -3,6 +3,7 @@
     <tr>
       <th><%= t('dashboard.file_list.edit.name') %></th>
       <th><%= t('dashboard.file_list.edit.size') %></th>
+      <th><%= t('dashboard.file_list.edit.virus') %></th>
       <th><%= t('dashboard.file_list.edit.mime_type') %></th>
       <th><%= t('dashboard.file_list.edit.actions') %></th>
     </tr>
@@ -15,6 +16,7 @@
           <%= render 'inline_filename_editor', membership: membership %>
         </td>
         <td><%= number_to_human_size membership.size %></td>
+        <td><%= membership.virus %></td>
         <td><%= membership.mime_type %></td>
         <td>
           <%= link_to t('dashboard.file_list.edit.rename'),

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -4,8 +4,11 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Whitelisted hosts
+  # Used for local development when integrating with Docker-ized services like metadata-listener, or
+  # sending API requests via ngrok.
   config.hosts << 'localhost'
   config.hosts << /.*ngrok\.io$/
+  config.hosts << 'host.docker.internal'
 
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development

--- a/config/initializers/default_url_host.rb
+++ b/config/initializers/default_url_host.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-default_url_host = ENV['DEFAULT_URL_HOST']
-Rails.application.routes.default_url_options[:host] = default_url_host
-
-if default_url_host.blank?
-  raise "ENV['DEFAULT_URL_HOST'] is required to be set"
-end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -126,6 +126,7 @@ en:
         name: Name
         size: Size
         mime_type: Mime Type
+        virus: Virus?
         actions: Actions
         rename: Rename
         delete: Delete

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :ingest, only: [:create]
       resources :collections, only: [:create]
+      resources :files, only: [:update]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,9 @@
 require 'sidekiq/web'
 
 Rails.application.routes.draw do
+  default_url_options protocol: ENV.fetch('DEFAULT_URL_PROTOCOL', 'http'),
+                      host: ENV.fetch('DEFAULT_URL_HOST', 'localhost')
+
   mount Qa::Engine => '/authorities'
 
   namespace :admin do

--- a/config/samples/application.yml
+++ b/config/samples/application.yml
@@ -71,6 +71,7 @@ SOLR_PORT: 8983
 # Required for all environments. For development, you can set it to
 # "localhost:3000" for `bin/rails s` or "scholarsphere-4.test" for puma-dev
 DEFAULT_URL_HOST: "localhost:3000"
+DEFAULT_URL_PROTOCOL: "http"
 
 # If the oauth servers authorize path differs from /oauth/authorize, you can set that value here
 # Under normal circumstances, this shouldn't need changing

--- a/config/samples/application.yml
+++ b/config/samples/application.yml
@@ -36,64 +36,117 @@
 # DATACITE_USERNAME: ""
 # DATACITE_PASSWORD: ""
 #
-
-## Logging
+# --------------------------------------------------------------------------------------------------------------------
+#
+# Logging (production only)
+#
 # LOGRAGE_ENABLED: 
 # RAILS_LOG_JSON: 
-
-
-## ADMIN UMG
-## protects the admin namespace 
+#
+# --------------------------------------------------------------------------------------------------------------------
+#
+# Admins: all users in the given UMG are administrators
+#
 # ADMIN_GROUP: "umg/up.dlt.scholarsphere-admin"
-
-## Redis Configuration
+#
+# --------------------------------------------------------------------------------------------------------------------
+#
+# Redis Configuration (production only)
+#
+# Note: you can also add this to your development configuration to test integration with Sidekiq and other external
+# services that are run async, but it should NOT be in your test environment.
+#
 # REDIS_HOST:
 # REDIS_PORT:
 # REDIS_PASSWORD:
 # REDIS_DATABASE:
-
-## Sidekiq Configuration
+#
+# --------------------------------------------------------------------------------------------------------------------
+#
+# Sidekiq Configuration (production only)
+#
 # SIDEKIQ_QUEUE_LATENCY_THRESHOLD: 30
 # SIDEKIQ_MAX_RETRIES: 2
-
-POSTGRES_USER: "[username]" # This is typically $ whoami
-
-SOLR_HOST: localhost
-SOLR_COLLECTION: scholarsphere
-SOLR_PORT: 8983
+# 
+# --------------------------------------------------------------------------------------------------------------------
+# 
+# Solr
+#
+# SOLR_COLLECTION: scholarsphere-development
+# SOLR_HOST: localhost
+# SOLR_PORT: 8983
 # SOLR_CONFIG_DIR: solr/conf
 # SOLR_NUM_SHARDS: 1
+#
+# --------------------------------------------------------------------------------------------------------------------
+#
+# Minio: configuration used when starting minio with bin/minio
+#
 # MINIO_ACCESS_KEY: "asdf"
 # MINIO_SECRET_KEY: "asdfasdf"
 # MINIO_PORT: "9000"
-
-# Default URL host. answers the question "who am i?"
-# Required for all environments. For development, you can set it to
-# "localhost:3000" for `bin/rails s` or "scholarsphere-4.test" for puma-dev
-DEFAULT_URL_HOST: "localhost:3000"
-DEFAULT_URL_PROTOCOL: "http"
-
+#
+# --------------------------------------------------------------------------------------------------------------------
+#
+# OAuth Server
+#
 # If the oauth servers authorize path differs from /oauth/authorize, you can set that value here
 # Under normal circumstances, this shouldn't need changing
+# 
 # OAUTH_AUTHORIZE_URL: "/oauth/authorize"
-
-# Geonames
-# Username used to connect to the geonames api (https://sws.geonames.org)
+#
+# --------------------------------------------------------------------------------------------------------------------
+# 
+# Geonames: username used to connect to the geonames api (https://sws.geonames.org)
+# 
 # GEONAMES_USER: "scholarsphere_test"
+#
+# --------------------------------------------------------------------------------------------------------------------
+#
+# URLs
+#
+# Used to construct the URI to the application:
+#
+# DEFAULT_URL_HOST: "localhost:3000
+# DEFAULT_URL_PROTOCOL: "http"
+#
+# In cases where the API endpoint might differ from the actual application, we can supply one here. This is used in
+# local development where external services, like metadata-listener, that run inside a docker container needed a
+# different url to access Scholarpshere. For typical production deployments, this variable will not be needed.
+# The protocol is the same.
+#
+# API_URL_HOST: "localhost:3000"
+#
+# --------------------------------------------------------------------------------------------------------------------
 
-# Time to live for presigned download links
+# Defaults for your local development environment
 DOWNLOAD_URL_TTL: 6
+POSTGRES_USER: "[username]" # This is typically $ whoami
+SOLR_HOST: localhost
+SOLR_PORT: 8983
 
 development:
   POSTGRES_DB: "scholarsphere_4_development"
   OAUTH_APP_ID: ""
   OAUTH_APP_URL: ""
   OAUTH_APP_SECRET: ""
-  # Configure uploading via S3 or Minio (see above)
+  SOLR_COLLECTION: scholarsphere-development
+
+  # Additional configurations, see above for details:
+  # Required:
+  #  * uploading via S3 or Minio
+  #  * OAuth server
+  # Optional:
+  #  * Redis
+  #  * Geonames 
 
 test:
   POSTGRES_DB: "scholarsphere_4_test"
   OAUTH_APP_ID: ""
   OAUTH_APP_URL: ""
   OAUTH_APP_SECRET: ""
-  # Configure uploading via Minio (see above)
+  SOLR_COLLECTION: scholarsphere-test
+
+  # Additional configurations, see above for details:
+  # Required:
+  #  * uploading via Minio ONLY

--- a/lib/scholarsphere/cleaner.rb
+++ b/lib/scholarsphere/cleaner.rb
@@ -6,7 +6,7 @@ module Scholarsphere
   class Cleaner
     class << self
       def clean
-        clean_minio && clean_solr
+        clean_minio && clean_solr && clean_redis
       end
 
       def clean_minio
@@ -24,6 +24,10 @@ module Scholarsphere
         SolrAdmin.new.create_collection
       end
 
+      def clean_redis
+        redis.keys { |key| redis.del(key) }
+      end
+
       def verify_aws
         return true if aws?
 
@@ -33,6 +37,10 @@ module Scholarsphere
 
       def aws?
         system('which aws')
+      end
+
+      def redis
+        @redis ||= Redis.new(RedisConfig.new.to_hash)
       end
     end
   end

--- a/spec/controllers/api/v1/files_controller_spec.rb
+++ b/spec/controllers/api/v1/files_controller_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::FilesController, type: :controller do
+  let(:api_token) { create(:api_token).token }
+
+  before { request.headers[:'X-API-Key'] = api_token }
+
+  describe 'PATCH #update' do
+    let(:file) { create(:file_resource) }
+    let(:scan_time) { Time.zone.now.iso8601 }
+
+    context 'with valid input' do
+      before do
+        patch :update, params: {
+          id: file.id,
+          metadata: { virus: { status: false, scanned_at: scan_time } },
+          key: ApiToken.metadata_listener
+        }
+      end
+
+      it "updates the file's metadata" do
+        expect(response).to be_ok
+        expect(file.reload.file_data['metadata']).to include(
+          'virus' => { 'status' => 'false', 'scanned_at' => scan_time }
+        )
+      end
+    end
+
+    context 'when saving fails' do
+      before do
+        file.errors.add(:metadata, 'bad')
+        allow(FileResource).to receive(:find).and_return(file)
+        allow(file).to receive(:save).and_return(false)
+        patch :update, params: {
+          id: file.id,
+          metadata: { virus: { status: false, scanned_at: scan_time } },
+          key: ApiToken.metadata_listener
+        }
+      end
+
+      it 'returns an error response' do
+        expect(response.status).to eq(422)
+        expect(response.body).to eq(
+          '{"message":"Unable to complete the request","errors":["Metadata bad"]}'
+        )
+      end
+    end
+  end
+end

--- a/spec/controllers/api/v1/rest_controller_spec.rb
+++ b/spec/controllers/api/v1/rest_controller_spec.rb
@@ -47,6 +47,25 @@ RSpec.describe Api::V1::RestController, type: :controller do
     its(:body) { is_expected.to eq 'success' }
   end
 
+  context 'when a record is not found' do
+    let!(:api_key) { create :api_token }
+
+    before do
+      allow(controller).to receive(:index).and_raise(ActiveRecord::RecordNotFound)
+      request.headers[:'X-API-Key'] = api_key.token
+      get :index
+    end
+
+    it 'reports the error' do
+      expect(response.status).to eq(404)
+      expect(response.body).to eq(
+        '{' \
+        '"message":"Record not found"' \
+        '}'
+      )
+    end
+  end
+
   context 'when there is an unexpected error' do
     let!(:api_key) { create :api_token }
 

--- a/spec/lib/scholarsphere/cleaner_spec.rb
+++ b/spec/lib/scholarsphere/cleaner_spec.rb
@@ -29,4 +29,10 @@ RSpec.describe Scholarsphere::Cleaner do
       end
     end
   end
+
+  describe '#clean_redis' do
+    it 'removes all jobs from the queues' do
+      expect(described_class.clean_redis).to be_an(Array)
+    end
+  end
 end

--- a/spec/models/file_resource_spec.rb
+++ b/spec/models/file_resource_spec.rb
@@ -18,4 +18,32 @@ RSpec.describe FileResource, type: :model do
     it { is_expected.to have_many(:file_version_memberships) }
     it { is_expected.to have_many(:work_versions).through(:file_version_memberships) }
   end
+
+  describe '#save' do
+    let(:file_resource) { described_class.new }
+    let(:file) { File.open(File.join(fixture_path, 'image.png')) }
+    let(:file_data) { { 'id' => file_resource.file_data['id'], 'storage' => file_resource.file_data['storage'] } }
+
+    before { file_resource.file = file }
+
+    it 'promotes the file to storage asynchronously' do
+      allow(Shrine::PromotionJob).to receive(:perform_later)
+      file_resource.save
+      expect(Shrine::PromotionJob).to have_received(:perform_later).with(
+        record: file_resource,
+        file_data: file_data,
+        name: 'file'
+      )
+    end
+
+    it 'initiates a metadata listener job' do
+      allow(MetadataListener::Job).to receive(:perform_later)
+      file_resource.save
+      expect(MetadataListener::Job).to have_received(:perform_later).with(
+        path: "#{file_data['storage']}/#{file_data['id']}",
+        endpoint: "http://#{Rails.application.routes.default_url_options[:host]}/api/v1/files/#{file_resource.id}",
+        api_token: ApiToken.metadata_listener.token
+      )
+    end
+  end
 end

--- a/spec/models/file_version_membership_spec.rb
+++ b/spec/models/file_version_membership_spec.rb
@@ -106,4 +106,20 @@ RSpec.describe FileVersionMembership, type: :model do
       end
     end
   end
+
+  describe '#virus' do
+    context 'when there is no metadata' do
+      subject { build(:file_version_membership) }
+
+      its(:virus) { is_expected.to eq('unknown') }
+    end
+
+    context 'when there is a status' do
+      subject { build(:file_version_membership, file_resource: file_resource) }
+
+      let(:file_resource) { build(:file_resource, file_data: { metadata: { virus: { status: 'virus-status' } } }) }
+
+      its(:virus) { is_expected.to eq('virus-status') }
+    end
+  end
 end


### PR DESCRIPTION
This ties into https://github.com/psu-stewardship/metadata-listener/pull/28

Scholarsphere submits a job via ActiveJob to the `metadata` queue on Redis when a file is promoted to S3 storage in Shrine. This MetdataListener application is listening to that queue and performs additional work on the file, downloading it from S3 and checking for viruses. The result of the virus check is submitted by the MetadataListener application back to Scholarsphere via the API.