### PR TITLE
Set defaults for url host and protocol

### DIFF
--- a/config/initializers/default_url_host.rb
+++ b/config/initializers/default_url_host.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-default_url_host = ENV['DEFAULT_URL_HOST']
-Rails.application.routes.default_url_options[:host] = default_url_host
-
-if default_url_host.blank?
-  raise "ENV['DEFAULT_URL_HOST'] is required to be set"
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,9 @@
 require 'sidekiq/web'
 
 Rails.application.routes.draw do
+  default_url_options protocol: ENV.fetch('DEFAULT_URL_PROTOCOL', 'http'),
+                      host: ENV.fetch('DEFAULT_URL_HOST', 'localhost')
+
   mount Qa::Engine => '/authorities'
 
   namespace :admin do

--- a/config/samples/application.yml
+++ b/config/samples/application.yml
@@ -71,6 +71,7 @@ SOLR_PORT: 8983
 # Required for all environments. For development, you can set it to
 # "localhost:3000" for `bin/rails s` or "scholarsphere-4.test" for puma-dev
 DEFAULT_URL_HOST: "localhost:3000"
+DEFAULT_URL_PROTOCOL: "http"
 
 # If the oauth servers authorize path differs from /oauth/authorize, you can set that value here
 # Under normal circumstances, this shouldn't need changing


### PR DESCRIPTION
Instead of requiring the host, we can have defaults for local development and set the protocol as well to construct the full url when needed.