### PR TITLE
Do not persist failed oauth to session

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -10,7 +10,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   rescue User::OAuthError => e
     logger.error("\n\n\n#{e.class} (#{e.message}):\n\n")
     logger.error(e.backtrace.join("\n"))
-    session['devise.doorkeeper_data'] = request.env['omniauth.auth']
     redirect_to root_path, alert: t('omniauth.login_error')
   end
 

--- a/spec/controllers/users/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/users/omniauth_callbacks_controller_spec.rb
@@ -41,10 +41,6 @@ RSpec.describe Users::OmniauthCallbacksController, type: :controller do
         get :psu
       end
 
-      it 'saves the oauth response to a session variable' do
-        expect(session['devise.doorkeeper_data']).to eq oauth_response
-      end
-
       it { is_expected.to redirect_to root_path }
     end
   end


### PR DESCRIPTION
This was causing a cookie overflow during retro.

Closes #279 