### PR TITLE
Add #virus to UploadedFile

### DIFF
--- a/app/models/file_version_membership.rb
+++ b/app/models/file_version_membership.rb
@@ -14,7 +14,7 @@ class FileVersionMembership < ApplicationRecord
 
   validate :filename_extentions_cannot_change
 
-  delegate :size, :mime_type, :original_filename, to: :uploader
+  delegate :size, :mime_type, :original_filename, :virus, to: :uploader
 
   attr_accessor :changed_by_system
 
@@ -26,15 +26,6 @@ class FileVersionMembership < ApplicationRecord
       work_version_id: :work_version_id
     }
   )
-
-  # @todo It's probably a better idea to add make our own FileUploader::UploadedFile#virus and delegate to that as we're
-  # doing with size, mime_type, and original_filename.
-  def virus
-    status = file_resource.file_data.dig('metadata', 'virus', 'status')
-    return 'unknown' if status.nil?
-
-    status
-  end
 
   private
 

--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -43,4 +43,10 @@ class FileUploader < Shrine
       data: data
     )
   end
+
+  class UploadedFile
+    def virus
+      metadata.dig('virus', 'status')
+    end
+  end
 end

--- a/app/views/dashboard/file_lists/_uploaded_file_list.html.erb
+++ b/app/views/dashboard/file_lists/_uploaded_file_list.html.erb
@@ -16,7 +16,7 @@
           <%= render 'inline_filename_editor', membership: membership %>
         </td>
         <td><%= number_to_human_size membership.size %></td>
-        <td><%= membership.virus %></td>
+        <td><%= membership.virus.nil? ? t('dashboard.file_list.edit.unknown_virus') : membership.virus %></td>
         <td><%= membership.mime_type %></td>
         <td>
           <%= link_to t('dashboard.file_list.edit.rename'),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,6 +127,7 @@ en:
         size: Size
         mime_type: Mime Type
         virus: Virus?
+        unknown_virus: unknown
         actions: Actions
         rename: Rename
         delete: Delete

--- a/spec/models/file_resource_spec.rb
+++ b/spec/models/file_resource_spec.rb
@@ -46,4 +46,15 @@ RSpec.describe FileResource, type: :model do
       )
     end
   end
+
+  describe '#file' do
+    subject { file_resource.file }
+
+    let(:file_resource) { build(:file_resource, :with_processed_image) }
+
+    its(:virus) { is_expected.to be_nil }
+    its(:size) { is_expected.to eq(63960) }
+    its(:mime_type) { is_expected.to eq('image/png') }
+    its(:original_filename) { is_expected.to eq('image.png') }
+  end
 end

--- a/spec/models/file_version_membership_spec.rb
+++ b/spec/models/file_version_membership_spec.rb
@@ -55,6 +55,11 @@ RSpec.describe FileVersionMembership, type: :model do
       membership.mime_type
       expect(mock_uploader).to have_received(:mime_type)
     end
+
+    it "delegates #virus to the FileResource's uploader" do
+      membership.virus
+      expect(mock_uploader).to have_received(:virus)
+    end
   end
 
   describe 'PaperTrail::Versions', versioning: true do
@@ -104,22 +109,6 @@ RSpec.describe FileVersionMembership, type: :model do
           .not_to change(membership, :title)
           .from('provided_a_filename.png')
       end
-    end
-  end
-
-  describe '#virus' do
-    context 'when there is no metadata' do
-      subject { build(:file_version_membership) }
-
-      its(:virus) { is_expected.to eq('unknown') }
-    end
-
-    context 'when there is a status' do
-      subject { build(:file_version_membership, file_resource: file_resource) }
-
-      let(:file_resource) { build(:file_resource, file_data: { metadata: { virus: { status: 'virus-status' } } }) }
-
-      its(:virus) { is_expected.to eq('virus-status') }
     end
   end
 end


### PR DESCRIPTION
This moves the virus status method to the UploadedFile class to make it consistent with other metadata methods such as #mime_type and #size. The display logic is also now contained completely within the view, which can be refactored out later into view component or presenter.

Fixes #376 