### PR TITLE
Preview/matomo

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -13,4 +13,20 @@
   <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
   <%= csrf_meta_tags %>
   <%= content_for(:head) %>
+
+  <!-- Matomo -->
+  <script type="text/javascript">
+    var _paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u = "<%= ENV.fetch('MATOMO_URL', 'https://analytics.libraries.psu.edu/matomo/') %>";
+      _paq.push(['setTrackerUrl', u+'matomo.php']);
+      _paq.push(['setSiteId', '<%= ENV.fetch('MATOMO_SITE_ID', '15') %>']);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+  </script>
+  <!-- End Matomo Code -->
 </head>

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -1,0 +1,16 @@
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+  <!-- Internet Explorer use the highest version available -->
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+  <title><%= render_page_title %></title>
+  <%= opensearch_description_tag application_name, opensearch_catalog_url(format: 'xml') %>
+  <%= favicon_link_tag %>
+  <%= javascript_pack_tag 'application' %>
+  <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+  <%= csrf_meta_tags %>
+  <%= content_for(:head) %>
+</head>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title><%= t('application_name') %></title>
-    <%= csrf_meta_tags %>
-    <%= csp_meta_tag %>
-
-    <%= javascript_pack_tag 'application' %>
-    <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-  </head>
-
+  <%= render partial: 'layouts/head' %>
   <body>
     <%= yield %>
   </body>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -1,22 +1,6 @@
 <!DOCTYPE html>
 <html lang="en" class="no-js">
-  <head>
-    <meta charset="utf-8">
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-
-    <!-- Internet Explorer use the highest version available -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-
-    <title><%= render_page_title %></title>
-    <%= opensearch_description_tag application_name, opensearch_catalog_url(format: 'xml') %>
-    <%= favicon_link_tag %>
-    <%# Overrides blacklight's base layout to use the webpacker pack tag instead of asset pipeline %>
-    <%= javascript_pack_tag 'application' %>
-    <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= csrf_meta_tags %>
-    <%= content_for(:head) %>
-  </head>
+  <%= render partial: 'layouts/head' %>
   <body class="<%= render_body_class %>">
     <div id="skip-link">
       <%= link_to t('blacklight.skip_links.search_field'), '#search_field', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>

--- a/spec/features/matomo_spec.rb
+++ b/spec/features/matomo_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Matomo Traking Code' do
+  before { Capybara.ignore_hidden_elements = false }
+
+  after { Capybara.ignore_hidden_elements = true }
+
+  it 'has the default configuration' do
+    visit(blacklight_path)
+    expect(page).to have_content('https://analytics.libraries.psu.edu/matomo')
+    expect(page).to have_content('15')
+    expect(page).to have_content('/* tracker methods like "setCustomDimension" should be called before "trackPageView" */')
+  end
+end


### PR DESCRIPTION
Using `MATOMO_` ENV vars, adds the tracking code to the header. After numerous attempts to get this working with webpack, we went back to the original standard approach. It's probable that webpack integration isn't supported.