### PR TITLE
Harbor k8s

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ jobs:
     docker:
       - image: devago/docker-compose
     environment:
-      REGISTRY_HOST: harbor.dsrd.libraries.psu.edu
-      REGISTRY_URL: harbor.dsrd.libraries.psu.edu/library/scholarsphere
+      REGISTRY_HOST: harbor.k8s.libraries.psu.edu
+      REGISTRY_URL: harbor.k8s.libraries.psu.edu/library/scholarsphere
       DOCKER_USERNAME: 'robot$circleci'
     steps:
     - setup_remote_docker
@@ -48,15 +48,15 @@ jobs:
         name: "Publishing the image"
         command: |
           docker build -t $REGISTRY_URL:$CIRCLE_SHA1 .
-          docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD $REGISTRY_HOST
+          docker login -u $DOCKER_USERNAME -p $HARBOR_PASSWORD $REGISTRY_HOST
           docker push $REGISTRY_URL:$CIRCLE_SHA1
   deploy-qa:
     docker:
-      - image: harbor.dsrd.libraries.psu.edu/public/drone-utils:latest
+      - image: harbor.k8s.libraries.psu.edu/public/drone-utils:latest
     environment:
       CONFIG_REPO: git@github.com:psu-stewardship/scholarsphere-config.git
       CONFIG_ENV: qa
-      IMAGE_REPOSITORY: harbor.dsrd.libraries.psu.edu/library/scholarsphere
+      IMAGE_REPOSITORY: harbor.k8s.libraries.psu.edu/library/scholarsphere
     steps:
     - add_ssh_keys
     - run:
@@ -68,10 +68,10 @@ jobs:
             ./generate_circle_application.sh
   deploy-preview:
     docker:
-      - image: harbor.dsrd.libraries.psu.edu/public/drone-utils:latest
+      - image: harbor.k8s.libraries.psu.edu/public/drone-utils:latest
     environment:
       CONFIG_REPO: git@github.com:psu-stewardship/scholarsphere-config.git
-      IMAGE_REPOSITORY: harbor.dsrd.libraries.psu.edu/library/scholarsphere
+      IMAGE_REPOSITORY: harbor.k8s.libraries.psu.edu/library/scholarsphere
     steps:
     - add_ssh_keys
     - run:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -30,4 +30,4 @@ services:
       POSTGRES_HOST: db
     tty: true
     stdin_open: true
-    image: harbor.dsrd.libraries.psu.edu/library/scholarsphere:$TAG
+    image: harbor.k8s.libraries.psu.edu/library/scholarsphere:$TAG


### PR DESCRIPTION
Migrates image pulling and publishing to harbor.k8s.libraries.psu.edu; our shiny new harbor server.