### PR TITLE
Track views and downloads with ViewStatistic model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ ruby '2.6.6'
 gem 'aasm'
 gem 'blacklight', '~> 7.7'
 gem 'bootsnap', '>= 1.4.2', require: false
+gem 'browser'
 gem 'cocoon'
 gem 'devise', '~> 4.7'
 gem 'diffy'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,7 @@ GEM
       rails (>= 5.1, < 7)
     bootsnap (1.4.6)
       msgpack (~> 1.0)
+    browser (4.2.0)
     builder (3.2.4)
     byebug (11.1.3)
     capybara (3.32.2)
@@ -503,6 +504,7 @@ DEPENDENCIES
   binding_of_caller
   blacklight (~> 7.7)
   bootsnap (>= 1.4.2)
+  browser
   byebug
   capybara
   cocoon

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -3,9 +3,10 @@
 class DownloadsController < ApplicationController
   def content
     work_version = WorkVersion.find_by!(uuid: params[:resource_id])
-    file = work_version.file_version_memberships.find(params[:id])
-    authorize(file)
-    redirect_to s3_presigned_url(file)
+    file_version = work_version.file_version_memberships.find(params[:id])
+    authorize(file_version)
+    file_version.file_resource.count_view! unless browser.bot?
+    redirect_to s3_presigned_url(file_version)
   end
 
   private

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -4,6 +4,7 @@ class ResourcesController < ApplicationController
   def show
     @resource = ResourceDecorator.new(find_resource(params[:id]))
     authorize @resource
+    @resource.count_view! unless browser.bot?
   end
 
   private

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -3,6 +3,7 @@
 class Collection < ApplicationRecord
   include Permissions
   include DepositedAtTimestamp
+  include ViewStatistics
 
   jsonb_accessor :metadata,
                  title: :string,

--- a/app/models/concerns/view_statistics.rb
+++ b/app/models/concerns/view_statistics.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module ViewStatistics
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :view_statistics,
+             as: :resource,
+             dependent: :destroy
+  end
+
+  def count_view!
+    view_statistics
+      .find_or_initialize_by(date: Time.zone.today)
+      .increment(:count)
+      .save
+  end
+end

--- a/app/models/file_resource.rb
+++ b/app/models/file_resource.rb
@@ -3,6 +3,7 @@
 class FileResource < ApplicationRecord
   include FileUploader::Attachment(:file)
   include DepositedAtTimestamp
+  include ViewStatistics
 
   has_many :file_version_memberships, dependent: :destroy
   has_many :work_versions, through: :file_version_memberships

--- a/app/models/view_statistic.rb
+++ b/app/models/view_statistic.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ViewStatistic < ApplicationRecord
+  belongs_to :resource, polymorphic: true
+end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -128,6 +128,12 @@ class Work < ApplicationRecord
     embargoed_until > Time.zone.now
   end
 
+  def count_view!
+    raise ArgumentError, 'work must have a published version' if latest_published_version.nil?
+
+    latest_published_version.count_view!
+  end
+
   private
 
     def document_builder

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -2,6 +2,7 @@
 
 class WorkVersion < ApplicationRecord
   include AASM
+  include ViewStatistics
   has_paper_trail
 
   jsonb_accessor :metadata,

--- a/db/migrate/20200624134610_create_view_statistics.rb
+++ b/db/migrate/20200624134610_create_view_statistics.rb
@@ -1,0 +1,13 @@
+class CreateViewStatistics < ActiveRecord::Migration[6.0]
+  def change
+    create_table :view_statistics do |t|
+      t.date :date, default: -> { "NOW()" }
+      t.integer :count, default: 0
+      t.references :resource, polymorphic: true, null: false
+
+      t.timestamps
+    end
+
+    add_index :view_statistics, [:resource_type, :resource_id, :date]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_04_125257) do
+ActiveRecord::Schema.define(version: 2020_06_24_134610) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -171,6 +171,17 @@ ActiveRecord::Schema.define(version: 2020_06_04_125257) do
     t.integer "work_version_id"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
     t.index ["work_version_id"], name: "index_versions_on_work_version_id"
+  end
+
+  create_table "view_statistics", force: :cascade do |t|
+    t.date "date", default: -> { "now()" }
+    t.integer "count", default: 0
+    t.string "resource_type", null: false
+    t.bigint "resource_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["resource_type", "resource_id", "date"], name: "index_view_statistics_on_resource_type_and_resource_id_and_date"
+    t.index ["resource_type", "resource_id"], name: "index_view_statistics_on_resource_type_and_resource_id"
   end
 
   create_table "work_version_creations", force: :cascade do |t|

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -11,6 +11,17 @@ RSpec.describe DownloadsController, type: :controller do
         get :content, params: { resource_id: work_version.uuid, id: work_version.file_version_memberships[0].id }
         expect(response).to be_redirect
       end
+
+      it 'adds a view statistic record for the file resource' do
+        expect {
+          get :content, params: { resource_id: work_version.uuid, id: work_version.file_version_memberships[0].id }
+        }.to change {
+          ViewStatistic.where(
+            resource_type: 'FileResource',
+            resource_id: work_version.file_version_memberships[0].id
+          ).count
+        }.from(0).to(1)
+      end
     end
 
     context 'when requesting a non-existent file from a work version' do
@@ -48,6 +59,26 @@ RSpec.describe DownloadsController, type: :controller do
         expect {
           get :content, params: { resource_id: work.uuid, id: 1 }
         }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context 'when a bot is requesting a file' do
+      let(:work_version) { create(:work_version, :published, :with_files, file_count: 2) }
+      let(:bot) { Browser.new('Bot') }
+
+      before { allow(controller).to receive(:browser).and_return(bot) }
+
+      it 'does NOT add a view statistic record for the file resource' do
+        expect {
+          get :content, params: { resource_id: work_version.uuid, id: work_version.file_version_memberships[0].id }
+        }.not_to(
+          change {
+            ViewStatistic.where(
+              resource_type: 'FileResource',
+              resource_id: work_version.file_version_memberships[0].id
+            ).count
+          }
+        )
       end
     end
   end

--- a/spec/factories/view_statistics.rb
+++ b/spec/factories/view_statistics.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :view_statistic do
+    count { Faker::Number.number(digits: 2) }
+    with_work_version
+
+    trait :with_work_version do
+      association :resource, factory: :work_version
+    end
+
+    trait :with_collection do
+      association :resource, factory: :collection
+    end
+  end
+end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe Collection, type: :model do
     let(:factory_name) { :collection }
   end
 
+  it_behaves_like 'a resource with view statistics' do
+    let(:resource) { create(:collection) }
+  end
+
   it_behaves_like 'a resource with a deposited at timestamp'
 
   describe 'table' do
@@ -45,6 +49,7 @@ RSpec.describe Collection, type: :model do
     it { is_expected.to have_many(:works).through(:collection_work_memberships) }
     it { is_expected.to have_many(:creator_aliases) }
     it { is_expected.to have_many(:creators).through(:creator_aliases) }
+    it { is_expected.to have_many(:view_statistics) }
 
     describe 'default order of works' do
       let(:collection) { build :collection }

--- a/spec/models/file_resource_spec.rb
+++ b/spec/models/file_resource_spec.rb
@@ -5,6 +5,10 @@ require 'rails_helper'
 RSpec.describe FileResource, type: :model do
   it_behaves_like 'a resource with a deposited at timestamp'
 
+  it_behaves_like 'a resource with view statistics' do
+    let(:resource) { create(:file_resource) }
+  end
+
   describe 'table' do
     it { is_expected.to have_db_column(:file_data).of_type(:jsonb) }
   end
@@ -17,6 +21,7 @@ RSpec.describe FileResource, type: :model do
   describe 'associations' do
     it { is_expected.to have_many(:file_version_memberships) }
     it { is_expected.to have_many(:work_versions).through(:file_version_memberships) }
+    it { is_expected.to have_many(:view_statistics) }
   end
 
   describe '#save' do

--- a/spec/models/view_statistic_spec.rb
+++ b/spec/models/view_statistic_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ViewStatistic, type: :model do
+  describe 'table' do
+    it { is_expected.to have_db_column(:count).of_type(:integer) }
+    it { is_expected.to have_db_column(:date).of_type(:date) }
+    it { is_expected.to have_db_column(:resource_type).of_type(:string) }
+    it { is_expected.to have_db_column(:resource_id).of_type(:integer) }
+  end
+
+  describe 'factory' do
+    it { is_expected.to have_valid_factory(:legacy_identifier) }
+  end
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:resource) }
+  end
+
+  describe '#count' do
+    context 'with a default record' do
+      its(:count) { is_expected.to eq(0) }
+    end
+  end
+
+  describe '#date' do
+    subject(:view_statistic) { create(:view_statistic) }
+
+    before { view_statistic.reload }
+
+    its(:date) { is_expected.to eq(Time.zone.now.to_date) }
+  end
+end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -337,4 +337,28 @@ RSpec.describe Work, type: :model do
       it { is_expected.not_to be_embargoed }
     end
   end
+
+  describe '#count_view!' do
+    context 'when the work has a published version' do
+      let(:work) { build(:work) }
+      let(:version) { instance_spy('version') }
+
+      before { allow(work).to receive(:latest_published_version).and_return(version) }
+
+      it 'calls the method on the published version' do
+        work.count_view!
+        expect(version).to have_received(:count_view!)
+      end
+    end
+
+    context 'when the work does NOT have a published version' do
+      let(:work) { build(:work) }
+
+      it 'raises an error' do
+        expect {
+          work.count_view!
+        }.to raise_error(ArgumentError, 'work must have a published version')
+      end
+    end
+  end
 end

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -5,6 +5,10 @@ require 'rails_helper'
 RSpec.describe WorkVersion, type: :model do
   it_behaves_like 'an indexable resource'
 
+  it_behaves_like 'a resource with view statistics' do
+    let(:resource) { create(:work_version) }
+  end
+
   describe 'table' do
     it { is_expected.to have_db_column(:work_id) }
     it { is_expected.to have_db_index(:work_id) }
@@ -41,6 +45,7 @@ RSpec.describe WorkVersion, type: :model do
     it { is_expected.to have_many(:file_resources).through(:file_version_memberships) }
     it { is_expected.to have_many(:creator_aliases) }
     it { is_expected.to have_many(:creators).through(:creator_aliases) }
+    it { is_expected.to have_many(:view_statistics) }
     it { is_expected.to be_versioned }
 
     it { is_expected.to accept_nested_attributes_for(:file_resources) }

--- a/spec/support/shared/a_resource_with_view_statistics.rb
+++ b/spec/support/shared/a_resource_with_view_statistics.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'a resource with view statistics' do
+  before do
+    raise 'resource must be set with `let(:perform_request)`' unless defined? resource
+  end
+
+  describe '#count_view!' do
+    specify do
+      expect {
+        resource.count_view!
+      }.to change {
+        ViewStatistic.where(resource: resource).count
+      }.from(0).to(1)
+    end
+  end
+end


### PR DESCRIPTION
Adds a view statistic model with relationships to work versions, collections, and file resources, in order to track views and downloads of resources.

Requests from known bots are not counted using the Browser gem, and only views for work versions are counted. Viewing a work increments the view count for the latest published version only.