### PR TITLE
changes the pattern for ruby base.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM psul/ruby:20200604-2.6.6-node-12 as base
+FROM psul/ruby-2.6.6-node-12:20200624 as base
 
 COPY bin/vaultshell /usr/local/bin/
 


### PR DESCRIPTION
tacking the build time on the end alows dependabot to submit PRs to the repo. vulnerable packages updated in base. 

