### PR TITLE
Show view statistics on resource page

### DIFF
--- a/app/components/collection_metadata_component.rb
+++ b/app/components/collection_metadata_component.rb
@@ -16,7 +16,6 @@ class CollectionMetadataComponent < ActionView::Component::Base
     :title,
     :subtitle,
     :creator_aliases,
-    :description,
     :keyword,
     :contributor,
     :publisher,

--- a/app/components/work_version_metadata_component.rb
+++ b/app/components/work_version_metadata_component.rb
@@ -16,7 +16,6 @@ class WorkVersionMetadataComponent < ActionView::Component::Base
     :subtitle,
     :creator_aliases,
     :version_number,
-    :description,
     :keyword,
     :rights,
     :display_work_type,

--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class AnalyticsController < ApplicationController
+  def show
+    resource = FindResource.call(params[:resource_id])
+    view_statistics = load_view_statistics(resource)
+
+    respond_to do |format|
+      format.html { head :unsupported_media_type }
+      format.json { render json: view_statistics }
+    end
+  end
+
+  private
+
+    def load_view_statistics(resource)
+      resource
+        .stats
+        .map { |date, count, total| [date.iso8601, count, total] }
+    end
+end

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -10,9 +10,6 @@ class ResourcesController < ApplicationController
   private
 
     def find_resource(uuid)
-      Work.where(uuid: uuid).first ||
-        WorkVersion.where(uuid: uuid).first ||
-        Collection.where(uuid: uuid).first ||
-        raise(ActiveRecord::RecordNotFound)
+      FindResource.call(uuid)
     end
 end

--- a/app/javascript/scholarsphere/index.js
+++ b/app/javascript/scholarsphere/index.js
@@ -1,8 +1,9 @@
 // Load our local stylesheets
 import './styles'
 
+// Load any additional custom javascript code here...
+import './view_statistics_chart'
+
 // Load images
 // Retrieve the path to the image via <%= image_pack_tag('image.png') %>
 require.context('./images/', true)
-
-// Load any additional custom javascript code here...

--- a/app/javascript/scholarsphere/styles/_view_statistics_chart.scss
+++ b/app/javascript/scholarsphere/styles/_view_statistics_chart.scss
@@ -1,0 +1,42 @@
+$chart-line-color: #1e407c;
+$axis-stroke-color: #afafaf;
+$axis-text-color: #444;
+$point-marker-color: #f00;
+
+.analytics--info {
+  .counts {
+    font-weight: 600;
+  }
+}
+
+.analytics--chart {
+  .line {
+    fill: none;
+    stroke: $chart-line-color;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 1.5px;
+  }
+
+  .point-marker {
+    fill: $point-marker-color;
+  }
+
+  .point-marker-bar {
+    shape-rendering: crispEdges;
+    stroke: $axis-stroke-color;
+    stroke-width: 1px;
+  }
+
+  .axis {
+    line,
+    path {
+      shape-rendering: crispEdges;
+      stroke: $axis-stroke-color;
+    }
+
+    text {
+      fill: $axis-text-color;
+    }
+  }
+}

--- a/app/javascript/scholarsphere/styles/index.scss
+++ b/app/javascript/scholarsphere/styles/index.scss
@@ -11,3 +11,4 @@
 @import 'work_versions';
 @import 'works';
 @import 'diffy';
+@import 'view_statistics_chart';

--- a/app/javascript/scholarsphere/view_statistics_chart.js
+++ b/app/javascript/scholarsphere/view_statistics_chart.js
@@ -1,0 +1,131 @@
+import $ from 'jquery'
+import * as d3 from 'd3' // @todo we don't need to import the entire d3 library, we can import only the parts that we use. Let's do that after the visualization is finished
+
+$(document).ready(loadCharts)
+
+function loadCharts () {
+  d3.selectAll('.analytics-chart-container')
+    .each(loadChart)
+}
+
+function loadChart () {
+  const url = this.dataset.url
+  d3.json(url)
+    .then(parseData)
+    .then((parsedData) => drawChart(d3.select(this), parsedData))
+}
+
+function parseData (data) {
+  const parseDate = d3.timeParse('%Y-%m-%d')
+  data.forEach((row) => { row[0] = parseDate(row[0]) })
+  return Promise.resolve(data)
+}
+
+function drawChart (selection, data) {
+  const margin = { top: 2, right: 10, bottom: 20, left: 10 }
+  const width = 350
+  const height = 80
+
+  var formatDate = d3.timeFormat('%B %d, %Y')
+  const [firstDate] = data[0]
+  const [,, lastTotal] = data[data.length - 1]
+
+  const x = d3.scaleTime()
+    .domain(d3.extent(data, d => d[0]))
+    .range([margin.left, width - margin.right])
+
+  const y = d3.scaleLinear()
+    .domain(d3.extent(data, d => d[2]))
+    .range([height - margin.bottom, margin.top])
+
+  const xAxis = d3.axisBottom(x)
+    .ticks(5)
+    .tickSizeOuter(0)
+    .tickSizeInner(4)
+
+  const line = d3.line()
+    .x(d => x(d[0]))
+    .y(d => y(d[2]))
+
+  const info = selection
+    .append('div')
+    .attr('class', 'analytics--info')
+
+  const viewCounts = info
+    .append('span')
+    .attr('class', 'counts')
+    .text(`${lastTotal} views`)
+
+  const viewDate = info
+    .append('span')
+    .attr('class', 'date')
+    .text(` since ${formatDate(firstDate)}`)
+
+  const svg = selection
+    .append('svg')
+    .attr('class', 'analytics--chart')
+    .attr('viewBox', [0, 0, width, height])
+  // Uncomment below for fixed-size. Comment out for responsive size
+  // .attr('width', width)
+  // .attr('height', height)
+
+  svg.append('g')
+    .attr('class', 'axis axis--x')
+    .attr('transform', `translate(0,${height - margin.bottom + 2})`)
+    .call(xAxis)
+
+  const chartGroup = svg.append('g')
+    .attr('class', 'chart')
+
+  const pointMarkerBar = chartGroup.append('line')
+    .attr('class', 'point-marker-bar')
+    .attr('y1', margin.top)
+    .attr('y2', height - margin.bottom)
+    .attr('display', 'none')
+
+  chartGroup.append('path')
+    .datum(data)
+    .attr('class', 'line')
+    .attr('d', line)
+
+  const pointMarker = chartGroup
+    .append('circle')
+    .attr('class', 'point-marker')
+    .attr('r', 2)
+    .attr('display', 'none')
+
+  // Interactivity
+
+  // Binary search function to look up closet data point to a given date
+  const bisectDate = d3.bisector(row => row[0])
+
+  svg.on('mousemove click touchmove', function () {
+    const mouseCoords = d3.mouse(this)
+    const mouseDate = x.invert(mouseCoords[0])
+    const nearestIndex = bisectDate.right(data, mouseDate)
+
+    if (nearestIndex < data.length) {
+      const [nearestDate,, nearestValue] = data[nearestIndex]
+
+      viewCounts.text(`${nearestValue} views`)
+      viewDate.text(` by ${formatDate(nearestDate)}`)
+
+      pointMarker
+        .attr('display', null)
+        .attr('cx', x(nearestDate))
+        .attr('cy', y(nearestValue))
+
+      pointMarkerBar
+        .attr('display', null)
+        .attr('x1', x(nearestDate))
+        .attr('x2', x(nearestDate))
+    }
+  })
+
+  svg.on('mouseleave', event => {
+    viewCounts.text(`${lastTotal} views`)
+    viewDate.text(` since ${formatDate(firstDate)}`)
+    pointMarker.attr('display', 'none')
+    pointMarkerBar.attr('display', 'none')
+  })
+}

--- a/app/models/concerns/view_statistics.rb
+++ b/app/models/concerns/view_statistics.rb
@@ -15,4 +15,8 @@ module ViewStatistics
       .increment(:count)
       .save
   end
+
+  def stats
+    @stats ||= LoadViewStatistics.call(model: self)
+  end
 end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -134,6 +134,10 @@ class Work < ApplicationRecord
     latest_published_version.count_view!
   end
 
+  def stats
+    @stats ||= AggregateViewStatistics.call(models: versions.published)
+  end
+
   private
 
     def document_builder

--- a/app/services/aggregate_view_statistics.rb
+++ b/app/services/aggregate_view_statistics.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# @abstract Loads the view statistics for an array of models. It returns these
+# statistics as a 2d array, sorted by date ascenting, just like LoadViewStatistics:
+#   [Date, number of views that day, running total of all views through time]
+# @example
+#   > AggregateViewStatistics.call(models: [model_1, model_2])
+#   => [
+#        [Date(2020-06-01), 1,     1],
+#        [Date(2020-06-02), 100, 101],
+#        [Date(2020-06-03), 3,   104]
+#      ]
+class AggregateViewStatistics
+  def self.call(models:)
+    new(models: models).load_view_statistics
+  end
+
+  attr_reader :models
+
+  def initialize(models:)
+    @models = models
+  end
+
+  def load_view_statistics
+    date_historgram = Hash.new(0)
+
+    models.each do |model|
+      stats = ::LoadViewStatistics.call(model: model)
+
+      stats.each do |date, count, _total|
+        date_historgram[date] = date_historgram[date] + count
+      end
+    end
+
+    date_historgram
+      .to_a
+      .sort_by { |date, _count| date }
+      .reduce([]) do |accumulator, row|
+        date, count = row
+        running_total = accumulator.last&.last || 0
+        accumulator << [date, count, running_total + count]
+      end
+  end
+end

--- a/app/services/find_resource.rb
+++ b/app/services/find_resource.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class FindResource
+  def self.call(uuid)
+    Work.where(uuid: uuid).first ||
+      WorkVersion.where(uuid: uuid).first ||
+      Collection.where(uuid: uuid).first ||
+      raise(ActiveRecord::RecordNotFound)
+  end
+end

--- a/app/services/load_view_statistics.rb
+++ b/app/services/load_view_statistics.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# @abstract Loads the view statistics for a given model. It returns these
+# statistics as a 2d array of raw values, rather than ActiveRecords, for speed.
+# The returned rows are ordered by date ascending, and have the structure:
+#   [Date, number of views that day, running total of all views through time]
+# @example
+#   > LoadViewStatistics.call(my_model)
+#   => [
+#        [Date(2020-06-01), 1,     1],
+#        [Date(2020-06-02), 100, 101],
+#        [Date(2020-06-03), 3,   104]
+#      ]
+
+class LoadViewStatistics
+  def self.call(model:)
+    new(model: model).load_view_statistics
+  end
+
+  attr_reader :model,
+              :relation
+
+  def initialize(model:)
+    @model = model
+    @relation = model.view_statistics
+  end
+
+  # @return [Array<Array(Date, Integer, Integer)>]
+  def load_view_statistics
+    sql = query.to_sql
+
+    ViewStatistic
+      .connection
+      .select_rows(sql)
+      .reduce([]) do |accumulator, row|
+        date_string, count = row
+        parsed_date = Date.parse(date_string)
+        count ||= 0
+        running_total = accumulator.last&.last || 0
+
+        accumulator << [parsed_date, count, running_total + count]
+      end
+  end
+
+  def query
+    relation
+      .reorder('date ASC')
+      .select([:date, :count])
+  end
+end

--- a/app/services/load_view_statistics.rb
+++ b/app/services/load_view_statistics.rb
@@ -5,7 +5,7 @@
 # The returned rows are ordered by date ascending, and have the structure:
 #   [Date, number of views that day, running total of all views through time]
 # @example
-#   > LoadViewStatistics.call(my_model)
+#   > LoadViewStatistics.call(model: my_model)
 #   => [
 #        [Date(2020-06-01), 1,     1],
 #        [Date(2020-06-02), 100, 101],

--- a/app/views/resources/_collection.html.erb
+++ b/app/views/resources/_collection.html.erb
@@ -1,4 +1,14 @@
-<h1><%= collection.title %></h1>
-
-<%= render CollectionMetadataComponent.new(collection: collection) %>
-<%= render 'shared/collection_works', collection: collection %>
+<div class="row">
+  <div class="col">
+    <h1><%= collection.title %></h1>
+    <p><%= collection.description %></p>
+    <h2><%= t('resources.works') %></h2>
+    <%= render 'shared/collection_works', collection: collection %>
+  </div>
+  <div class="col-4">
+    <h3><%= t('resources.metadata') %></h3>
+    <%= render CollectionMetadataComponent.new(collection: collection) %>
+    <h3><%= t('resources.analytics') %></h3>
+    <div class='analytics-chart-container' data-url="<%= resource_analytics_path(collection.uuid, format: :json) %>"></div>
+  </div>
+</div>

--- a/app/views/resources/_work.html.erb
+++ b/app/views/resources/_work.html.erb
@@ -1,5 +1,15 @@
 <% work_version = ResourceDecorator.new(work.latest_published_version) -%>
-<h1><%= work_version.title %></h1>
-
-<%= render WorkVersionMetadataComponent.new(work_version: work_version) %>
-<%= render 'shared/work_version_files', work_version: work_version %>
+<div class="row">
+  <div class="col">
+    <h1><%= work_version.title %></h1>
+    <p><%= work_version.description %></p>
+    <h2><%= t('resources.files') %></h2>
+    <%= render 'shared/work_version_files', work_version: work_version %>
+  </div>
+  <div class="col-4">
+    <h3><%= t('resources.metadata') %></h3>
+    <%= render WorkVersionMetadataComponent.new(work_version: work_version) %>
+    <h3><%= t('resources.analytics') %></h3>
+    <div class='analytics-chart-container' data-url="<%= resource_analytics_path(work.uuid, format: :json) %>"></div>
+  </div>
+</div>

--- a/app/views/resources/_work_version.html.erb
+++ b/app/views/resources/_work_version.html.erb
@@ -1,4 +1,14 @@
-<h1><%= work_version.title %></h1>
-
-<%= render WorkVersionMetadataComponent.new(work_version: work_version) %>
-<%= render 'shared/work_version_files', work_version: work_version %>
+<div class="row">
+  <div class="col">
+    <h1><%= work_version.title %></h1>
+    <p><%= work_version.description %></p>
+    <h2><%= t('resources.files') %></h2>
+    <%= render 'shared/work_version_files', work_version: work_version %>
+  </div>
+  <div class="col-4">
+    <h3><%= t('resources.metadata') %></h3>
+    <%= render WorkVersionMetadataComponent.new(work_version: work_version) %>
+    <h3><%= t('resources.analytics') %></h3>
+    <div class='analytics-chart-container' data-url="<%= resource_analytics_path(work_version.uuid, format: :json) %>"></div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,3 +165,8 @@ en:
         truncated_attributes: "and %{count} more"
   omniauth:
     login_error: 'There was a problem logging you in. We have been notified of the issue and will work to fix it. Please try again later.'
+  resources:
+    works: Works
+    files: Files
+    analytics: Analytics
+    metadata: Metadata

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
 
   resources :resources, only: [:show] do
     get 'downloads/:id', to: 'downloads#content', as: :download
+    get 'analytics', to: 'analytics#show', as: :analytics
   end
 
   resources :bookmarks do

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "bootstrap": "^4.5.0",
     "caniuse-lite": "^1.0.30001061",
     "cocoon-js": "^0.0.5",
+    "d3": "^5.16.0",
     "jquery": "^3.5.1",
     "popper.js": "^1.16.1",
     "stimulus": "^1.1.1",

--- a/spec/components/collection_metadata_component_spec.rb
+++ b/spec/components/collection_metadata_component_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe CollectionMetadataComponent, type: :component do
       subtitle: 'My subtitle',
       deposited_at: Time.zone.parse('2020-01-15 16:07'),
       keyword: %w(one two),
-      description: nil,
       subject: []
     ) }
 
@@ -31,7 +30,6 @@ RSpec.describe CollectionMetadataComponent, type: :component do
     end
 
     it 'does not render any fields that are empty' do
-      expect(result.css('dd.collection-description')).to be_empty
       expect(result.css('dd.collection-subject')).to be_empty
     end
 
@@ -51,7 +49,6 @@ RSpec.describe CollectionMetadataComponent, type: :component do
       # Titles
       expect(result.css('dt.collection-title')).to be_present
       expect(result.css('dt.collection-subtitle')).to be_present
-      expect(result.css('dt.collection-description')).to be_present
       expect(result.css('dt.collection-keyword')).to be_present
       expect(result.css('dt.collection-contributor')).to be_present
       expect(result.css('dt.collection-publisher')).to be_present
@@ -71,7 +68,6 @@ RSpec.describe CollectionMetadataComponent, type: :component do
       expect(result.css('dd.collection-title').text).to eq collection[:title]
       expect(result.css('dd.collection-subtitle').text).to eq collection[:subtitle]
       expect(result.css('dd.collection-creator-aliases').text).to include collection.creator_aliases.map(&:alias).first
-      expect(result.css('dd.collection-description').text).to include collection[:description].first
       expect(result.css('dd.collection-keyword').text).to include collection[:keyword].first
       expect(result.css('dd.collection-contributor').text).to include collection[:contributor].first
       expect(result.css('dd.collection-publisher').text).to include collection[:publisher].first

--- a/spec/components/work_version_metadata_component_spec.rb
+++ b/spec/components/work_version_metadata_component_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe WorkVersionMetadataComponent, type: :component do
                                        work: work,
                                        subtitle: 'My subtitle',
                                        keyword: %w(one two),
-                                       description: nil
+                                       published_date: nil
     }
 
     it 'renders a string with label' do
@@ -32,7 +32,7 @@ RSpec.describe WorkVersionMetadataComponent, type: :component do
     end
 
     it 'does not render any fields that are empty' do
-      expect(result.css('dd.work-version-description')).to be_empty
+      expect(result.css('dd.work-version-published-date')).to be_empty
     end
 
     it 'accepts a decorated and non-decorated Work Version' do
@@ -52,7 +52,6 @@ RSpec.describe WorkVersionMetadataComponent, type: :component do
       expect(result.css('dt.work-version-title')).to be_present
       expect(result.css('dt.work-version-subtitle')).to be_present
       expect(result.css('dt.work-version-version-number')).to be_present
-      expect(result.css('dt.work-version-description')).to be_present
       expect(result.css('dt.work-version-keyword')).to be_present
       expect(result.css('dt.work-version-rights')).to be_present
       expect(result.css('dt.work-version-resource-type')).not_to be_present
@@ -76,7 +75,6 @@ RSpec.describe WorkVersionMetadataComponent, type: :component do
       expect(result.css('dd.work-version-subtitle').text).to eq work_version[:subtitle]
       expect(result.css('dd.work-version-creator-aliases').text).to include work_version.creator_aliases.map(&:alias).first
       expect(result.css('dd.work-version-version-number').text).to eq work_version[:version_number].to_s
-      expect(result.css('dd.work-version-description').text).to include work_version[:description].first
       expect(result.css('dd.work-version-keyword').text).to include work_version[:keyword].first
       expect(result.css('dd.work-version-rights').text).to eq work_version[:rights]
       expect(result.css('dd.work-version-display-work-type').text).to eq decorated_work_version.display_work_type
@@ -103,7 +101,6 @@ RSpec.describe WorkVersionMetadataComponent, type: :component do
         expect(result.css('dt.work-version-creator-aliases')).to be_present
         expect(result.css('dt.work-version-subtitle')).not_to be_present
         expect(result.css('dt.work-version-version-number')).not_to be_present
-        expect(result.css('dt.work-version-description')).not_to be_present
         expect(result.css('dt.work-version-keyword')).not_to be_present
         expect(result.css('dt.work-version-rights')).not_to be_present
         expect(result.css('dt.work-version-display-work-type')).not_to be_present

--- a/spec/controllers/analytics_controller_spec.rb
+++ b/spec/controllers/analytics_controller_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# @note While this is technically a controller test, because it's testing our
+# REST API, we're really using it as a feature/request test
+
+RSpec.describe AnalyticsController, type: :controller do
+  let(:parsed_body) { JSON.parse response.body }
+
+  describe 'GET #show' do
+    context 'with a work version' do
+      let(:resource) { instance_double('Collection', uuid: 'abc-123') }
+
+      before do
+        allow(FindResource).to receive(:call).with(resource.uuid).and_return(resource)
+
+        allow(resource)
+          .to receive(:stats)
+          .and_return(
+            [
+              [Date.parse('2020-06-01'), 1, 1],
+              [Date.parse('2020-06-02'), 2, 3]
+            ]
+          )
+      end
+
+      it 'returns the view counts as json' do
+        get(:show, params: { resource_id: resource.uuid, format: :json })
+        expect(resource).to have_received(:stats)
+
+        expect(response).to be_ok
+        expect(parsed_body).to eq [
+          ['2020-06-01', 1, 1],
+          ['2020-06-02', 2, 3]
+        ]
+      end
+
+      context 'when the format is not json' do
+        subject { response }
+
+        before { get(:show, params: { resource_id: resource.uuid }) }
+
+        it { is_expected.to have_http_status(:unsupported_media_type) }
+      end
+    end
+  end
+end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -361,4 +361,15 @@ RSpec.describe Work, type: :model do
       end
     end
   end
+
+  describe '#stats' do
+    subject(:work) { create :work, versions_count: 3, has_draft: true }
+
+    before { allow(AggregateViewStatistics).to receive(:call).and_return(:returned_stats) }
+
+    it 'Passes all published works to AggregateViewStatistics' do
+      expect(work.stats).to eq :returned_stats
+      expect(AggregateViewStatistics).to have_received(:call).with(models: work.versions.published)
+    end
+  end
 end

--- a/spec/services/aggregate_view_statistics_spec.rb
+++ b/spec/services/aggregate_view_statistics_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe AggregateViewStatistics, type: :model do
+  # Helper method to quickly make Dates
+  def d(str)
+    Date.parse(str)
+  end
+
+  describe '#call' do
+    subject(:view_stats) { described_class.call(models: [model_1, model_2]) }
+
+    let(:model_1) { create :work_version, :draft }
+    let(:model_2) { create :work_version, :draft }
+    let(:another_model) { create :work_version, :draft }
+
+    before do
+      {
+        # Date           Count
+        d('2020-06-01') => 1,
+        d('2020-06-03') => 3,
+        d('2020-06-02') => 2
+      }.each do |date, count|
+        model_1.view_statistics.create!(date: date, count: count)
+      end
+
+      {
+        # Date           Count
+        d('2020-05-31') => 1,
+        d('2020-06-03') => 3,
+        d('2020-06-04') => 4
+      }.each do |date, count|
+        model_2.view_statistics.create!(date: date, count: count)
+      end
+
+      another_model.view_statistics.create!(date: d('2020-06-01'), count: 100)
+    end
+
+    it 'returns an ordered 2d array of view statistics for the given models' do
+      expect(view_stats).to eq(
+        [
+          [d('2020-05-31'), 1, 1],
+          [d('2020-06-01'), 1, 2],
+          [d('2020-06-02'), 2, 4],
+          [d('2020-06-03'), 6, 10],
+          [d('2020-06-04'), 4, 14]
+        ]
+      )
+    end
+  end
+end

--- a/spec/services/find_resource_spec.rb
+++ b/spec/services/find_resource_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FindResource, type: :model do
+  describe '.call' do
+    context 'when requesting a Work' do
+      let(:work) { create(:work, has_draft: false) }
+
+      it 'returns the Work' do
+        expect(described_class.call(work.uuid)).to eq work
+      end
+    end
+
+    context 'when requesting a WorkVersion' do
+      let(:work_version) { create :work_version }
+
+      it 'returns the WorkVersion' do
+        expect(described_class.call(work_version.uuid)).to eq work_version
+      end
+    end
+
+    context 'when requesting a Collection' do
+      let(:collection) { create :collection }
+
+      it 'returns the WorkVersion' do
+        expect(described_class.call(collection.uuid)).to eq collection
+      end
+    end
+
+    context 'when requesting an unknown uuid' do
+      it do
+        expect {
+          described_class.call('unknown-uuid')
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/spec/services/load_view_statistics_spec.rb
+++ b/spec/services/load_view_statistics_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe LoadViewStatistics, type: :model do
+  # Helper method to quickly make Dates
+  def d(str)
+    Date.parse(str)
+  end
+
+  describe '#call' do
+    subject(:view_stats) { described_class.call(model: model) }
+
+    let(:model) { create :work_version, :draft }
+    let(:another_model) { create :work_version, :draft }
+
+    before do
+      {
+        # Date           Count
+        d('2020-06-01') => 1,
+        d('2020-06-03') => 3,
+        d('2020-06-02') => 2
+      }.each do |date, count|
+        model.view_statistics.create!(date: date, count: count)
+      end
+
+      another_model.view_statistics.create!(date: d('2020-06-01'), count: 100)
+    end
+
+    it 'returns an ordered 2d array of view statistics for the given model' do
+      expect(view_stats).to eq(
+        [
+          [d('2020-06-01'), 1, 1],
+          [d('2020-06-02'), 2, 3],
+          [d('2020-06-03'), 3, 6]
+        ]
+      )
+    end
+  end
+end

--- a/spec/support/shared/a_resource_with_view_statistics.rb
+++ b/spec/support/shared/a_resource_with_view_statistics.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'a resource with view statistics' do
+  let(:stat_loader_class) { LoadViewStatistics }
+
   before do
-    raise 'resource must be set with `let(:perform_request)`' unless defined? resource
+    raise 'resource must be set with `let(:resource)`' unless defined? resource
   end
 
   describe '#count_view!' do
@@ -12,6 +14,20 @@ RSpec.shared_examples 'a resource with view statistics' do
       }.to change {
         ViewStatistic.where(resource: resource).count
       }.from(0).to(1)
+    end
+  end
+
+  describe '#stats' do
+    before { allow(stat_loader_class).to receive(:call).and_return(:returned_stats) }
+
+    specify do
+      expect(resource.stats).to eq :returned_stats
+      expect(stat_loader_class).to have_received(:call).with(model: resource)
+
+      # This is a hack to get a nicer spec output message. I want it to say `it
+      # "delegates to #{stat_loader_class}"` but rspec doesn't allow this, and
+      # there's no other way to pass stat_loader_class into this shared example.
+      expect(stat_loader_class).to eq stat_loader_class
     end
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2149,7 +2149,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.20.0:
+commander@2, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -2598,6 +2598,254 @@ cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
+
+d3-array@1, d3-array@^1.1.1, d3-array@^1.2.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
+  integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
+
+d3-axis@1:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-1.0.12.tgz#cdf20ba210cfbb43795af33756886fb3638daac9"
+  integrity sha512-ejINPfPSNdGFKEOAtnBtdkpr24c4d4jsei6Lg98mxf424ivoDP2956/5HDpIAtmHo85lqT4pruy+zEgvRUBqaQ==
+
+d3-brush@1:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-1.1.5.tgz#066b8e84d17b192986030446c97c0fba7e1bacdc"
+  integrity sha512-rEaJ5gHlgLxXugWjIkolTA0OyMvw8UWU1imYXy1v642XyyswmI1ybKOv05Ft+ewq+TFmdliD3VuK0pRp1VT/5A==
+  dependencies:
+    d3-dispatch "1"
+    d3-drag "1"
+    d3-interpolate "1"
+    d3-selection "1"
+    d3-transition "1"
+
+d3-chord@1:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-chord/-/d3-chord-1.0.6.tgz#309157e3f2db2c752f0280fedd35f2067ccbb15f"
+  integrity sha512-JXA2Dro1Fxw9rJe33Uv+Ckr5IrAa74TlfDEhE/jfLOaXegMQFQTAgAw9WnZL8+HxVBRXaRGCkrNU7pJeylRIuA==
+  dependencies:
+    d3-array "1"
+    d3-path "1"
+
+d3-collection@1:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
+  integrity sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==
+
+d3-color@1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.1.tgz#c52002bf8846ada4424d55d97982fef26eb3bc8a"
+  integrity sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==
+
+d3-contour@1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/d3-contour/-/d3-contour-1.3.2.tgz#652aacd500d2264cb3423cee10db69f6f59bead3"
+  integrity sha512-hoPp4K/rJCu0ladiH6zmJUEz6+u3lgR+GSm/QdM2BBvDraU39Vr7YdDCicJcxP1z8i9B/2dJLgDC1NcvlF8WCg==
+  dependencies:
+    d3-array "^1.1.1"
+
+d3-dispatch@1:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-1.0.6.tgz#00d37bcee4dd8cd97729dd893a0ac29caaba5d58"
+  integrity sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==
+
+d3-drag@1:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-1.2.5.tgz#2537f451acd39d31406677b7dc77c82f7d988f70"
+  integrity sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==
+  dependencies:
+    d3-dispatch "1"
+    d3-selection "1"
+
+d3-dsv@1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-1.2.0.tgz#9d5f75c3a5f8abd611f74d3f5847b0d4338b885c"
+  integrity sha512-9yVlqvZcSOMhCYzniHE7EVUws7Fa1zgw+/EAV2BxJoG3ME19V6BQFBwI855XQDsxyOuG7NibqRMTtiF/Qup46g==
+  dependencies:
+    commander "2"
+    iconv-lite "0.4"
+    rw "1"
+
+d3-ease@1:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-1.0.6.tgz#ebdb6da22dfac0a22222f2d4da06f66c416a0ec0"
+  integrity sha512-SZ/lVU7LRXafqp7XtIcBdxnWl8yyLpgOmzAk0mWBI9gXNzLDx5ybZgnRbH9dN/yY5tzVBqCQ9avltSnqVwessQ==
+
+d3-fetch@1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/d3-fetch/-/d3-fetch-1.2.0.tgz#15ce2ecfc41b092b1db50abd2c552c2316cf7fc7"
+  integrity sha512-yC78NBVcd2zFAyR/HnUiBS7Lf6inSCoWcSxFfw8FYL7ydiqe80SazNwoffcqOfs95XaLo7yebsmQqDKSsXUtvA==
+  dependencies:
+    d3-dsv "1"
+
+d3-force@1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-1.2.1.tgz#fd29a5d1ff181c9e7f0669e4bd72bdb0e914ec0b"
+  integrity sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==
+  dependencies:
+    d3-collection "1"
+    d3-dispatch "1"
+    d3-quadtree "1"
+    d3-timer "1"
+
+d3-format@1:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.4.4.tgz#356925f28d0fd7c7983bfad593726fce46844030"
+  integrity sha512-TWks25e7t8/cqctxCmxpUuzZN11QxIA7YrMbram94zMQ0PXjE4LVIMe/f6a4+xxL8HQ3OsAFULOINQi1pE62Aw==
+
+d3-geo@1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-1.12.1.tgz#7fc2ab7414b72e59fbcbd603e80d9adc029b035f"
+  integrity sha512-XG4d1c/UJSEX9NfU02KwBL6BYPj8YKHxgBEw5om2ZnTRSbIcego6dhHwcxuSR3clxh0EpE38os1DVPOmnYtTPg==
+  dependencies:
+    d3-array "1"
+
+d3-hierarchy@1:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-1.1.9.tgz#2f6bee24caaea43f8dc37545fa01628559647a83"
+  integrity sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ==
+
+d3-interpolate@1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.4.0.tgz#526e79e2d80daa383f9e0c1c1c7dcc0f0583e987"
+  integrity sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==
+  dependencies:
+    d3-color "1"
+
+d3-path@1:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.9.tgz#48c050bb1fe8c262493a8caf5524e3e9591701cf"
+  integrity sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==
+
+d3-polygon@1:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-polygon/-/d3-polygon-1.0.6.tgz#0bf8cb8180a6dc107f518ddf7975e12abbfbd38e"
+  integrity sha512-k+RF7WvI08PC8reEoXa/w2nSg5AUMTi+peBD9cmFc+0ixHfbs4QmxxkarVal1IkVkgxVuk9JSHhJURHiyHKAuQ==
+
+d3-quadtree@1:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-1.0.7.tgz#ca8b84df7bb53763fe3c2f24bd435137f4e53135"
+  integrity sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA==
+
+d3-random@1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-1.1.2.tgz#2833be7c124360bf9e2d3fd4f33847cfe6cab291"
+  integrity sha512-6AK5BNpIFqP+cx/sreKzNjWbwZQCSUatxq+pPRmFIQaWuoD+NrbVWw7YWpHiXpCQ/NanKdtGDuB+VQcZDaEmYQ==
+
+d3-scale-chromatic@1:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-1.5.0.tgz#54e333fc78212f439b14641fb55801dd81135a98"
+  integrity sha512-ACcL46DYImpRFMBcpk9HhtIyC7bTBR4fNOPxwVSl0LfulDAwyiHyPOTqcDG1+t5d4P9W7t/2NAuWu59aKko/cg==
+  dependencies:
+    d3-color "1"
+    d3-interpolate "1"
+
+d3-scale@2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-2.2.2.tgz#4e880e0b2745acaaddd3ede26a9e908a9e17b81f"
+  integrity sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==
+  dependencies:
+    d3-array "^1.2.0"
+    d3-collection "1"
+    d3-format "1"
+    d3-interpolate "1"
+    d3-time "1"
+    d3-time-format "2"
+
+d3-selection@1, d3-selection@^1.1.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.4.1.tgz#98eedbbe085fbda5bafa2f9e3f3a2f4d7d622a98"
+  integrity sha512-BTIbRjv/m5rcVTfBs4AMBLKs4x8XaaLkwm28KWu9S2vKNqXkXt2AH2Qf0sdPZHjFxcWg/YL53zcqAz+3g4/7PA==
+
+d3-shape@1:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.3.7.tgz#df63801be07bc986bc54f63789b4fe502992b5d7"
+  integrity sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==
+  dependencies:
+    d3-path "1"
+
+d3-time-format@2:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.2.3.tgz#0c9a12ee28342b2037e5ea1cf0b9eb4dd75f29cb"
+  integrity sha512-RAHNnD8+XvC4Zc4d2A56Uw0yJoM7bsvOlJR33bclxq399Rak/b9bhvu/InjxdWhPtkgU53JJcleJTGkNRnN6IA==
+  dependencies:
+    d3-time "1"
+
+d3-time@1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.1.0.tgz#b1e19d307dae9c900b7e5b25ffc5dcc249a8a0f1"
+  integrity sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==
+
+d3-timer@1:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.10.tgz#dfe76b8a91748831b13b6d9c793ffbd508dd9de5"
+  integrity sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==
+
+d3-transition@1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-1.3.2.tgz#a98ef2151be8d8600543434c1ca80140ae23b398"
+  integrity sha512-sc0gRU4PFqZ47lPVHloMn9tlPcv8jxgOQg+0zjhfZXMQuvppjG6YuwdMBE0TuqCZjeJkLecku/l9R0JPcRhaDA==
+  dependencies:
+    d3-color "1"
+    d3-dispatch "1"
+    d3-ease "1"
+    d3-interpolate "1"
+    d3-selection "^1.1.0"
+    d3-timer "1"
+
+d3-voronoi@1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/d3-voronoi/-/d3-voronoi-1.1.4.tgz#dd3c78d7653d2bb359284ae478645d95944c8297"
+  integrity sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg==
+
+d3-zoom@1:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-1.8.3.tgz#b6a3dbe738c7763121cd05b8a7795ffe17f4fc0a"
+  integrity sha512-VoLXTK4wvy1a0JpH2Il+F2CiOhVu7VRXWF5M/LroMIh3/zBAC3WAt7QoIvPibOavVo20hN6/37vwAsdBejLyKQ==
+  dependencies:
+    d3-dispatch "1"
+    d3-drag "1"
+    d3-interpolate "1"
+    d3-selection "1"
+    d3-transition "1"
+
+d3@^5.16.0:
+  version "5.16.0"
+  resolved "https://registry.yarnpkg.com/d3/-/d3-5.16.0.tgz#9c5e8d3b56403c79d4ed42fbd62f6113f199c877"
+  integrity sha512-4PL5hHaHwX4m7Zr1UapXW23apo6pexCgdetdJ5kTmADpG/7T9Gkxw0M0tf/pjoB63ezCCm0u5UaFYy2aMt0Mcw==
+  dependencies:
+    d3-array "1"
+    d3-axis "1"
+    d3-brush "1"
+    d3-chord "1"
+    d3-collection "1"
+    d3-color "1"
+    d3-contour "1"
+    d3-dispatch "1"
+    d3-drag "1"
+    d3-dsv "1"
+    d3-ease "1"
+    d3-fetch "1"
+    d3-force "1"
+    d3-format "1"
+    d3-geo "1"
+    d3-hierarchy "1"
+    d3-interpolate "1"
+    d3-path "1"
+    d3-polygon "1"
+    d3-quadtree "1"
+    d3-random "1"
+    d3-scale "2"
+    d3-scale-chromatic "1"
+    d3-selection "1"
+    d3-shape "1"
+    d3-time "1"
+    d3-time-format "2"
+    d3-timer "1"
+    d3-transition "1"
+    d3-voronoi "1"
+    d3-zoom "1"
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -4016,7 +4264,7 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24:
+iconv-lite@0.4, iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -7064,6 +7312,11 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   integrity sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=
   dependencies:
     aproba "^1.1.1"
+
+rw@1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
+  integrity sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=
 
 rxjs@^6.5.3:
   version "6.5.5"


### PR DESCRIPTION
Show a graph of views through time on resource pages. 

WorkVersions and Collections show the exact number of views for that particular resource.

Works show an aggregate of all _published_ versions.

File downloads are not shown at this time. 