### PR TITLE
Migrate legacy identifiers for files

### DIFF
--- a/app/controllers/api/v1/ingest_controller.rb
+++ b/app/controllers/api/v1/ingest_controller.rb
@@ -129,7 +129,8 @@ module Api::V1
           content_parameter
             .permit(
               :file,
-              :deposited_at
+              :deposited_at,
+              :noid
             )
         end
       end

--- a/app/models/file_resource.rb
+++ b/app/models/file_resource.rb
@@ -7,4 +7,8 @@ class FileResource < ApplicationRecord
 
   has_many :file_version_memberships, dependent: :destroy
   has_many :work_versions, through: :file_version_memberships
+
+  has_many :legacy_identifiers,
+           as: :resource,
+           dependent: :destroy
 end

--- a/app/models/legacy_identifier.rb
+++ b/app/models/legacy_identifier.rb
@@ -9,4 +9,13 @@ class LegacyIdentifier < ApplicationRecord
     legacy_id&.resource&.uuid ||
       raise(ActiveRecord::RecordNotFound)
   end
+
+  # @param [Collection,Work,WorkVersion,FileResource] resource
+  # @param [String] noid
+  # @note Creates a legacy identifier for a Scholarsphere 3 noid
+  def self.create_noid(resource:, noid:)
+    return if noid.nil?
+
+    resource.legacy_identifiers.find_or_initialize_by(version: 3, old_id: noid)
+  end
 end

--- a/app/services/create_new_collection.rb
+++ b/app/services/create_new_collection.rb
@@ -62,12 +62,7 @@ class CreateNewCollection
     )
 
     collection = Collection.new(params)
-    if noid.present?
-      collection.legacy_identifiers.find_or_initialize_by(
-        version: 3,
-        old_id: noid
-      )
-    end
+    LegacyIdentifier.create_noid(resource: collection, noid: noid)
     UpdatePermissionsService.call(resource: collection, permissions: permissions, create_agents: true)
 
     if collection.save(context: :migration_api)

--- a/app/services/publish_new_work.rb
+++ b/app/services/publish_new_work.rb
@@ -51,17 +51,13 @@ class PublishNewWork
     }
 
     work = Work.build_with_empty_version(params)
-    if noid.present?
-      work.legacy_identifiers.find_or_initialize_by(
-        version: 3,
-        old_id: noid
-      )
-    end
+    LegacyIdentifier.create_noid(resource: work, noid: noid)
     UpdatePermissionsService.call(resource: work, permissions: permissions, create_agents: true)
     work_version = work.versions.first
 
     content.map do |file|
-      work_version.file_resources.build(file: file[:file], deposited_at: file[:deposited_at])
+      file_resource = work_version.file_resources.build(file: file[:file], deposited_at: file[:deposited_at])
+      LegacyIdentifier.create_noid(resource: file_resource, noid: file[:noid])
     end
 
     return work unless work.valid?

--- a/spec/factories/legacy_identifiers.rb
+++ b/spec/factories/legacy_identifiers.rb
@@ -17,5 +17,9 @@ FactoryBot.define do
     trait :with_collection do
       association :resource, factory: :collection
     end
+
+    trait :with_file do
+      association :resource, factory: :file_resource
+    end
   end
 end

--- a/spec/models/file_resource_spec.rb
+++ b/spec/models/file_resource_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe FileResource, type: :model do
     it { is_expected.to have_many(:file_version_memberships) }
     it { is_expected.to have_many(:work_versions).through(:file_version_memberships) }
     it { is_expected.to have_many(:view_statistics) }
+    it { is_expected.to have_many(:legacy_identifiers) }
   end
 
   describe '#save' do

--- a/spec/services/publish_new_work_spec.rb
+++ b/spec/services/publish_new_work_spec.rb
@@ -269,7 +269,7 @@ RSpec.describe PublishNewWork do
   end
 
   context 'when the work has a NOID from Scholarpshere 3' do
-    let(:legacy_identifier) { build(:legacy_identifier) }
+    let(:noid) { FactoryBotHelpers.noid }
 
     let(:new_work) do
       described_class.call(
@@ -286,7 +286,7 @@ RSpec.describe PublishNewWork do
                                                       }
                                                     }
                                                   ],
-                                                  noid: legacy_identifier.old_id
+                                                  noid: noid
                                                 )),
         depositor: depositor,
         content: [
@@ -296,8 +296,11 @@ RSpec.describe PublishNewWork do
     end
 
     it 'creates a new work with a legacy identifier' do
-      expect(new_work.legacy_identifiers.map(&:old_id)).to contain_exactly(legacy_identifier.old_id)
-      expect(new_work.legacy_identifiers.map(&:version)).to contain_exactly(3)
+      expect {
+        new_work
+      }.to change {
+        LegacyIdentifier.find_by(old_id: noid, resource_type: 'Work')
+      }.from(nil).to(a_kind_of(LegacyIdentifier))
     end
   end
 
@@ -378,6 +381,45 @@ RSpec.describe PublishNewWork do
       expect(new_work.latest_published_version.file_resources.first.deposited_at.strftime('%Y-%m-%d')).to eq(
         '2018-03-01'
       )
+    end
+  end
+
+  context 'when the file has a NOID from Scholarsphere 3' do
+    let(:noid) { FactoryBotHelpers.noid }
+
+    let(:new_work) do
+      described_class.call(
+        metadata: HashWithIndifferentAccess.new(work.metadata.merge(
+                                                  work_type: 'dataset',
+                                                  creator_aliases_attributes: [
+                                                    {
+                                                      alias: user.name,
+                                                      actor_attributes: {
+                                                        email: user.email,
+                                                        given_name: user.actor.given_name,
+                                                        surname: user.actor.surname,
+                                                        psu_id: user.actor.psu_id
+                                                      }
+                                                    }
+                                                  ],
+                                                  deposited_at: '2018-02-28T15:12:54Z'
+                                                )),
+        depositor: depositor,
+        content: [
+          HashWithIndifferentAccess.new(
+            file: fixture_file_upload(File.join(fixture_path, 'image.png')),
+            noid: noid
+          )
+        ]
+      )
+    end
+
+    it 'creates a file with the legacy identifier' do
+      expect {
+        new_work
+      }.to change {
+        LegacyIdentifier.find_by(old_id: noid, resource_type: 'FileResource')
+      }.from(nil).to(a_kind_of(LegacyIdentifier))
     end
   end
 

--- a/spec/support/factory_bot_helpers.rb
+++ b/spec/support/factory_bot_helpers.rb
@@ -25,4 +25,9 @@ module FactoryBotHelpers
 
     %(#{a}: "#{b}; #{id} #{c}")
   end
+
+  # @note Generate a random Noid-like string to mimic Scholarsphere 3's noid identifiers
+  def self.noid
+    [*('a'..'z'), *('0'..'9')].shuffle[0, 10].join
+  end
 end


### PR DESCRIPTION
Adds a noid parameter for files coming over from Scholarsphere 3. The noid is added as a legacy identifier to the FileResource. An additional association is added to the file resource linking the old file set noid in Scholarsphere 3 to the new file resource.

Noid creation is refactored out to a class method on LegacyIdentifier for consistency.

Related to #379 

