### PR TITLE
Use Redis to track unique visits to pages

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -4,12 +4,18 @@ class ResourcesController < ApplicationController
   def show
     @resource = ResourceDecorator.new(find_resource(params[:id]))
     authorize @resource
-    @resource.count_view! unless browser.bot?
+    @resource.count_view! if count_view?
   end
 
   private
 
     def find_resource(uuid)
       FindResource.call(uuid)
+    end
+
+    def count_view?
+      return false if browser.bot?
+
+      SessionViewStatsCache.call(session: session, resource: @resource)
     end
 end

--- a/app/services/session_view_stats_cache.rb
+++ b/app/services/session_view_stats_cache.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class SessionViewStatsCache
+  def self.call(session:, resource:)
+    redis = Redis.new(Rails.configuration.redis)
+    digest = Digest::MD5.hexdigest("#{session.id}#{resource.id}")[0..6]
+    key = "vs:#{digest}"
+
+    return false if redis.get(key)
+
+    redis.set(key, true)
+    redis.expire(key, Rails.configuration.redis[:ttl])
+
+    true
+  end
+end

--- a/lib/scholarsphere/redis_config.rb
+++ b/lib/scholarsphere/redis_config.rb
@@ -18,6 +18,10 @@ module Scholarsphere
       ENV['REDIS_PASSWORD']
     end
 
+    def ttl
+      ENV.fetch('REDIS_TTL', 24.hours)
+    end
+
     def to_hash
       return base_config.merge(password: password) if password
 
@@ -28,7 +32,8 @@ module Scholarsphere
 
       def base_config
         {
-          url: "redis://#{host}:#{port}/#{database}"
+          url: "redis://#{host}:#{port}/#{database}",
+          ttl: ttl
         }
       end
   end

--- a/spec/controllers/resources_controller_spec.rb
+++ b/spec/controllers/resources_controller_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 
 RSpec.describe ResourcesController, type: :controller do
   describe '#show' do
+    let(:redis) { Redis.new(Rails.configuration.redis) }
+
     context 'when requesting a Work' do
       let(:work) { create(:work, has_draft: false) }
 
@@ -18,6 +20,30 @@ RSpec.describe ResourcesController, type: :controller do
         }.to change {
           ViewStatistic.where(resource_type: 'WorkVersion', resource_id: work.latest_published_version).count
         }.from(0).to(1)
+      end
+    end
+
+    context 'when requesting a work for the first time in a session' do
+      let(:work) { create(:work, has_draft: false) }
+
+      it 'marks it as a unique view' do
+        expect {
+          get :show, params: { id: work.uuid }
+        }.to change {
+          redis.keys.count
+        }.by(1)
+      end
+    end
+
+    context 'when requesting the same work twice the same session' do
+      let(:work) { create(:work, has_draft: false) }
+
+      before { get :show, params: { id: work.uuid } }
+
+      it 'does NOT mark the request in the cache' do
+        expect {
+          get :show, params: { id: work.uuid }
+        }.not_to(change { redis.keys.count })
       end
     end
 


### PR DESCRIPTION
Using Rails' feature that lets Redis serve as a cache storage layer, we can store key value pairs that correspond to unique visits to a page. By creating a key using a user's session id and the UUID of the resource they are visiting, we store that key value for a period of time. As long as the key is present, no additional page views will be counted.

There are a couple of gotchas to this method:
1. We need to expire the key on a periodic basis. Fortunately, this is very easy to do in Redis; however...
2. Using Redis as a cache layer has a couple of caveats which are outlined in https://guides.rubyonrails.org/caching_with_rails.html#activesupport-cache-rediscachestore

Notably, the recommendation is to use a _separate_ Redis service solely for caching:

> Deployment note: Redis doesn't expire keys by default, so take care to use a dedicated Redis cache server. Don't fill up your persistent-Redis server with volatile cache data! 

But, we not really using Redis as a persistent store, since job data isn't persisted. So we may have some wiggle room. I'll leave it to @whereismyjetpack to weigh in.

It is also worth noting that using Redis as a cache store alone, without any of the page view verification, is useful as well since it performs better than Rails' standard memcache method.