### PR TITLE
Redis configuration is now a core service

### DIFF
--- a/app/models/view_statistic.rb
+++ b/app/models/view_statistic.rb
@@ -2,4 +2,12 @@
 
 class ViewStatistic < ApplicationRecord
   belongs_to :resource, polymorphic: true
+
+  after_initialize :set_defaults
+
+  private
+
+    def set_defaults
+      self.date ||= Time.zone.now
+    end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,14 +39,10 @@ module Scholarsphere
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
 
-    # Active Job Configurations
-    redis_config = Scholarsphere::RedisConfig.new
+    config.redis = Scholarsphere::RedisConfig.new.to_hash
 
-    config.active_job.queue_adapter = if redis_config.valid?
-                                        :sidekiq
-                                      else
-                                        :async
-                                      end
+    # ActiveJob config
+    config.active_job.queue_adapter = :sidekiq
 
     # Don't generate system test files.
     config.generators.system_tests = nil

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -10,6 +10,11 @@ Rails.application.configure do
   config.hosts << /.*ngrok\.io$/
   config.hosts << 'host.docker.internal'
 
+  # ActiveJob config
+  # Comment this out if you want to test Sidekiq integration locally
+  config.active_job.queue_adapter = :async
+  config.active_job.queue_name_prefix = 'ss_dev'
+
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,6 +10,11 @@ Rails.application.configure do
 
   config.cache_classes = false
 
+  # ActiveJob config
+  # Use a queue name prefix so the test suite doesn't overrwrite anything in dev.
+  # We don't need to do this in production because we're using a dedicated Redis instance.
+  config.active_job.queue_name_prefix = 'ss_test'
+
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,18 +1,27 @@
 # frozen_string_literal: true
 
-redis_config = Scholarsphere::RedisConfig.new
-
 OkComputer.mount_at = false
 
-OkComputer::Registry.register 'solr', OkComputer::SolrCheck.new(Rails.application.config_for(:blacklight)[:url])
+OkComputer::Registry.register(
+  'solr',
+  OkComputer::SolrCheck.new(Rails.application.config_for(:blacklight)[:url])
+)
 
-## When we have a valid redis configuration, we register
-## sidekiq and redis checks
-if redis_config.valid?
-  OkComputer::Registry.register 'redis', OkComputer::RedisCheck.new(redis_config.to_hash)
-  OkComputer::Registry.register 'sidekiq', HealthChecks::QueueLatencyCheck.new(ENV.fetch('SIDEKIQ_QUEUE_LATENCY_THRESHOLD', 30).to_i)
-  OkComputer::Registry.register 'sidekiq_deadset', HealthChecks::QueueDeadSetCheck.new
-  # Reports as Failed, but continues to return 200 status code.
-  # This is so a POD won't get restarted just for latency checks.
-  OkComputer.make_optional %w(sidekiq sidekiq_deadset)
-end
+OkComputer::Registry.register(
+  'redis',
+  OkComputer::RedisCheck.new(Rails.configuration.redis)
+)
+
+OkComputer::Registry.register(
+  'sidekiq',
+  HealthChecks::QueueLatencyCheck.new(ENV.fetch('SIDEKIQ_QUEUE_LATENCY_THRESHOLD', 30).to_i)
+)
+
+OkComputer::Registry.register(
+  'sidekiq_deadset',
+  HealthChecks::QueueDeadSetCheck.new
+)
+
+# Reports as Failed, but continues to return 200 status code.
+# This is so a POD won't get restarted just for latency checks.
+OkComputer.make_optional %w(sidekiq sidekiq_deadset)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
-redis_config = Scholarsphere::RedisConfig.new
-
 Sidekiq.configure_server do |config|
-  config.redis = redis_config.to_hash
+  config.redis = Rails.configuration.redis
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = redis_config.to_hash
+  config.redis = Rails.configuration.redis
 end

--- a/config/samples/application.yml
+++ b/config/samples/application.yml
@@ -51,10 +51,10 @@
 #
 # --------------------------------------------------------------------------------------------------------------------
 #
-# Redis Configuration (production only)
+# Redis Configuration
 #
-# Note: you can also add this to your development configuration to test integration with Sidekiq and other external
-# services that are run async, but it should NOT be in your test environment.
+# Note: Defaults to 'redis://127.0.0.1:6379/0' which should work for local development. Password is only required for
+# production instances.
 #
 # REDIS_HOST:
 # REDIS_PORT:

--- a/db/migrate/20200708021358_change_view_statistics_date_to_not_null.rb
+++ b/db/migrate/20200708021358_change_view_statistics_date_to_not_null.rb
@@ -1,0 +1,6 @@
+class ChangeViewStatisticsDateToNotNull < ActiveRecord::Migration[6.0]
+  def change
+    change_column_default :view_statistics, :date, nil
+    change_column_null :view_statistics, :date, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_24_134610) do
+ActiveRecord::Schema.define(version: 2020_07_08_021358) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -174,7 +174,7 @@ ActiveRecord::Schema.define(version: 2020_06_24_134610) do
   end
 
   create_table "view_statistics", force: :cascade do |t|
-    t.date "date", default: -> { "now()" }
+    t.date "date", null: false
     t.integer "count", default: 0
     t.string "resource_type", null: false
     t.bigint "resource_id", null: false

--- a/lib/scholarsphere/cleaner.rb
+++ b/lib/scholarsphere/cleaner.rb
@@ -40,7 +40,7 @@ module Scholarsphere
       end
 
       def redis
-        @redis ||= Redis.new(RedisConfig.new.to_hash)
+        @redis ||= Redis.new(Rails.configuration.redis)
       end
     end
   end

--- a/lib/scholarsphere/redis_config.rb
+++ b/lib/scholarsphere/redis_config.rb
@@ -3,7 +3,7 @@
 module Scholarsphere
   class RedisConfig
     def host
-      ENV.fetch('REDIS_HOST', nil)
+      ENV.fetch('REDIS_HOST', 'localhost')
     end
 
     def port
@@ -15,20 +15,21 @@ module Scholarsphere
     end
 
     def password
-      ENV.fetch('REDIS_PASSWORD', nil)
-    end
-
-    def valid?
-      return true if host
-
-      false
+      ENV['REDIS_PASSWORD']
     end
 
     def to_hash
-      {
-        url: "redis://#{host}:#{port}/#{database}",
-        password: password
-      }
+      return base_config.merge(password: password) if password
+
+      base_config
     end
+
+    private
+
+      def base_config
+        {
+          url: "redis://#{host}:#{port}/#{database}"
+        }
+      end
   end
 end

--- a/spec/lib/healthchecks/queue_dead_set_check_spec.rb
+++ b/spec/lib/healthchecks/queue_dead_set_check_spec.rb
@@ -1,16 +1,10 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 require 'sidekiq/testing'
-require 'okcomputer'
-require 'healthchecks'
-require 'scholarsphere/redis_config'
 
-RSpec.describe HealthChecks::QueueDeadSetCheck, unless: !Scholarsphere::RedisConfig.new.valid? do
-  before do
-    Sidekiq::Testing.disable!
-    Sidekiq::DeadSet.new.clear
-  end
+RSpec.describe HealthChecks::QueueDeadSetCheck, :sidekiq do
+  before { Sidekiq::DeadSet.new.clear }
 
   describe '#check' do
     context 'when there are no messages in deadset' do

--- a/spec/lib/healthchecks/queue_latency_check_spec.rb
+++ b/spec/lib/healthchecks/queue_latency_check_spec.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 require 'sidekiq/testing'
-require 'okcomputer'
-require 'healthchecks'
-require 'scholarsphere/redis_config'
 
-RSpec.describe HealthChecks::QueueLatencyCheck, unless: !Scholarsphere::RedisConfig.new.valid? do
-  let(:queue_name) { 'test_queue' }
+RSpec.describe HealthChecks::QueueLatencyCheck, :sidekiq do
+  let(:queue_name) { "#{Rails.configuration.active_job.queue_name_prefix}_test_queue" }
 
   before(:all) do
     class TestJob < ApplicationJob
@@ -24,7 +21,6 @@ RSpec.describe HealthChecks::QueueLatencyCheck, unless: !Scholarsphere::RedisCon
   end
 
   before do
-    Sidekiq::Testing.disable!
     Sidekiq::Queue.all.map(&:clear)
     TestJob.perform_later
   end

--- a/spec/support/sidekiq_helper.rb
+++ b/spec/support/sidekiq_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.around(:each, :sidekiq) do |example|
+    original_queue_adapter = ActiveJob::Base.queue_adapter
+    Sidekiq::Testing.disable!
+    ActiveJob::Base.queue_adapter = :sidekiq
+    example.run
+    ActiveJob::Base.queue_adapter = original_queue_adapter
+  end
+end


### PR DESCRIPTION
Refactors the Redis configuration to be a core service. We no longer check to see if the service is valid or active, it is assumed to be, just like our database services. The configuration is persisted as a hash within Rails' application configuration structure and can be referenced from anywhere within application.

ActiveJob configuration is now kept separate from Redis and Sidekiq tests are tied to this configuration setting instead.

Note: Includes an additional commit that changes how the dates of view statistics are set. This bug was discovered when running the test suite after 10 PM local time.