### PR TITLE
Downgrade simplecov

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,9 @@ group :development do
   gem 'xray-rails'
 end
 
+
+# Lock simplecov at 0.17 until issue with test-reporter is solved
+# https://github.com/codeclimate/test-reporter/issues/413
 group :test do
   gem 'capybara'
   gem 'launchy'
@@ -75,7 +78,7 @@ group :test do
   gem 'rspec-rails', '~> 4.0.0.beta3'
   gem 'selenium-webdriver'
   gem 'shoulda-matchers', '~> 4.3'
-  gem 'simplecov', require: false
+  gem 'simplecov', '~> 0.17.1', require: false
   gem 'vcr'
   gem 'webdrivers'
   gem 'webmock'

--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,6 @@ group :development do
   gem 'xray-rails'
 end
 
-
 # Lock simplecov at 0.17 until issue with test-reporter is solved
 # https://github.com/codeclimate/test-reporter/issues/413
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,6 +198,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json (2.3.1)
     jsonb_accessor (1.0.0)
       activerecord (>= 5.0)
       activesupport (>= 5.0)
@@ -434,10 +435,11 @@ GEM
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
-    simplecov (0.18.5)
+    simplecov (0.17.1)
       docile (~> 1.1)
-      simplecov-html (~> 0.11)
-    simplecov-html (0.12.2)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     smart_properties (1.15.0)
     spring (2.1.0)
     spring-commands-rspec (1.0.4)
@@ -550,7 +552,7 @@ DEPENDENCIES
   shoulda-matchers (~> 4.3)
   shrine (~> 3.0)
   sidekiq (~> 6.0)
-  simplecov
+  simplecov (~> 0.17.1)
   spring
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)

--- a/bin/ci-rspec
+++ b/bin/ci-rspec
@@ -3,6 +3,7 @@
 # 
 # Runs the rspec test suite in our CI environment using Code Climate to send coverage reporting data.
 #
+set -e
 
 # Local variables
 REPORTER_BIN="cc-test-reporter"


### PR DESCRIPTION
- exit ci script if there are any failures (fails the build if results can't be shipped to codeclimate)

- version pins simplecov

First commit was with a known-broken version of simplecov to test the CI script fails properly ✅ 
Second commit pins simlecov with a note why ✅ 

Fixes #370 