### PR TITLE
Update to ViewComponent 2.x and Blacklight 7.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,11 +33,8 @@ gem 'scholarsphere-client', github: 'psu-stewardship/scholarsphere-client', bran
 gem 'shrine', '~> 3.0'
 gem 'sidekiq', '~> 6.0'
 gem 'uppy-s3_multipart', '~> 0.3'
+gem 'view_component'
 gem 'webpacker', '~> 4.0'
-
-# Experimental
-# @todo upgrade to latest version that alters the implementation pattern
-gem 'actionview-component', '= 1.17.0'
 
 group :development, :test do
   gem 'byebug', platform: :mri

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.6.6'
 
 gem 'aasm'
-gem 'blacklight', '~> 7.7.0'
+gem 'blacklight', '~> 7.10'
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'browser'
 gem 'cocoon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,12 +104,13 @@ GEM
     bindex (0.8.1)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
-    blacklight (7.7.0)
+    blacklight (7.10.0)
       deprecation
       globalid
       jbuilder (~> 2.7)
       kaminari (>= 0.15)
       rails (>= 5.1, < 7)
+      view_component
     bootsnap (1.4.6)
       msgpack (~> 1.0)
     browser (4.2.0)
@@ -500,7 +501,7 @@ DEPENDENCIES
   aasm
   better_errors
   binding_of_caller
-  blacklight (~> 7.7.0)
+  blacklight (~> 7.10)
   bootsnap (>= 1.4.2)
   browser
   byebug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,8 +48,6 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    actionview-component (1.17.0)
-      capybara (~> 3)
     activejob (6.0.3.2)
       activesupport (= 6.0.3.2)
       globalid (>= 0.3.6)
@@ -465,6 +463,8 @@ GEM
       content_disposition (~> 1.0)
       roda (>= 2.27, < 4)
     vcr (6.0.0)
+    view_component (2.14.0)
+      activesupport (>= 5.0.0, < 7.0)
     warden (1.2.8)
       rack (>= 2.0.6)
     web-console (4.0.3)
@@ -498,7 +498,6 @@ PLATFORMS
 
 DEPENDENCIES
   aasm
-  actionview-component (= 1.17.0)
   better_errors
   binding_of_caller
   blacklight (~> 7.7.0)
@@ -558,6 +557,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   uppy-s3_multipart (~> 0.3)
   vcr
+  view_component
   web-console (>= 3.3.0)
   webdrivers
   webmock

--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ApplicationComponent < ViewComponent::Base
+end

--- a/app/components/collection_metadata_component.rb
+++ b/app/components/collection_metadata_component.rb
@@ -2,13 +2,8 @@
 
 # @todo: this is a great candidate for refactoring with WorkVersionMetadataComponent
 
-require 'action_view/component'
-
-class CollectionMetadataComponent < ActionView::Component::Base
+class CollectionMetadataComponent < ApplicationComponent
   attr_reader :collection
-
-  validates :collection,
-            presence: true
 
   # A list of Collection's attributes that you'd like rendered, in the order
   # that you want them to appear.

--- a/app/components/embargo_detail_component.rb
+++ b/app/components/embargo_detail_component.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
-require 'action_view/component'
-
-class EmbargoDetailComponent < ActionView::Component::Base
-  validates :work_version,
-            presence: true
-
+class EmbargoDetailComponent < ApplicationComponent
   attr_reader :work_version
 
   # @param [WorkVersion]

--- a/app/components/visibility_badge_component.rb
+++ b/app/components/visibility_badge_component.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
-require 'action_view/component'
-
-class VisibilityBadgeComponent < ActionView::Component::Base
-  validates :work,
-            presence: true
-
+class VisibilityBadgeComponent < ApplicationComponent
   # @param [Work, SolrDocument]
   def initialize(work:)
     @work = work

--- a/app/components/work_histories/creator_alias_change_component.rb
+++ b/app/components/work_histories/creator_alias_change_component.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 class WorkHistories::CreatorAliasChangeComponent < WorkHistories::PaperTrailChangeBaseComponent
-  # This apparently is a little quirk of ActionView::Component, and requires an
-  # explicit #initialize method on each class.
-  def initialize(**args)
-    super
-  end
-
   private
 
     def i18n_key

--- a/app/components/work_histories/file_membership_change_component.rb
+++ b/app/components/work_histories/file_membership_change_component.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 class WorkHistories::FileMembershipChangeComponent < WorkHistories::PaperTrailChangeBaseComponent
-  # This apparently is a little quirk of ActionView::Component, and requires an
-  # explicit #initialize method on each class.
-  def initialize(**args)
-    super
-  end
-
   private
 
     def i18n_key

--- a/app/components/work_histories/paper_trail_change_base_component.rb
+++ b/app/components/work_histories/paper_trail_change_base_component.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
-require 'action_view/component'
-
-class WorkHistories::PaperTrailChangeBaseComponent < ActionView::Component::Base
-  validates :paper_trail_version,
-            :user,
-            presence: true
-
+class WorkHistories::PaperTrailChangeBaseComponent < ApplicationComponent
   # @param paper_trail_version [PaperTrail::Version] representing a change to a
   #        WorkVersionCreation
   # @param user [User]

--- a/app/components/work_histories/work_history_component.rb
+++ b/app/components/work_histories/work_history_component.rb
@@ -1,12 +1,7 @@
 # frozen_string_literal: true
 
-require 'action_view/component'
-
 module WorkHistories
-  class WorkHistoryComponent < ActionView::Component::Base
-    validates :work,
-              presence: true
-
+  class WorkHistoryComponent < ApplicationComponent
     # @param work [Work]
     def initialize(work:)
       @work = work

--- a/app/components/work_histories/work_version_change_component.rb
+++ b/app/components/work_histories/work_version_change_component.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 class WorkHistories::WorkVersionChangeComponent < WorkHistories::PaperTrailChangeBaseComponent
-  # This apparently is a little quirk of ActionView::Component, and requires an
-  # explicit #initialize method on each class.
-  def initialize(**args)
-    super
-  end
-
   private
 
     def i18n_key

--- a/app/components/work_version_metadata_component.rb
+++ b/app/components/work_version_metadata_component.rb
@@ -1,13 +1,8 @@
 # frozen_string_literal: true
 
-require 'action_view/component'
-
-class WorkVersionMetadataComponent < ActionView::Component::Base
+class WorkVersionMetadataComponent < ApplicationComponent
   attr_reader :work_version,
               :mini
-
-  validates :work_version,
-            presence: true
 
   # A list of WorkVersion's attributes that you'd like rendered, in the order
   # that you want them to appear.

--- a/app/components/work_versions/status_badge_component.rb
+++ b/app/components/work_versions/status_badge_component.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
-require 'action_view/component'
-
-class WorkVersions::StatusBadgeComponent < ActionView::Component::Base
-  validates :work_version,
-            presence: true
-
+class WorkVersions::StatusBadgeComponent < ApplicationComponent
   def initialize(work_version:)
     @work_version = work_version
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,7 +15,7 @@ require 'action_text/engine'
 require 'action_view/railtie'
 require 'action_cable/engine'
 require 'sprockets/railtie'
-require 'action_view/component/railtie'
+require 'view_component/engine'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -15,7 +15,7 @@ abort('The Rails environment is running in production mode!') if Rails.env.produ
 require 'rspec/rails'
 require 'aasm/rspec'
 require 'paper_trail/frameworks/rspec'
-require 'action_view/component/test_helpers'
+require 'view_component/test_helpers'
 
 # Add additional requires below this line. Rails is not loaded until this point!
 
@@ -52,7 +52,7 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
 
   config.include Devise::Test::IntegrationHelpers, type: :request
-  config.include ActionView::Component::TestHelpers, type: :component
+  config.include ViewComponent::TestHelpers, type: :component
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and


### PR DESCRIPTION
The newest version of Blacklight uses the new ViewComponent gem, however, we were using an older, different version of it that is incompatible with the new Blacklight version.

Previous versions of ViewComponent were under ActionView because at the time the plan was that the gem would be added to Rails. That is now not the case, and it will remain a separate gem outside of the Rails and ActionView namespace.

This upgrades us to the new gem and changes our component classes accordingly. The only major difference is that ViewComponent does not support validation. But, since we didn't seem to be making much use of
that feature, removing it from our components doesn't affect the outcomes of the tests.

Fixes #403 