### PR TITLE
Admins can do everything

### DIFF
--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -9,15 +9,15 @@ class ApplicationPolicy
   end
 
   def index?
-    false
+    user.admin?
   end
 
   def show?
-    false
+    user.admin?
   end
 
   def create?
-    false
+    user.admin?
   end
 
   def new?
@@ -25,7 +25,7 @@ class ApplicationPolicy
   end
 
   def update?
-    false
+    user.admin?
   end
 
   def edit?
@@ -33,19 +33,23 @@ class ApplicationPolicy
   end
 
   def destroy?
-    false
+    user.admin?
   end
 
   class Scope
     attr_reader :user, :scope
 
     def initialize(user, scope)
+      raise NoMethodError, "#{self.class}#limit must be defined instead of #resolve" unless respond_to?(:limit)
+
       @user = user
       @scope = scope
     end
 
     def resolve
-      scope.all
+      return scope.all if user.admin?
+
+      limit
     end
   end
 end

--- a/app/policies/collection_policy.rb
+++ b/app/policies/collection_policy.rb
@@ -5,12 +5,12 @@
 # some point we may combine the two, but don't want to prefactor
 class CollectionPolicy < ApplicationPolicy
   class Scope < Scope
-    def resolve
+    def limit
       scope.all
     end
   end
 
   def show?
-    record.read_access? user
+    record.read_access?(user) || user.admin?
   end
 end

--- a/app/policies/dashboard/collection_policy.rb
+++ b/app/policies/dashboard/collection_policy.rb
@@ -2,13 +2,13 @@
 
 class Dashboard::CollectionPolicy < ApplicationPolicy
   class Scope < Scope
-    def resolve
+    def limit
       scope.where(depositor: user.actor)
     end
   end
 
   def show?
-    owner?
+    owner? || user.admin?
   end
 
   alias_method :edit?, :show?

--- a/app/policies/dashboard/work_policy.rb
+++ b/app/policies/dashboard/work_policy.rb
@@ -2,7 +2,7 @@
 
 class Dashboard::WorkPolicy < ApplicationPolicy
   class Scope < Scope
-    def resolve
+    def limit
       scope
         .where(depositor: user.actor)
         .or(scope.where(proxy_depositor: user.actor))
@@ -10,7 +10,7 @@ class Dashboard::WorkPolicy < ApplicationPolicy
   end
 
   def create_version?
-    owner? && record.draft_version.blank?
+    (owner? && record.draft_version.blank?) || user.admin?
   end
 
   private

--- a/app/policies/dashboard/work_version_policy.rb
+++ b/app/policies/dashboard/work_version_policy.rb
@@ -2,7 +2,7 @@
 
 class Dashboard::WorkVersionPolicy < WorkVersionPolicy
   class Scope < Scope
-    def resolve
+    def limit
       scope
         .where(works: { depositor_id: user.actor_id })
         .or(scope.where(works: { proxy_id: user.actor_id }))
@@ -11,11 +11,11 @@ class Dashboard::WorkVersionPolicy < WorkVersionPolicy
   end
 
   def show?
-    owner?
+    owner? || user.admin?
   end
 
   def edit?
-    record.draft? && owner?
+    (record.draft? && owner?) || user.admin?
   end
 
   alias_method :update?, :edit?

--- a/app/policies/work_policy.rb
+++ b/app/policies/work_policy.rb
@@ -5,12 +5,12 @@
 # some point we may combine the two, but don't want to prefactor
 class WorkPolicy < ApplicationPolicy
   class Scope < Scope
-    def resolve
+    def limit
       scope.all
     end
   end
 
   def show?
-    record.discover_access? user
+    record.discover_access?(user) || user.admin?
   end
 end

--- a/app/policies/work_version_policy.rb
+++ b/app/policies/work_version_policy.rb
@@ -5,13 +5,13 @@
 # some point we may combine the two, but don't want to prefactor
 class WorkVersionPolicy < ApplicationPolicy
   class Scope < Scope
-    def resolve
+    def limit
       scope.all
     end
   end
 
   def show?
-    record.work.read_access? user
+    record.work.read_access?(user) || user.admin?
   end
 
   def download?
@@ -25,7 +25,7 @@ class WorkVersionPolicy < ApplicationPolicy
 
     # @todo There's a bug in the permissions because a depositor should have edit access by default
     def editable?
-      record.work.edit_access?(user) || record.depositor == user.actor
+      record.work.edit_access?(user) || record.depositor == user.actor || user.admin?
     end
 
     def download_published_version?

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,7 +5,7 @@ require Rails.root.join('spec', 'support', 'factory_bot_helpers')
 FactoryBot.define do
   factory :user do
     trait :admin do
-      groups { [Group.new(name: Rails.application.config.admin_group)] }
+      groups { User.default_groups + [Group.new(name: Rails.application.config.admin_group)] }
     end
     groups { User.default_groups }
     email { "#{access_id}@psu.edu" }

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationPolicy, type: :policy do
+  subject { described_class }
+
+  let(:record) { instance_double 'Work' }
+
+  permissions :index?, :show?, :create?, :new?, :update?, :edit?, :destroy? do
+    context 'with an admin user' do
+      let(:user) { build(:user, :admin) }
+
+      it { is_expected.to permit(user, record) }
+    end
+
+    context 'with an authenticated user' do
+      let(:user) { build(:user) }
+
+      it { is_expected.not_to permit(user, record) }
+    end
+  end
+
+  describe ApplicationPolicy::Scope do
+    it 'raises an error if #limit is not defined' do
+      expect {
+        described_class.new('user', 'model')
+      }.to raise_error(NoMethodError, 'ApplicationPolicy::Scope#limit must be defined instead of #resolve')
+    end
+  end
+end

--- a/spec/policies/collection_policy_spec.rb
+++ b/spec/policies/collection_policy_spec.rb
@@ -3,15 +3,30 @@
 require 'rails_helper'
 
 RSpec.describe CollectionPolicy, type: :policy do
-  let(:user) { instance_double 'User' }
+  subject { described_class }
+
   let(:collection) { instance_double 'Collection' }
+  let(:user) { build(:user) }
 
-  describe '#show?' do
-    it 'delegates to Collection#read_access?' do
-      allow(collection).to receive(:read_access?)
-        .with(user).and_return(:whatever_read_access_returns)
+  permissions :show? do
+    context 'when the user has read access' do
+      before { allow(collection).to receive(:read_access?).with(user).and_return(true) }
 
-      expect(described_class.new(user, collection).show?).to eq :whatever_read_access_returns
+      it { is_expected.to permit(user, collection) }
+    end
+
+    context 'when the user does NOT have read access' do
+      before { allow(collection).to receive(:read_access?).with(user).and_return(false) }
+
+      it { is_expected.not_to permit(user, collection) }
+    end
+
+    context 'when the user is an admin' do
+      let(:user) { build(:user, :admin) }
+
+      before { allow(collection).to receive(:read_access?).with(user).and_return(false) }
+
+      it { is_expected.to permit(user, collection) }
     end
   end
 end

--- a/spec/policies/dashboard/collection_policy_spec.rb
+++ b/spec/policies/dashboard/collection_policy_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Dashboard::CollectionPolicy, type: :policy do
 
   let(:user) { create :user }
   let(:other_user) { create :user }
+  let(:admin) { create :user, :admin }
 
   let!(:my_collection) { create :collection, depositor: user.actor }
 
@@ -25,5 +26,6 @@ RSpec.describe Dashboard::CollectionPolicy, type: :policy do
   permissions :show?, :edit?, :update?, :destroy? do
     it { is_expected.to permit(user, my_collection) }
     it { is_expected.not_to permit(other_user, my_collection) }
+    it { is_expected.to permit(admin, my_collection) }
   end
 end

--- a/spec/policies/dashboard/work_policy_spec.rb
+++ b/spec/policies/dashboard/work_policy_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe Dashboard::WorkPolicy, type: :policy do
 
   let(:other_user) { build_stubbed :user }
 
+  let(:admin) { create(:user, :admin) }
+
   permissions '.scope' do
     let(:scoped_works) { described_class::Scope.new(user, Work).resolve }
 
@@ -31,6 +33,7 @@ RSpec.describe Dashboard::WorkPolicy, type: :policy do
     context 'when a draft exists' do
       it { is_expected.not_to permit(user, work) }
       it { is_expected.not_to permit(other_user, work) }
+      it { is_expected.to permit(admin, work) }
     end
 
     context 'when no draft exists' do
@@ -38,6 +41,7 @@ RSpec.describe Dashboard::WorkPolicy, type: :policy do
 
       it { is_expected.to permit(user, work) }
       it { is_expected.not_to permit(other_user, work) }
+      it { is_expected.to permit(admin, work) }
     end
   end
 end

--- a/spec/policies/work_policy_spec.rb
+++ b/spec/policies/work_policy_spec.rb
@@ -3,15 +3,30 @@
 require 'rails_helper'
 
 RSpec.describe WorkPolicy, type: :policy do
-  let(:user) { instance_double 'User' }
+  subject { described_class }
+
   let(:work) { instance_double 'Work' }
+  let(:user) { build(:user) }
 
-  describe '#show?' do
-    it 'delegates to Work#read_access?' do
-      allow(work).to receive(:discover_access?)
-        .with(user).and_return(:whatever_discover_access_returns)
+  permissions :show? do
+    context 'when the user has discover access' do
+      before { allow(work).to receive(:discover_access?).with(user).and_return(true) }
 
-      expect(described_class.new(user, work).show?).to eq :whatever_discover_access_returns
+      it { is_expected.to permit(user, work) }
+    end
+
+    context 'when the user does NOT have discover access' do
+      before { allow(work).to receive(:discover_access?).with(user).and_return(false) }
+
+      it { is_expected.not_to permit(user, work) }
+    end
+
+    context 'when the user is an admin' do
+      let(:user) { build(:user, :admin) }
+
+      before { allow(work).to receive(:discover_access?).with(user).and_return(false) }
+
+      it { is_expected.to permit(user, work) }
     end
   end
 end


### PR DESCRIPTION
Admins can do anything, but we have to do that in _every_ policy. Could there be an easier way?

This answer is, _kinda_... We still have to hit every `xxx?` method and add a `user.admin?` to it, but we can simplify scoping by changing the pattern slightly. In this case, `Scope#limit` should be used instead of `#resolve`. This avoids having to do a `if...else` to check for admin access in every resolve method in every policy.