### PR TITLE
Use policies to authorize work history views

### DIFF
--- a/app/controllers/dashboard/work_histories_controller.rb
+++ b/app/controllers/dashboard/work_histories_controller.rb
@@ -3,7 +3,7 @@
 module Dashboard
   class WorkHistoriesController < BaseController
     def show
-      @work = current_user.works.find(params[:work_id])
+      @work = policy_scope(Work).find(params[:work_id])
       @latest_work_version = Dashboard::WorkVersionDecorator.new(@work.latest_version)
     end
   end


### PR DESCRIPTION
Viewing a work's version history was tied to only the current user's works. If the user is an admin or another user with the appropriate access, then they should be able to view the version history for the work. We can use our existing policies to accomplish that.