### PR TITLE
upgrades solr

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,7 @@ module Scholarsphere
   class Application < Rails::Application
     require 'healthchecks'
     require 'scholarsphere/redis_config'
+    require 'scholarsphere/solr_config'
     require 'json_log_formatter'
     require 'qa/authorities/persons'
 
@@ -39,6 +40,7 @@ module Scholarsphere
     # the framework and any gems in your application.
 
     config.redis = Scholarsphere::RedisConfig.new.to_hash
+    config.solr = Scholarsphere::SolrConfig.new
 
     # ActiveJob config
     config.active_job.queue_adapter = :sidekiq

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -1,9 +1,21 @@
 development: 
   adapter: solr
+  <% if ENV.fetch('SOLR_USERNAME', nil) and ENV.fetch('SOLR_PASSWORD', nil) %>
+  url: http://<%= ENV.fetch("SOLR_USERNAME", "solr") %>:<%= ENV.fetch("SOLR_PASSWORD", "solr") %>@<%= ENV.fetch("SOLR_HOST", "localhost") %>:<%= ENV.fetch("SOLR_PORT", "8983") %>/solr/<%= ENV.fetch("SOLR_COLLECTION", "blacklight-core") %>
+  <% else %>
   url: http://<%= ENV.fetch("SOLR_HOST", "localhost") %>:<%= ENV.fetch("SOLR_PORT", "8983") %>/solr/<%= ENV.fetch("SOLR_COLLECTION", "blacklight-core") %>
+  <% end %>
 test:
   adapter: solr
+  <% if ENV.fetch('SOLR_USERNAME', nil) and ENV.fetch('SOLR_PASSWORD', nil) %>
+  url: http://<%= ENV.fetch("SOLR_USERNAME", "solr") %>:<%= ENV.fetch("SOLR_PASSWORD", "solr") %>@<%= ENV.fetch("SOLR_HOST", "localhost") %>:<%= ENV.fetch("SOLR_PORT", "8983") %>/solr/<%= ENV.fetch("SOLR_COLLECTION", "blacklight-core") %>
+  <% else %>
   url: http://<%= ENV.fetch("SOLR_HOST", "localhost") %>:<%= ENV.fetch("SOLR_PORT", "8983") %>/solr/<%= ENV.fetch("SOLR_COLLECTION", "blacklight-core") %>
+  <% end %>
 production:
   adapter: solr
+  <% if ENV.fetch('SOLR_USERNAME', nil) and ENV.fetch('SOLR_PASSWORD', nil) %>
+  url: http://<%= ENV.fetch("SOLR_USERNAME", "solr") %>:<%= ENV.fetch("SOLR_PASSWORD", "solr") %>@<%= ENV.fetch("SOLR_HOST", "localhost") %>:<%= ENV.fetch("SOLR_PORT", "8983") %>/solr/<%= ENV.fetch("SOLR_COLLECTION", "blacklight-core") %>
+  <% else %>
   url: http://<%= ENV.fetch("SOLR_HOST", "localhost") %>:<%= ENV.fetch("SOLR_PORT", "8983") %>/solr/<%= ENV.fetch("SOLR_COLLECTION", "blacklight-core") %>
+  <% end %>

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -1,21 +1,9 @@
 development: 
   adapter: solr
-  <% if ENV.fetch('SOLR_USERNAME', nil) and ENV.fetch('SOLR_PASSWORD', nil) %>
-  url: http://<%= ENV.fetch("SOLR_USERNAME", "solr") %>:<%= ENV.fetch("SOLR_PASSWORD", "solr") %>@<%= ENV.fetch("SOLR_HOST", "localhost") %>:<%= ENV.fetch("SOLR_PORT", "8983") %>/solr/<%= ENV.fetch("SOLR_COLLECTION", "blacklight-core") %>
-  <% else %>
-  url: http://<%= ENV.fetch("SOLR_HOST", "localhost") %>:<%= ENV.fetch("SOLR_PORT", "8983") %>/solr/<%= ENV.fetch("SOLR_COLLECTION", "blacklight-core") %>
-  <% end %>
+  url: <%= Rails.configuration.solr.query_url %>
 test:
   adapter: solr
-  <% if ENV.fetch('SOLR_USERNAME', nil) and ENV.fetch('SOLR_PASSWORD', nil) %>
-  url: http://<%= ENV.fetch("SOLR_USERNAME", "solr") %>:<%= ENV.fetch("SOLR_PASSWORD", "solr") %>@<%= ENV.fetch("SOLR_HOST", "localhost") %>:<%= ENV.fetch("SOLR_PORT", "8983") %>/solr/<%= ENV.fetch("SOLR_COLLECTION", "blacklight-core") %>
-  <% else %>
-  url: http://<%= ENV.fetch("SOLR_HOST", "localhost") %>:<%= ENV.fetch("SOLR_PORT", "8983") %>/solr/<%= ENV.fetch("SOLR_COLLECTION", "blacklight-core") %>
-  <% end %>
+  url: <%= Rails.configuration.solr.query_url %>
 production:
   adapter: solr
-  <% if ENV.fetch('SOLR_USERNAME', nil) and ENV.fetch('SOLR_PASSWORD', nil) %>
-  url: http://<%= ENV.fetch("SOLR_USERNAME", "solr") %>:<%= ENV.fetch("SOLR_PASSWORD", "solr") %>@<%= ENV.fetch("SOLR_HOST", "localhost") %>:<%= ENV.fetch("SOLR_PORT", "8983") %>/solr/<%= ENV.fetch("SOLR_COLLECTION", "blacklight-core") %>
-  <% else %>
-  url: http://<%= ENV.fetch("SOLR_HOST", "localhost") %>:<%= ENV.fetch("SOLR_PORT", "8983") %>/solr/<%= ENV.fetch("SOLR_COLLECTION", "blacklight-core") %>
-  <% end %>
+  url: <%= Rails.configuration.solr.query_url %>

--- a/config/samples/application.yml
+++ b/config/samples/application.yml
@@ -77,6 +77,8 @@
 # SOLR_PORT: 8983
 # SOLR_CONFIG_DIR: solr/conf
 # SOLR_NUM_SHARDS: 1
+# SOLR_USERNAME: solr
+# SOLR_PASSWORD: solr
 #
 # --------------------------------------------------------------------------------------------------------------------
 #

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -8,6 +8,8 @@ services:
       CC_TEST_REPORTER_ID: ${CC_TEST_REPORTER_ID}
       CI: ${CI}
       CIRCLECI: ${CIRCLECI}
+      SOLR_USERNAME: scholarsphere
+      SOLR_PASSWORD: scholarsphere
       CIRCLE_SHA1: ${CIRCLE_SHA1}
       CIRCLE_BRANCH: ${CIRCLE_BRANCH}
       GIT_COMMITTED_AT: ${GIT_COMMITED_AT}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ x-web_env: &web_env
   environment:
       CI: "true"
       REDIS_HOST: redis
+      SOLR_USERNAME: scholarsphere
+      SOLR_PASSWORD: scholarsphere
       REDIS_PASSWORD: redispassword
       OAUTH_APP_ID: ${OAUTH_APP_ID}
       OAUTH_APP_SECRET: ${OAUTH_APP_SECRET}
@@ -79,15 +81,17 @@ services:
     - -c 
     - mkdir -p /data/scholarsphere; minio --compat server --address ':9000' /data
   solr:
-    image: solr:8.2.0-slim
+    image: psul/solr:8.5.2-slim
     restart: always
+    environment:
+      SOLR_USERNAME: scholarsphere
+      SOLR_PASSWORD: scholarsphere
     volumes:
     - solr-data:/var/solr
     ports:
     - ${SOLR_PORT:-8983}:8983
     command: [
-      "solr-foreground",
-      "-DzkRun"
+      "/usr/local/bin/start-solr.sh"
     ]
 
   adminer:

--- a/lib/scholarsphere/solr_admin.rb
+++ b/lib/scholarsphere/solr_admin.rb
@@ -89,6 +89,9 @@ module Scholarsphere
 
       def connection
         @connection ||= Faraday.new(config.url) do |faraday|
+          if config.solr_username && config.solr_password
+            faraday.request :basic_auth, config.solr_username, config.solr_password
+          end
           faraday.request :multipart
           faraday.adapter :net_http
         end

--- a/lib/scholarsphere/solr_config.rb
+++ b/lib/scholarsphere/solr_config.rb
@@ -8,11 +8,11 @@ module Scholarsphere
     COLLECTION_PATH = '/solr/admin/collections'
 
     def solr_username
-      ENV.fetch('SOLR_USERNAME', nil)
+      ENV.fetch('SOLR_USERNAME', 'scholarsphere')
     end
 
     def solr_password
-      ENV.fetch('SOLR_PASSWORD', nil)
+      ENV.fetch('SOLR_PASSWORD', 'scholarsphere')
     end
 
     def solr_host
@@ -33,6 +33,10 @@ module Scholarsphere
 
     def collection_url
       "#{url}#{COLLECTION_PATH}"
+    end
+
+    def query_url
+      "http://#{solr_username}:#{solr_password}@#{solr_host}:#{solr_port}/solr/#{collection_name}"
     end
 
     def dir

--- a/lib/scholarsphere/solr_config.rb
+++ b/lib/scholarsphere/solr_config.rb
@@ -7,6 +7,14 @@ module Scholarsphere
     CONFIG_PATH = '/solr/admin/configs'
     COLLECTION_PATH = '/solr/admin/collections'
 
+    def solr_username
+      ENV.fetch('SOLR_USERNAME', nil)
+    end
+
+    def solr_password
+      ENV.fetch('SOLR_PASSWORD', nil)
+    end
+
     def solr_host
       ENV.fetch('SOLR_HOST', 'localhost')
     end


### PR DESCRIPTION
_Highway to the Danger Zone!_

rails application should be passed `SOLR_USERNAME` and `SOLR_PASSWORD` values. solr should be running with the psul/solr:* images to ease setting up auth. solr container should be sent the `SOLR_USERNAME` and `SOLR_PASSWORD` env variables. the psul startup script will take care of enabling security based of the existence of those values. `docker-compose up solr` gives that to you for free. 

any pre-existing solr configuration will need to be rebuilt, configurations uploaded in solr 8.2 unauthenticated are untrusted to new versions of solr.

after spinning up rails with this configuration: 

```
bundle exec rake solr:reset # this will probably fail
bundle exec rake solr:init
bundle exec rake solr:reindex_all
```


