### PR TITLE
Delete resources from the index

### DIFF
--- a/app/jobs/solr_delete_job.rb
+++ b/app/jobs/solr_delete_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class SolrDeleteJob < ApplicationJob
+  queue_as :indexing
+
+  def perform(id)
+    IndexingService.delete_document(id, commit: true)
+  end
+end

--- a/app/models/actor.rb
+++ b/app/models/actor.rb
@@ -55,6 +55,8 @@ class Actor < ApplicationRecord
 
   after_save :reindex_if_default_alias_changed
 
+  after_destroy :update_index_async
+
   def default_alias
     super.presence || "#{given_name} #{surname}"
   end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -69,6 +69,8 @@ class Collection < ApplicationRecord
 
   after_save :update_index_async
 
+  after_destroy { SolrDeleteJob.perform_later(uuid) }
+
   # Fields that can contain multiple values automatically remove blank values
   %i[
     keyword

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -87,6 +87,8 @@ class WorkVersion < ApplicationRecord
 
   after_save :update_index_async
 
+  after_destroy { SolrDeleteJob.perform_later(uuid) }
+
   aasm do
     state :draft, intial: true
     state :published, :withdrawn, :removed

--- a/app/services/indexing_service.rb
+++ b/app/services/indexing_service.rb
@@ -1,15 +1,25 @@
 # frozen_string_literal: true
 
 class IndexingService
-  # @param [Hash]
-  # @param [Boolean]
-  def self.add_document(document, commit: false)
-    connection = Blacklight.default_index.connection
-    connection.add(document)
-    connection.commit if commit
-  end
+  class << self
+    # @param [Hash]
+    # @param [Boolean]
+    def add_document(document, commit: false)
+      connection = Blacklight.default_index.connection
+      connection.add(document)
+      connection.commit if commit
+    end
 
-  def self.commit
-    Blacklight.default_index.connection.commit
+    # @param [String]
+    # @param [Boolean]
+    def delete_document(id, commit: false)
+      connection = Blacklight.default_index.connection
+      connection.delete_by_id(id)
+      connection.commit if commit
+    end
+
+    def commit
+      Blacklight.default_index.connection.commit
+    end
   end
 end

--- a/spec/jobs/solr_delete_job_spec.rb
+++ b/spec/jobs/solr_delete_job_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SolrDeleteJob, type: :job do
+  describe '#perform' do
+    before { allow(IndexingService).to receive(:delete_document) }
+
+    it 'calls IndexingService#delete_document' do
+      described_class.perform_now('uuid')
+      expect(IndexingService).to have_received(:delete_document).with('uuid', commit: true)
+    end
+  end
+end

--- a/spec/models/actor_spec.rb
+++ b/spec/models/actor_spec.rb
@@ -3,8 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe Actor, type: :model do
-  it_behaves_like 'an indexable resource'
-
   describe 'table' do
     it { is_expected.to have_db_column(:given_name).of_type(:string) }
     it { is_expected.to have_db_column(:surname).of_type(:string) }
@@ -62,6 +60,17 @@ RSpec.describe Actor, type: :model do
         actor.save
         expect(actor).not_to have_received(:update_index_async)
       end
+    end
+  end
+
+  describe 'after destroy' do
+    let(:actor) { create :actor }
+
+    before { allow(actor).to receive(:update_index_async) }
+
+    it 'reindexes its former works and collections' do
+      actor.destroy
+      expect(actor).to have_received(:update_index_async)
     end
   end
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe Collection, type: :model do
-  it_behaves_like 'an indexable resource'
+  it_behaves_like 'an indexable resource' do
+    let(:resource) { create(:collection) }
+  end
 
   it_behaves_like 'a resource with permissions' do
     let(:factory_name) { :collection }

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe WorkVersion, type: :model do
-  it_behaves_like 'an indexable resource'
+  it_behaves_like 'an indexable resource' do
+    let(:resource) { build(:work_version) }
+  end
 
   it_behaves_like 'a resource with view statistics' do
     let(:resource) { create(:work_version) }

--- a/spec/support/shared/an_indexable_resource.rb
+++ b/spec/support/shared/an_indexable_resource.rb
@@ -3,4 +3,13 @@
 RSpec.shared_examples 'an indexable resource' do
   it { is_expected.to respond_to(:update_index) }
   it { is_expected.to respond_to(:update_index_async) }
+
+  describe 'after destroy' do
+    before { allow(SolrDeleteJob).to receive(:perform_later) }
+
+    it 'removes the resource from the index' do
+      resource.destroy
+      expect(SolrDeleteJob).to have_received(:perform_later).with(resource.uuid)
+    end
+  end
 end


### PR DESCRIPTION
When resources are delete from Postgres they should be deleted from the Solr index as well.