### PR TITLE
Display icons for work types

### DIFF
--- a/app/components/thumbnail_component.html.erb
+++ b/app/components/thumbnail_component.html.erb
@@ -1,0 +1,3 @@
+<div class="<%= html_classes %>">
+  <i class="material-icons material-icons--thumbnail"><%= icon %></i>
+</div>

--- a/app/components/thumbnail_component.rb
+++ b/app/components/thumbnail_component.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+class ThumbnailComponent < ApplicationComponent
+  attr_reader :resource, :featured
+
+  # @param [SolrDocument, WorkVersion] resource
+  def initialize(resource:, featured: false)
+    @resource = resource
+    @featured = featured
+  end
+
+  def icon
+    icon_map.fetch(resource.work_type, 'bar_chart')
+  end
+
+  def html_classes
+    if featured?
+      'thumbnail col-xxl-6 ft-work__img'
+    else
+      'thumbnail'
+    end
+  end
+
+  private
+
+    def featured?
+      @featured != false
+    end
+
+    # @note Maps a work type with an icon from https://material.io/resources/icons
+    def icon_map
+      HashWithIndifferentAccess.new({
+                                      article: 'article',
+                                      audio: 'headset',
+                                      book: 'book',
+                                      capstone_project: 'landscape',
+                                      conference_proceeding: 'groups',
+                                      dataset: 'analytics',
+                                      dissertation: 'subject',
+                                      image: 'image',
+                                      journal: 'subject',
+                                      map_or_cartographic_material: 'map',
+                                      masters_culminating_experience: 'landscape',
+                                      masters_thesis: 'subject',
+                                      other: 'bar_chart',
+                                      # part_of_book: nil,
+                                      # poster: nil,
+                                      presentation: 'stacked_line_chart',
+                                      # project: nil,
+                                      report: 'stacked_line_chart',
+                                      research_paper: 'biotech',
+                                      # software_or_program_code: nil,
+                                      thesis: 'subject',
+                                      unspecified: 'bar_chart',
+                                      video: 'movie'
+                                    })
+    end
+end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -85,7 +85,7 @@ class CatalogController < ApplicationController
     # prefixes that will be used to create the navigation (note: It is
     # case sensitive when searching values)
 
-    config.add_facet_field 'work_type_ssim', label: 'Work Type'
+    config.add_facet_field 'display_work_type_ssi', label: 'Work Type'
     config.add_facet_field 'keyword_tesim', label: 'Keywords'
     config.add_facet_field 'subject_tesim', label: 'Subject'
     config.add_facet_field 'creators_sim', label: 'Creators'

--- a/app/javascript/frontend/styles/_common.scss
+++ b/app/javascript/frontend/styles/_common.scss
@@ -1230,3 +1230,20 @@ h4,
     padding: $spacer * 3;
   }
 }
+
+.material-icons {
+
+  &--thumbnail {
+    font-size: 200px;
+    height: 200px;
+    width: 200px;
+    color: $black;
+    background: $gray-85;
+  }
+
+}
+
+.thumbnail {
+  background: $gray-85;
+}
+

--- a/app/javascript/frontend/styles/index.scss
+++ b/app/javascript/frontend/styles/index.scss
@@ -5,6 +5,9 @@
 // Import Google Fonts
 @import url('https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,600;0,700;1,400&family=Roboto+Slab&display=swap');
 
+// Import Material Icons
+@import url('https://fonts.googleapis.com/icon?family=Material+Icons');
+
 // Import Bootstrap with our own variables
 @import 'variables-override';
 @import 'bootstrap-loader';

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -30,8 +30,12 @@ class SolrDocument
     Array.wrap(self[:published_date_tesim]).first
   end
 
+  def display_work_type
+    self[:display_work_type_ssi]
+  end
+
   def work_type
-    Array.wrap(self[:work_type_ssim]).first
+    self[:work_type_ss]
   end
 
   def aasm_state

--- a/app/schemas/work_type_schema.rb
+++ b/app/schemas/work_type_schema.rb
@@ -3,7 +3,8 @@
 class WorkTypeSchema < BaseSchema
   def document
     {
-      work_type_ssim: Work::Types.display(resource.work_type)
+      display_work_type_ssi: Work::Types.display(resource.work_type),
+      work_type_ss: resource.work_type
     }
   end
 

--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -2,7 +2,7 @@
      class="card card--horizontal mb-3"
      data-document-counter="<%= document_counter %>"
      itemscope itemtype="<%= document.itemtype %>">
-  <img src="http://placehold.it/500x500">
+  <%= render ThumbnailComponent.new(resource: document) %>
   <div class="card-body">
     <h2 class="card-title">
       <%= link_to document.title, resource_path(document.id) %>
@@ -12,7 +12,7 @@
       <%= t('activerecord.attributes.work_version.published_date') %>
       <time><%= document.published_date %></time>
     </p>
-    <p><%= document.work_type %></p>
+    <p><%= document.display_work_type %></p>
     <div class="card-actions">
       <%= render VisibilityBadgeComponent.new(work: document) %>
       <%= render WorkVersions::StatusBadgeComponent.new(work_version: document) if document.aasm_state.present? %>

--- a/app/views/dashboard/catalog/_index_work_version.html.erb
+++ b/app/views/dashboard/catalog/_index_work_version.html.erb
@@ -1,7 +1,7 @@
 <div id="document-<%= index_work_version.uuid %>"
      class="card card--horizontal mb-3"
      data-document-counter="<%= index_work_version_counter %>">
-  <img src="http://placehold.it/500x500">
+  <%= render ThumbnailComponent.new(resource: index_work_version) %>
   <div class="card-body">
     <h2 class="card-title">
       <%= link_to index_work_version.title, dashboard_work_version_path(index_work_version) %>

--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -8,7 +8,6 @@
     <!-- Internet Explorer use the highest version available -->
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <title><%= render_page_title %></title>
     <%= favicon_link_tag %>
     <%= javascript_pack_tag 'frontend' %>

--- a/app/views/pages/_featured.html.erb
+++ b/app/views/pages/_featured.html.erb
@@ -2,9 +2,7 @@
   <div class="surface ft-work">
     <h3><%= link_to work_version.title, resource_path(work_version.uuid) %></h3>
     <div class="row">
-      <div class="col-xxl-6 ft-work__img">
-        <a href="#"><img src="http://placehold.it/1000x1200" alt=""></a>
-      </div>
+      <%= render ThumbnailComponent.new(resource: work_version, featured: true) %>
       <%= render FeaturedWorkMetadataComponent.new(work_version: work_version) %>
     </div>
   </div>

--- a/spec/components/thumbnail_component_spec.rb
+++ b/spec/components/thumbnail_component_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ThumbnailComponent, type: :component do
+  let(:result) { render_inline(component) }
+  let(:resource) { instance_spy('Resource') }
+
+  context 'when featured is true' do
+    let(:component) { described_class.new(resource: resource, featured: true) }
+
+    it 'renders a thumbnail for a featured work' do
+      expect(result.css('div').first.classes).to contain_exactly('col-xxl-6', 'ft-work__img', 'thumbnail')
+      expect(result.css('div').first.text).to include('bar_chart')
+    end
+  end
+
+  context 'when featured is false' do
+    let(:component) { described_class.new(resource: resource) }
+
+    it 'renders a thumbnail for a featured work' do
+      expect(result.css('div').first.classes).to contain_exactly('thumbnail')
+      expect(result.css('div').first.text).to include('bar_chart')
+    end
+  end
+end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -223,6 +223,7 @@ RSpec.describe Work, type: :model do
           depositor_id_isi
           discover_groups_ssim
           discover_users_ssim
+          display_work_type_ssi
           doi_tesim
           embargoed_until_dtsi
           id
@@ -231,7 +232,7 @@ RSpec.describe Work, type: :model do
           updated_at_dtsi
           uuid_ssi
           visibility_ssi
-          work_type_ssim
+          work_type_ss
         )
       end
 
@@ -254,6 +255,7 @@ RSpec.describe Work, type: :model do
           description_tesim
           discover_groups_ssim
           discover_users_ssim
+          display_work_type_ssi
           doi_tesim
           embargoed_until_dtsi
           id
@@ -276,7 +278,7 @@ RSpec.describe Work, type: :model do
           version_number_isi
           visibility_ssi
           work_id_isi
-          work_type_ssim
+          work_type_ss
         )
       end
 

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -233,7 +233,8 @@ RSpec.describe WorkVersion, type: :model do
       is_expected.to include(
         title_tesim: [work_version.title],
         latest_version_bsi: false,
-        work_type_ssim: Work::Types.display(work_version.work_type),
+        display_work_type_ssi: Work::Types.display(work_version.work_type),
+        work_type_ss: work_version.work_type,
         published_date_dtrsi: '1999',
         embargoed_until_dtsi: nil,
         depositor_id_isi: work_version.work.depositor.id,

--- a/spec/schemas/work_type_schema_spec.rb
+++ b/spec/schemas/work_type_schema_spec.rb
@@ -9,13 +9,23 @@ RSpec.describe WorkTypeSchema do
     context 'with a work' do
       let(:resource) { build(:work) }
 
-      its(:document) { is_expected.to eq(work_type_ssim: Work::Types.display(Work::Types.default)) }
+      its(:document) do
+        is_expected.to eq(
+          display_work_type_ssi: Work::Types.display(Work::Types.default),
+          work_type_ss: Work::Types.default
+        )
+      end
     end
 
     context 'with a work version' do
       let(:resource) { build(:work_version) }
 
-      its(:document) { is_expected.to eq(work_type_ssim: Work::Types.display(Work::Types.default)) }
+      its(:document) do
+        is_expected.to eq(
+          display_work_type_ssi: Work::Types.display(Work::Types.default),
+          work_type_ss: Work::Types.default
+        )
+      end
     end
   end
 


### PR DESCRIPTION
Selects a icon from the materials.io icon set based on the work type. The icons are displayed for search results and dashboard results.

Works and work versions are indexed differently, and include the work type identifying key as well as the display variation of the type. Additionally, our icons are compiled into our webpack instead of being loaded separately.

Fixes #386 

## Search and Dashboard Results

![Screen Shot 2020-08-04 at 2 06 40 PM](https://user-images.githubusercontent.com/312085/89328696-c42ef080-d65b-11ea-9674-8dd52864f4c1.png)

## Featured Works

![Screen Shot 2020-08-04 at 2 07 37 PM](https://user-images.githubusercontent.com/312085/89328767-df016500-d65b-11ea-9acf-3f5a05e9f336.png)
