### PR TITLE
Status badges with and without a version number

### DIFF
--- a/app/components/work_versions/status_badge_component.rb
+++ b/app/components/work_versions/status_badge_component.rb
@@ -1,19 +1,32 @@
 # frozen_string_literal: true
 
 class WorkVersions::StatusBadgeComponent < ApplicationComponent
-  def initialize(work_version:)
+  STATE_CLASSES = {
+    WorkVersion::STATE_DRAFT => %w(badge--dark-blue badge--outline),
+    WorkVersion::STATE_PUBLISHED => %w(badge--dark-blue)
+  }.with_indifferent_access.freeze
+
+  INVERTED_STATE_CLASSES = {
+    WorkVersion::STATE_DRAFT => %w(badge-light badge--outline),
+    WorkVersion::STATE_PUBLISHED => %w(badge-light)
+  }.with_indifferent_access.freeze
+
+  def initialize(work_version:, invert: false)
     @work_version = work_version
+    @invert = invert
   end
 
   private
 
-    attr_reader :work_version
+    attr_reader :work_version,
+                :invert
 
     def html_class
       [
         'badge',
-        'badge--text',
-        "badge--#{color.fetch(content, 'red')}"
+        'badge--nudge-up',
+        'ml-1',
+        *state_classes
       ].join(' ')
     end
 
@@ -21,14 +34,8 @@ class WorkVersions::StatusBadgeComponent < ApplicationComponent
       work_version.aasm_state
     end
 
-    def version
-      "V#{work_version.version_number}"
-    end
-
-    def color
-      HashWithIndifferentAccess.new({
-                                      WorkVersion::STATE_DRAFT => 'gray-800',
-                                      WorkVersion::STATE_PUBLISHED => 'dark-blue'
-                                    })
+    def state_classes
+      class_hash = invert ? INVERTED_STATE_CLASSES : STATE_CLASSES
+      class_hash[work_version.aasm_state]
     end
 end

--- a/app/components/work_versions/version_status_badge_component.html.erb
+++ b/app/components/work_versions/version_status_badge_component.html.erb
@@ -1,0 +1,4 @@
+<%= content_tag :div, class: html_class do %>
+  <span class="badge--prepend"><%= version %></span>
+  <span class="badge--content"><%= content %></span>
+<% end %>

--- a/app/components/work_versions/version_status_badge_component.rb
+++ b/app/components/work_versions/version_status_badge_component.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# @abstract This is similar to the StatusBadgeComponent, but includes the
+# version number as part of the badge. Used on the search results and dashboard.
+class WorkVersions::VersionStatusBadgeComponent < ApplicationComponent
+  def initialize(work_version:)
+    @work_version = work_version
+  end
+
+  private
+
+    attr_reader :work_version
+
+    def html_class
+      [
+        'badge',
+        'badge--text',
+        *state_classes
+      ].join(' ')
+    end
+
+    def content
+      work_version.aasm_state
+    end
+
+    # TODO we need to extract this logic out into a decorator. It's already
+    # duplicated in Dashboard::WorkVersionDecorator but once we're done with the
+    # redesign I think it would be smart to factor them all into the same place.
+    def version
+      "V#{work_version.version_name.presence || work_version.version_number}"
+    end
+
+    def state_classes
+      {
+        WorkVersion::STATE_DRAFT => %w(badge--dark-blue badge--outline),
+        WorkVersion::STATE_PUBLISHED => %w(badge--dark-blue)
+      }.with_indifferent_access.fetch(work_version.aasm_state)
+    end
+end

--- a/app/javascript/frontend/styles/_common.scss
+++ b/app/javascript/frontend/styles/_common.scss
@@ -1074,6 +1074,14 @@ h4,
     }
   }
 
+  &-light {
+    &.badge--outline {
+      background: transparent;
+      border: 1px solid $light;
+      color: $light;
+    }
+  }
+
   &--icon {
     position: relative;
     padding: .55rem .5rem .55rem 2.25rem;
@@ -1128,22 +1136,30 @@ h4,
   }
 
   &--text {
-    position: relative;
-    padding: .65rem .5rem .65rem 2.5rem;
+    display: inline-flex;
+    padding: 0;
 
-    &::before {
-      content: attr(data-before);
-      font-size: 13px;
-      position: absolute;
-      left: 0;
-      top: 0;
-      height: 100%;
+    .badge--prepend {
+      flex: 0 0;
       display: inline-block;
+      padding: .65rem .5rem;
       text-transform: none;
       white-space: nowrap;
       word-wrap: normal;
-      padding: 8px 7px 8px 8px;
       border-right: 1px solid $white;
+    }
+
+    .badge--content {
+      flex: 1;
+      padding: .65rem .5rem;
+    }
+
+    @each $color, $value in $badge-colors {
+      &.badge--outline.badge--#{$color} {
+        .badge--prepend {
+          border-right-color: $value;
+        }
+      }
     }
   }
 

--- a/app/javascript/frontend/styles/_variables-override.scss
+++ b/app/javascript/frontend/styles/_variables-override.scss
@@ -91,3 +91,22 @@ $modal-header-padding-y: $modal-inner-padding;
 $modal-header-padding-x: $modal-inner-padding;
 
 $hr-margin-y: $spacer * 2;
+
+$badge-colors: (
+  "gray-100": $gray-100,
+  "gray-300": $gray-300,
+  "gray-800": $gray-800,
+  "gray-85": $gray-85,
+  "black": $black,
+  "blue": $blue,
+  "mid-blue": $mid-blue,
+  "dark-blue": $dark-blue,
+  "light-green": $light-green,
+  "dark-green": $dark-green,
+  "red": $red,
+  "light-red": $light-red,
+  "dark-red": $dark-red,
+  "orange": $orange,
+  "secondary": $secondary
+);
+

--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <!-- Internet Explorer use the highest version available -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <title>Component Preview</title>
+    <%= favicon_link_tag %>
+    <%= javascript_pack_tag 'frontend' %>
+    <%= stylesheet_pack_tag 'frontend', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= csrf_meta_tags %>
+  </head>
+
+  <body>
+    <header>
+      <nav class="navbar navbar-light navbar-expand-lg topbar">
+        <%= link_to 'ScholarSphere', root_path, class: 'navbar-brand slab-font' %>
+        <%= link_to image_pack_tag(
+              'media/frontend/img/logo-penn_state_university_libraries.png',
+              alt: 'Penn State – University Libraries'
+            ),
+                    'https://libraries.psu.edu/' %>
+        <button class="navbar-toggler ml-auto"
+                type="button"
+                data-toggle="collapse"
+                data-target="#topbar"
+                aria-controls="topbar"
+                aria-expanded="false"
+                aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="topbar">
+          <ul class="navbar-nav">
+            <li class="nav-item">
+              <%= link_to 'About', '#', class: 'nav-link' %>
+            </li>
+            <li class="nav-item">
+              <%= link_to 'Help', '#', class: 'nav-link' %>
+            </li>
+            <li class="nav-item">
+              <%= link_to 'Contact', '#', class: 'nav-link' %>
+            </li>
+          </ul>
+        </div>
+      </nav>
+    </header>
+
+    <main class="main">
+      <div class="container-fluid">
+        <%= yield %>
+      </div>
+    </main>
+  </body>
+</html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -49,5 +49,7 @@ module Scholarsphere
     config.generators.system_tests = nil
 
     config.time_zone = 'Eastern Time (US & Canada)'
+
+    config.view_component.default_preview_layout = 'component_preview'
   end
 end

--- a/spec/components/work_versions/status_badge_component_spec.rb
+++ b/spec/components/work_versions/status_badge_component_spec.rb
@@ -6,13 +6,28 @@ RSpec.describe WorkVersions::StatusBadgeComponent, type: :component do
   let(:node) { render_inline(described_class.new(work_version: work_version)) }
   let(:badge) { node.css('div').first }
 
+  let(:common_expected_classes) { %w(badge badge--nudge-up ml-1) }
+
   context 'with a draft' do
     let(:work_version) { build_stubbed :work_version, :draft }
 
     specify do
       expect(badge.text).to include('draft')
-      expect(badge.attributes['data-before'].value).to eq('V1')
-      expect(badge.classes).to contain_exactly('badge', 'badge--text', 'badge--gray-800')
+      expect(badge.classes).to contain_exactly(
+        *common_expected_classes,
+        'badge--dark-blue', 'badge--outline'
+      )
+    end
+
+    context 'when inverted' do
+      let(:node) { render_inline(described_class.new(work_version: work_version, invert: true)) }
+
+      specify do
+        expect(badge.classes).to contain_exactly(
+          *common_expected_classes,
+          'badge-light', 'badge--outline'
+        )
+      end
     end
   end
 
@@ -21,8 +36,21 @@ RSpec.describe WorkVersions::StatusBadgeComponent, type: :component do
 
     specify do
       expect(badge.text).to include('published')
-      expect(badge.attributes['data-before'].value).to eq('V3')
-      expect(badge.classes).to contain_exactly('badge', 'badge--text', 'badge--dark-blue')
+      expect(badge.classes).to contain_exactly(
+        *common_expected_classes,
+        'badge--dark-blue'
+      )
+    end
+
+    context 'when inverted' do
+      let(:node) { render_inline(described_class.new(work_version: work_version, invert: true)) }
+
+      specify do
+        expect(badge.classes).to contain_exactly(
+          *common_expected_classes,
+          'badge-light'
+        )
+      end
     end
   end
 end

--- a/spec/components/work_versions/version_status_badge_component_spec.rb
+++ b/spec/components/work_versions/version_status_badge_component_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WorkVersions::VersionStatusBadgeComponent, type: :component do
+  let(:node) { render_inline(described_class.new(work_version: work_version)) }
+  let(:badge) { node.css('div').first }
+
+  context 'with a draft' do
+    let(:work_version) { build_stubbed :work_version, :draft }
+
+    specify do
+      expect(badge.text).to include('draft').and include('V1')
+      expect(badge.classes).to contain_exactly('badge', 'badge--text', 'badge--dark-blue', 'badge--outline')
+    end
+  end
+
+  context 'with a published version' do
+    let(:work_version) { build_stubbed :work_version, :published, version_number: 3 }
+
+    specify do
+      expect(badge.text).to include('published')
+        .and include('V3')
+      expect(badge.classes).to contain_exactly('badge', 'badge--text', 'badge--dark-blue')
+    end
+  end
+
+  context 'when version_name is provided' do
+    let(:work_version) { build_stubbed :work_version, version_name: '1.2.3' }
+
+    specify do
+      expect(badge.text).to include('V1.2.3')
+    end
+  end
+end

--- a/test/components/previews/status_badge_component_preview.rb
+++ b/test/components/previews/status_badge_component_preview.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class StatusBadgeComponentPreview < ViewComponent::Preview
+  def default
+    draft = FactoryBot.build_stubbed(:work_version, :draft)
+    published = FactoryBot.build_stubbed(:work_version, :published, version_number: 3)
+    fancy_version_name = FactoryBot.build_stubbed(:work_version, :published, version_number: 3, version_name: '1.2.3')
+
+    render_with_template(locals: {
+                           draft: draft,
+                           published: published,
+                           fancy_version_name: fancy_version_name
+                         })
+  end
+end

--- a/test/components/previews/status_badge_component_preview/default.html.erb
+++ b/test/components/previews/status_badge_component_preview/default.html.erb
@@ -1,0 +1,16 @@
+<h1>Status Badge Component Variations</h1>
+
+<h2>With Version</h2>
+
+<%= render WorkVersions::VersionStatusBadgeComponent.new(work_version: draft) %><br><br>
+<%= render WorkVersions::VersionStatusBadgeComponent.new(work_version: published) %><br><br>
+<%= render WorkVersions::VersionStatusBadgeComponent.new(work_version: fancy_version_name) %><br><br>
+
+<h2>Sans-Version</h2>
+
+<%= render WorkVersions::StatusBadgeComponent.new(work_version: draft) %><br><br>
+<%= render WorkVersions::StatusBadgeComponent.new(work_version: published) %><br><br>
+<div style="background: rgb(44, 118, 199); padding-top: 1em">
+  <%= render WorkVersions::StatusBadgeComponent.new(work_version: draft, invert: true) %><br><br>
+  <%= render WorkVersions::StatusBadgeComponent.new(work_version: published, invert: true) %><br><br>
+</div>


### PR DESCRIPTION
This also includes a cool feature of View Components, that in dev mode gives you the ability to create a simple controller/view to demo the components.

Check out `test/components/previews/status_badge_component_preview.rb` and `test/components/previews/status_badge_component_preview/default.html.erb`

Which in development mode can be accessed at the route (both puma-dev and bin/rails s):
http://scholarsphere-4.test/rails/view_components/status_badge_component/default
http://localhost:3000/rails/view_components/status_badge_component/default