### PR TITLE
Monthly stats email

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -20,6 +20,7 @@ linters:
       - '*app/views/dashboard/catalog/_index_work_version.html.erb'
       - '*test/*'
       - '*app/views/layouts/component_preview.html.erb'
+      - '*app/views/actor_mailer/*'
   RightTrim:
     enabled: true
     enforced_style: '-'

--- a/app/mailers/actor_mailer.rb
+++ b/app/mailers/actor_mailer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class ActorMailer < ApplicationMailer
+  def monthly_stats(month: Time.zone.now.last_month)
+    @presenter = ActorStatsPresenter.new(
+      actor: params[:actor],
+      beginning_at: month.beginning_of_month,
+      ending_at: month.end_of_month
+    )
+    return if @presenter.file_downloads.zero?
+
+    mail(
+      to: @presenter.actor.email,
+      subject: ::I18n.t('mailers.actor.monthly_stats.subject')
+    )
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: Rails.configuration.no_reply_email
   layout 'mailer'
 end

--- a/app/presenters/actor_stats_presenter.rb
+++ b/app/presenters/actor_stats_presenter.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class ActorStatsPresenter
+  attr_reader :actor,
+              :beginning_at,
+              :ending_at
+
+  # @param [Actor] actor
+  # @param [Date] beginning_at
+  # @param [Date] ending_at
+  def initialize(actor:, beginning_at: 100.years.ago, ending_at: Time.zone.now)
+    @actor = actor
+    @beginning_at = beginning_at
+    @ending_at = ending_at
+  end
+
+  def display_name
+    actor.default_alias
+  end
+
+  def file_downloads
+    @file_downloads ||= ViewStatistic
+      .where(resource_type: 'FileResource', resource_id: file_resource_ids)
+      .where('date BETWEEN ? AND ?', beginning_at, ending_at)
+      .sum(:count)
+  end
+
+  def total_files
+    file_resource_ids.count
+  end
+
+  private
+
+    # @note Probably ought to look at optimizing this query
+    def file_resource_ids
+      @file_resource_ids ||= actor.deposited_works.flat_map(&:versions).flat_map(&:file_resource_ids)
+    end
+end

--- a/app/presenters/actor_stats_presenter.rb
+++ b/app/presenters/actor_stats_presenter.rb
@@ -31,8 +31,10 @@ class ActorStatsPresenter
 
   private
 
-    # @note Probably ought to look at optimizing this query
     def file_resource_ids
-      @file_resource_ids ||= actor.deposited_works.flat_map(&:versions).flat_map(&:file_resource_ids)
+      @file_resource_ids ||= FileVersionMembership
+        .joins(work_version: [:work])
+        .where(works: { depositor_id: actor.id })
+        .pluck(:file_resource_id)
     end
 end

--- a/app/views/actor_mailer/monthly_stats.html.erb
+++ b/app/views/actor_mailer/monthly_stats.html.erb
@@ -1,0 +1,40 @@
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=ISO-8859-1">
+  </head>
+<body>
+  <h1><%= t('mailers.actor.monthly_stats.heading', date: @presenter.ending_at.strftime('%B')) %></h1>
+   <p>Dear <%= @presenter.display_name %>, <br>
+      You had <%= @presenter.file_downloads %> new downloads last month across your <%= @presenter.total_files %> files
+      in <%= t('application_name') %>.
+      You can
+      <a href="https://scholarsphere.psu.edu/dashboard/">view your overall statistics in <%= t('application_name') %></a>
+      by accessing your dashboard.
+   </p>
+  <p>Interested in sharing, archiving, and preserving other work? Consider depositing any of the following in
+    <a href="https://scholarsphere.psu.edu/"><%= t('application_name') %></a></p>
+  <ul>
+    <li>Articles: Check <a href="http://www.sherpa.ac.uk/romeo/index.php">SHERPA/RoMEO</a> to determine which version of
+        an article you can archive.
+    </li>
+    <li>Datasets</li>
+    <li>Videos</li>
+    <li>Software and analysis code</li>
+    <li>Book chapters: Check your publishing agreement to see if you can deposit a contributed chapter.</li>
+    <li>Books: Consider
+      <a href="https://www.authorsalliance.org/resources/rights-reversion-portal/">regaining copyright</a>
+      from your publisher so you can deposit an out-of-print book. You can also deposit any book that is openly licensed,
+      such as an open access monograph bearing one of the Creative Commons licenses.
+    </li>
+  </ul>
+  <p>If you have questions please <a href="https://scholarsphere.psu.edu/contact">contact us!</a></p>
+  <p>If you'd like to opt out of receiving these emails, follow these steps:</p>
+    <ol>
+      <li>Login</li>
+      <li>Once directed to the dashboard, or from any page if you are already logged in, select "Edit Profile" from the
+          top right menu with your name listed.</li>
+      <li>Under the "Edit Profile" heading, select the first checkbox to "Opt out of monthly statistics via email"</li>
+      <li>Click the "Save Profile" button to save your choice to opt out of monthly statistics via email.</li>
+    </ol>
+</body>
+</html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,5 +51,7 @@ module Scholarsphere
     config.time_zone = 'Eastern Time (US & Canada)'
 
     config.view_component.default_preview_layout = 'component_preview'
+
+    config.no_reply_email = ENV.fetch('NO_REPLY_EMAIL', 'no_reply@scholarsphere.psu.edu')
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -49,6 +49,7 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.perform_caching = false
+  config.action_mailer.preview_path = Rails.root.join('spec', 'mailers', 'previews')
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -210,6 +210,11 @@ en:
       browse: 'Browse & Filter All Works'
     featured:
       heading: 'Featured Works'
+  mailers:
+    actor:
+      monthly_stats:
+        subject: "ScholarSphere - Reporting Monthly Downloads and Views"
+        heading: "Latest Report for the Month of %{date}"
   navbar:
     guest_name: 'Guest'
     heading:

--- a/db/migrate/20200810144730_add_stats_email_option_to_user.rb
+++ b/db/migrate/20200810144730_add_stats_email_option_to_user.rb
@@ -1,0 +1,5 @@
+class AddStatsEmailOptionToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :opt_out_stats_email, :boolean, default: false
+  end
+end

--- a/db/migrate/20200810144750_add_active_flag_to_user.rb
+++ b/db/migrate/20200810144750_add_active_flag_to_user.rb
@@ -1,0 +1,5 @@
+class AddActiveFlagToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :active, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_08_021358) do
+ActiveRecord::Schema.define(version: 2020_08_10_144750) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -156,6 +156,8 @@ ActiveRecord::Schema.define(version: 2020_07_08_021358) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "actor_id", null: false
+    t.boolean "opt_out_stats_email", default: false
+    t.boolean "active", default: true
     t.index ["access_id"], name: "index_users_on_access_id", unique: true
     t.index ["actor_id"], name: "index_users_on_actor_id"
   end

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :user do
+  desc 'Send out monthly download statistics email'
+  task monthly_stats_email: :environment do
+    User.where(provider: 'azure_oauth', opt_out_stats_email: false, active: true).each do |user|
+      ActorMailer.with(actor: user.actor).monthly_stats.deliver_later
+    end
+  end
+end

--- a/spec/lib/tasks/migration_spec.rb
+++ b/spec/lib/tasks/migration_spec.rb
@@ -3,8 +3,6 @@
 require 'rails_helper'
 
 describe 'migration' do
-  before(:all) { Rails.application.load_tasks }
-
   after { Rake::Task['migration:statistics'].reenable }
 
   describe ':statistics' do

--- a/spec/lib/tasks/user_spec.rb
+++ b/spec/lib/tasks/user_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'User rake tasks', type: :task do
+  describe ':monthly_stats_email', :inline_jobs do
+    before { allow_any_instance_of(ActorStatsPresenter).to receive(:file_downloads).and_return(3) }
+
+    after { Rake::Task['user:monthly_stats_email'].reenable }
+
+    context 'with an active user' do
+      context 'when they have opted to receive emails' do
+        before { create(:user) }
+
+        it 'sends an email to the user' do
+          expect {
+            Rake::Task['user:monthly_stats_email'].invoke
+          }.to change(ActionMailer::Base.deliveries, :count).by(1)
+        end
+      end
+
+      context 'when they have opted NOT to receive emails' do
+        before { create(:user, opt_out_stats_email: true) }
+
+        it 'does NOT send an email to the user' do
+          expect {
+            Rake::Task['user:monthly_stats_email'].invoke
+          }.not_to(change(ActionMailer::Base.deliveries, :count))
+        end
+      end
+    end
+
+    context 'with an inactive user' do
+      before { create(:user, active: false) }
+
+      it 'does NOT send an email to the user' do
+        expect {
+          Rake::Task['user:monthly_stats_email'].invoke
+        }.not_to(change(ActionMailer::Base.deliveries, :count))
+      end
+    end
+  end
+end

--- a/spec/mailers/actor_mailer_spec.rb
+++ b/spec/mailers/actor_mailer_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ActorMailer, type: :mailer do
+  let(:actor) { build(:actor) }
+
+  describe '#monthly_stats' do
+    context 'when the actor has NO file downloads' do
+      subject { described_class.with(actor: actor).monthly_stats }
+
+      its(:message) { is_expected.to be_a(ActionMailer::Base::NullMail) }
+    end
+
+    context 'when the actor has file downloads' do
+      let(:mail) { described_class.with(actor: actor).monthly_stats }
+      let(:mock_presenter) { ActorStatsPresenter.new(actor: actor) }
+
+      before do
+        allow(ActorStatsPresenter).to receive(:new).with(any_args).and_return(mock_presenter)
+        allow(mock_presenter).to receive(:file_downloads).and_return(3)
+      end
+
+      it "sends an email with the depositor's monthly download statistics" do
+        expect(mail.subject).to eq('ScholarSphere - Reporting Monthly Downloads and Views')
+        expect(mail.to).to contain_exactly(actor.email)
+        expect(mail.body.raw_source).to match(/You had 3 new downloads last month across your 0 files/)
+      end
+    end
+  end
+end

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationMailer, type: :mailer do
+  describe '#default' do
+    let(:default) { described_class.default }
+
+    specify do
+      expect(default[:from]).to eq('no_reply@scholarsphere.psu.edu')
+    end
+  end
+end

--- a/spec/mailers/previews/actor_mailer_preview.rb
+++ b/spec/mailers/previews/actor_mailer_preview.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Preview all emails at http://localhost:3000/rails/mailers/actor_mailer
+class ActorMailerPreview < ActionMailer::Preview
+  def monthly_stats
+    ActorMailer.with(actor: Actor.first).monthly_stats
+  end
+end

--- a/spec/presenters/actor_stats_presenter_spec.rb
+++ b/spec/presenters/actor_stats_presenter_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ActorStatsPresenter do
+  let(:work_version) { create(:work_version, :with_files) }
+  let(:another_work) { create(:work_version, :with_files) }
+  let(:actor) { work_version.depositor }
+
+  before do
+    ViewStatistic.create(
+      date: (Time.zone.now - 5.days).to_date,
+      count: 1,
+      resource_type: 'FileResource',
+      resource_id: work_version.file_resources.first.id
+    )
+
+    ViewStatistic.create(
+      date: (Time.zone.now - 10.days).to_date,
+      count: 2,
+      resource_type: 'FileResource',
+      resource_id: work_version.file_resources.first.id
+    )
+
+    ViewStatistic.create(
+      date: (Time.zone.now - 20.days).to_date,
+      count: 3,
+      resource_type: 'FileResource',
+      resource_id: work_version.file_resources.first.id
+    )
+
+    ViewStatistic.create(
+      date: (Time.zone.now - 30.days).to_date,
+      count: 4,
+      resource_type: 'FileResource',
+      resource_id: work_version.file_resources.first.id
+    )
+
+    ViewStatistic.create(
+      date: (Time.zone.now - 5.days).to_date,
+      count: 1,
+      resource_type: 'FileResource',
+      resource_id: another_work.file_resources.first.id
+    )
+  end
+
+  describe '#file_downloads' do
+    context 'when specifying a start date' do
+      subject { described_class.new(actor: actor, beginning_at: (Time.zone.now - 20.days).to_date) }
+
+      its(:file_downloads) { is_expected.to eq(6) }
+    end
+
+    context 'when specifying an end date' do
+      subject { described_class.new(actor: actor, ending_at: (Time.zone.now - 10.days).to_date) }
+
+      its(:file_downloads) { is_expected.to eq(9) }
+    end
+
+    context 'with no date restrictions' do
+      subject { described_class.new(actor: actor) }
+
+      its(:file_downloads) { is_expected.to eq(10) }
+    end
+  end
+
+  describe '#total_files' do
+    subject { described_class.new(actor: actor) }
+
+    its(:total_files) { is_expected.to eq(1) }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,6 +34,9 @@ require 'view_component/test_helpers'
 #
 Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
+# Load Rake tasks so we can test them
+Rails.application.load_tasks
+
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
 begin


### PR DESCRIPTION
Sends an email to each actor who has deposited works into Scholarpshere, informing them of how many files they have and the collective number of downloads for those files.

![Screen Shot 2020-08-07 at 4 35 02 PM](https://user-images.githubusercontent.com/312085/89686257-0cece080-d8cc-11ea-89a1-ef4beff276f0.png)

A rake task sends the email to users unless they have opted out of the process or are no longer active. Additional boolean attributes on the User model define these for us. It is assumed that a later process will mark inactive users, and than additional features added to the users' profile page will allow them to elect to NOT receive future emails.

For migration, we can migrate any opt outs to the new user records.

Fixes #380 