### PR TITLE
Correct the capitalization of Scholarsphere

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,7 +71,7 @@ en:
     messages:
       invalid_edtf: is not a valid date in EDTF format
   footer:
-    heading: 'Scholarsphere'
+    heading: 'ScholarSphere'
     description: 'A service of the University Libraries.'
     copyright_statement: 'Copyright © 2020 The Pennsylvania State University'
   dashboard:

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Home page', type: :feature do
     end
 
     within('footer') do
-      expect(page).to have_selector('h3', text: 'Scholarsphere')
+      expect(page).to have_selector('h3', text: 'ScholarSphere')
       expect(page).to have_content('A service of the University Libraries.')
       expect(page).to have_content('Copyright')
       expect(page).to have_link('Penn State')


### PR DESCRIPTION
Updates the footer to reflect the same capitalization that's in the header.

Fixes #467 