### PR TITLE
creates script to run monthly stats email task

### DIFF
--- a/bin/envconsul-wrapper
+++ b/bin/envconsul-wrapper
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Wraps a command in envconsul, if vault token is present
+
+# Check for vault token from an init container.
+if [ -f /vault/.vault-token ]; then
+    vault_token=$(cat /vault/.vault-token)
+    export VAULT_TOKEN=$vault_token
+fi
+
+function start() {
+    if [ "$1" != "" ]; then
+        cmd="$*"
+        if [ -n "${VAULT_TOKEN}" ]; then
+            echo "have token. wrapping ${cmd} with envconsul"
+            start_envconsul
+        else
+            echo "Running $cmd"
+            ${cmd}
+        fi
+    else
+        echo "Missing Command Argument"
+        exit 1
+    fi
+}
+
+
+function start_envconsul() {
+    set -u
+    envconsul \
+        -vault-addr="${VAULT_ADDR}" \
+        -secret="${VAULT_PATH}" \
+        -no-prefix=true \
+        -vault-renew-token=true \
+        -once \
+        -exec="${cmd}"
+}

--- a/bin/monthly_stats_email
+++ b/bin/monthly_stats_email
@@ -1,0 +1,4 @@
+#!/bin/bash
+source "$(dirname "$0")/envconsul-wrapper"
+
+start "bundle exec rake user:monthly_stats_email"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,6 +54,15 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "scholarsphere_production"
 
   config.action_mailer.perform_caching = false
+  config.action_mailer.logger = nil
+  config.action_mailer.delivery_method = ENV.fetch('MAIL_DELIVERY_METHOD', 'test').to_sym
+  config.action_mailer.smtp_settings = {
+    address: ENV.fetch('SMTP_ADDRESS', 'localhost'),
+    port: ENV.fetch('SMTP_PORT', 25),
+    user_name: ENV.fetch('SMTP_USERNAME', nil),
+    password: ENV.fetch('SMTP_PASSWORD', nil),
+    authentication: ENV.fetch('SMTP_AUTHENTICATION_TYPE', nil)
+  }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -2,4 +2,5 @@
 :max_retries: <%= ENV.fetch("SIDEKIQ_MAX_RETRIES", 2) %>
 :queues:
   - shrine
+  - mailers
   - indexing

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -3,8 +3,11 @@
 namespace :user do
   desc 'Send out monthly download statistics email'
   task monthly_stats_email: :environment do
+    Rails.logger.info('Starting monthly stats task...')
     User.where(provider: 'azure_oauth', opt_out_stats_email: false, active: true).each do |user|
+      Rails.logger.info("Putting Job on the queue for #{user.actor.email}")
       ActorMailer.with(actor: user.actor).monthly_stats.deliver_later
     end
+    Rails.logger.info('Monthly stats task is complete.')
   end
 end


### PR DESCRIPTION
Kubernetes CronJob runs `/app/bin/monthly_stats_mail`, on a configurable schedule. 