### PR TITLE
Deposit agreement version

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -86,6 +86,10 @@ class Work < ApplicationRecord
     end
   end
 
+  module DepositAgreement
+    CURRENT_VERSION = '1.0'
+  end
+
   enum work_type: Types.all.zip(Types.all).to_h
 
   validates :work_type,
@@ -136,6 +140,15 @@ class Work < ApplicationRecord
 
   def stats
     @stats ||= AggregateViewStatistics.call(models: versions.published)
+  end
+
+  def update_deposit_agreement
+    return if deposit_agreement_version == DepositAgreement::CURRENT_VERSION
+
+    update(
+      deposit_agreement_version: DepositAgreement::CURRENT_VERSION,
+      deposit_agreed_at: Time.zone.now
+    )
   end
 
   private

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -94,7 +94,7 @@ class WorkVersion < ApplicationRecord
     state :published, :withdrawn, :removed
 
     event :publish do
-      transitions from: [:draft, :withdrawn], to: :published
+      transitions from: [:draft, :withdrawn], to: :published, after: Proc.new { work.try(:update_deposit_agreement) }
     end
 
     event :withdraw do

--- a/db/migrate/20200818193712_add_deposit_agreement_to_works.rb
+++ b/db/migrate/20200818193712_add_deposit_agreement_to_works.rb
@@ -1,0 +1,6 @@
+class AddDepositAgreementToWorks < ActiveRecord::Migration[6.0]
+  def change
+    add_column :works, :deposit_agreement_version, :string
+    add_column :works, :deposit_agreed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_10_144750) do
+ActiveRecord::Schema.define(version: 2020_08_18_193712) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -219,6 +219,8 @@ ActiveRecord::Schema.define(version: 2020_08_10_144750) do
     t.bigint "depositor_id", null: false
     t.bigint "proxy_id"
     t.datetime "deposited_at"
+    t.string "deposit_agreement_version"
+    t.datetime "deposit_agreed_at"
     t.index ["depositor_id"], name: "index_works_on_depositor_id"
     t.index ["proxy_id"], name: "index_works_on_proxy_id"
   end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe Work, type: :model do
     it { is_expected.to have_db_column(:uuid).of_type(:uuid) }
     it { is_expected.to have_db_column(:doi).of_type(:string) }
     it { is_expected.to have_db_column(:embargoed_until).of_type(:datetime) }
+    it { is_expected.to have_db_column(:deposit_agreed_at).of_type(:datetime) }
+    it { is_expected.to have_db_column(:deposit_agreement_version) }
 
     it { is_expected.to have_db_index(:depositor_id) }
     it { is_expected.to have_db_index(:proxy_id) }
@@ -105,6 +107,34 @@ RSpec.describe Work, type: :model do
     describe '.display' do
       it 'returns a human-readable version of the type' do
         expect(types.display(types.default)).to eq('Dataset')
+      end
+    end
+  end
+
+  describe '::DepositAgreement::CURRENT_VERSION' do
+    subject { described_class::DepositAgreement::CURRENT_VERSION }
+
+    it { is_expected.to eq('1.0') }
+  end
+
+  describe '#update_deposit_agreement' do
+    context 'when the deposit agreement version is nil' do
+      let(:work) { build(:work) }
+
+      it 'updates the agreement version' do
+        expect {
+          work.update_deposit_agreement
+        }.to change(work, :deposit_agreement_version).from(nil).to(described_class::DepositAgreement::CURRENT_VERSION)
+      end
+    end
+
+    context 'when the work has the current deposit agreement version' do
+      let(:work) { build(:work, deposit_agreement_version: described_class::DepositAgreement::CURRENT_VERSION) }
+
+      it 'does NOT update the agreement version timestamp' do
+        expect {
+          work.update_deposit_agreement
+        }.not_to(change(work, :deposit_agreed_at))
       end
     end
   end
@@ -219,6 +249,8 @@ RSpec.describe Work, type: :model do
       let(:keys) do
         %w(
           created_at_dtsi
+          deposit_agreed_at_dtsi
+          deposit_agreement_version_tesim
           deposited_at_dtsi
           depositor_id_isi
           discover_groups_ssim
@@ -250,6 +282,8 @@ RSpec.describe Work, type: :model do
           created_at_dtsi
           creator_aliases_tesim
           creators_sim
+          deposit_agreed_at_dtsi
+          deposit_agreement_version_tesim
           deposited_at_dtsi
           depositor_id_isi
           description_tesim

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -285,4 +285,18 @@ RSpec.describe WorkVersion, type: :model do
       end
     end
   end
+
+  describe '#publish' do
+    let(:work_version) { build :work_version, :able_to_be_published }
+    let(:work) { work_version.work }
+
+    it "updates the work's deposit agreement" do
+      expect(work.deposit_agreement_version).to be_nil
+      expect(work.deposit_agreed_at).to be_nil
+      work_version.publish
+      work.reload
+      expect(work.deposit_agreement_version).to eq(Work::DepositAgreement::CURRENT_VERSION)
+      expect(work.deposit_agreed_at).to be_within(1.minute).of(Time.zone.now)
+    end
+  end
 end


### PR DESCRIPTION
Adds a deposit agreement version and timestamp to reflect the time when a work is published. The work will be updated with the current deposit agreement version when its first version is published. Subsequent published versions will not change the timestamp so long as the deposit agreement version remains unchanged.

If the deposit agreement version is changed, the work will NOT be updated until a work version is published. 

Fixes #185 