### PR TITLE
Require version name to be semver

### DIFF
--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -67,6 +67,15 @@ class WorkVersion < ApplicationRecord
             presence: true,
             uniqueness: { scope: :work_id }
 
+  # @note The regex comes from https://semver.org/
+  validates :version_name,
+            allow_nil: true,
+            format: {
+              with: /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/, # rubocop:disable Layout/LineLength
+              message: 'Version names must be in semantic version format, ex. 1.0.0',
+              multiline: true
+            }
+
   validates :visibility,
             inclusion: {
               in: [Permissions::Visibility::OPEN, Permissions::Visibility::AUTHORIZED],

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -124,6 +124,15 @@ RSpec.describe WorkVersion, type: :model do
       it { is_expected.to validate_uniqueness_of(:version_number).scoped_to(:work_id) }
       it { is_expected.to validate_presence_of(:version_number) }
     end
+
+    context 'with a version name' do
+      it { is_expected.to allow_value(nil).for(:version_name) }
+      it { is_expected.to allow_value('1.0.1').for(:version_name) }
+      it { is_expected.to allow_value('1.2.3-beta').for(:version_name) }
+      it { is_expected.not_to allow_value('1').for(:version_name) }
+      it { is_expected.not_to allow_value('1.0').for(:version_name) }
+      it { is_expected.not_to allow_value('v1').for(:version_name) }
+    end
   end
 
   describe 'multivalued fields' do


### PR DESCRIPTION
Adds a regex to the version name attribute so that it conforms to semantic versioning format.

Fixes #453 