### PR TITLE
Enable facet limits with modal display

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -22,6 +22,7 @@ linters:
       - '*test/*'
       - '*app/views/layouts/component_preview.html.erb'
       - '*app/views/actor_mailer/*'
+      - '*app/views/catalog/facet.html.erb'
   RightTrim:
     enabled: true
     enforced_style: '-'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -85,10 +85,10 @@ class CatalogController < ApplicationController
     # prefixes that will be used to create the navigation (note: It is
     # case sensitive when searching values)
 
-    config.add_facet_field 'display_work_type_ssi', label: 'Work Type'
-    config.add_facet_field 'keyword_tesim', label: 'Keywords'
-    config.add_facet_field 'subject_tesim', label: 'Subject'
-    config.add_facet_field 'creators_sim', label: 'Creators'
+    config.add_facet_field 'display_work_type_ssi', label: 'Work Type', limit: true
+    config.add_facet_field 'keyword_tesim', label: 'Keywords', limit: true
+    config.add_facet_field 'subject_tesim', label: 'Subject', limit: true
+    config.add_facet_field 'creators_sim', label: 'Creators', limit: true
 
     # Example pivot facet
     # config.add_facet_field 'example_pivot_field', label: 'Pivot Field', pivot: ['format', 'language_ssim']

--- a/app/javascript/frontend/index.js
+++ b/app/javascript/frontend/index.js
@@ -5,8 +5,15 @@ import './styles'
 // View statistics
 import './scripts/view_statistics_chart'
 
+// Load dependencies
 require('jquery/dist/jquery')
 require('bootstrap/dist/js/bootstrap')
+
+// Load Blacklight dependencies
+// This should be just enough JS to get the facet modals working.
+require('blacklight-frontend/app/javascript/blacklight/core')
+require('blacklight-frontend/app/javascript/blacklight/modal')
+require('blacklight-frontend/app/javascript/blacklight/facet_load')
 
 // Load images
 // Retrieve the path to the image via <%= image_pack_tag('image.png') %>

--- a/app/views/catalog/facet.html.erb
+++ b/app/views/catalog/facet.html.erb
@@ -1,0 +1,20 @@
+<div class="modal-header">
+  <h3 class="modal-title" id="modal-label"><%= facet_field_label(@facet.key) %></h3>
+  <button type="button" class="close" data-dismiss="modal" aria-label="<%= t('blacklight.modal.close') %>">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+
+<div class="modal-body">
+  <%= render partial: 'facet_index_navigation' if @facet.index_range && @display_facet.index? %>
+
+  <div class="facet-extended-list">
+    <%= render_facet_limit(@display_facet, layout: false) %>
+  </div>
+</div>
+
+<div class="modal-footer">
+  <div class="facet-pagination bottom row justify-content-between">
+    <%= render partial: 'facet_pagination' %>
+  </div>
+</div>

--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -95,5 +95,7 @@
         </div>
       </nav>
     </footer>
+
+    <%= render partial: 'shared/modal' %>
   </body>
 </html>

--- a/app/views/shared/_modal.html.erb
+++ b/app/views/shared/_modal.html.erb
@@ -1,0 +1,13 @@
+<aside>
+  <div class="modal fade"
+       id="blacklight-modal"
+       tabindex="-1"
+       role="dialog"
+       aria-hidden="true"
+       aria-labelledby="modal-label">
+    <div class="modal-dialog modal-lg">
+      <div class="modal-content">
+      </div>
+    </div>
+  </div>
+</aside>


### PR DESCRIPTION
Puts a default limit on the number of facets that will appear before a "more" link triggers the remaining facets in a modal window.

We use Blacklight's provided JS code to engage the window.