### PR TITLE
Custom error pages

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class ErrorsController < ApplicationController
+  def not_found
+    render 'not_found', status: :not_found
+  end
+
+  def server_error
+    render 'server_error', status: :internal_server_error
+  end
+
+  private
+
+    def determine_layout
+      'frontend'
+    end
+end

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,0 +1,16 @@
+<% content_for :navbar_heading do %>
+  <h1 class="navbar-brand navbar-brand--center slab-font"><%= t('navbar.heading.not_found') %></h1>
+<% end %>
+
+<div class="container-fluid">
+  <div class="row row--md-mb-3">
+    <div class="col-md">
+      <h2 class="h4 mb-2"><%= t('errors.not_found.heading') %></h2>
+      <div class="surface"><%= t('errors.not_found.content') %></div>
+    </div>
+
+    <%= render 'shared/search_or_browse' %>
+
+  </div>
+
+</div>

--- a/app/views/errors/server_error.html.erb
+++ b/app/views/errors/server_error.html.erb
@@ -1,0 +1,16 @@
+<% content_for :navbar_heading do %>
+  <h1 class="navbar-brand navbar-brand--center slab-font"><%= t('navbar.heading.server_error') %></h1>
+<% end %>
+
+<div class="container-fluid">
+  <div class="row row--md-mb-3">
+    <div class="col-md">
+      <h2 class="h4 mb-2"><%= t('errors.server_error.heading') %></h2>
+      <div class="surface"><%= t('errors.server_error.content') %></div>
+    </div>
+
+    <%= render 'shared/search_or_browse' %>
+
+  </div>
+
+</div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -9,28 +9,8 @@
       <div class="surface"><%= t('home.intro.content') %></div>
     </div>
 
-    <div class="col-md">
-      <h2 class="h4 mb-2"><%= t('home.search.heading') %></h2>
-      <div class="surface search">
-        <%= form_tag search_action_url, method: :get do %>
-          <div class="input-group input-group--icon mb-2">
-            <label class="sr-only" for="q"><%= t('home.search.label') %></label>
-            <%= text_field_tag :q, params[:q], placeholder: t('home.search.placeholder'), class: 'form-control' %>
-            <div class="input-group-append">
-              <button class="btn btn-primary" type="submit">
-                <i class="material-icons"><%= t('home.search.submit') %></i>
-              </button>
-            </div>
-          </div>
-        <% end %>
-        <div class="keyline keyline--center">
-          <p><%= t('home.search.subheading') %></p>
-        </div>
-        <div class="mt-2 text-center">
-          <%= link_to t('home.search.browse'), search_catalog_path, class: 'btn btn-primary' %>
-        </div>
-      </div>
-    </div>
+    <%= render 'shared/search_or_browse' %>
+
   </div>
 </div>
 

--- a/app/views/shared/_search_or_browse.html.erb
+++ b/app/views/shared/_search_or_browse.html.erb
@@ -1,0 +1,22 @@
+<div class="col-md">
+  <h2 class="h4 mb-2"><%= t('shared.search.heading') %></h2>
+  <div class="surface search">
+    <%= form_tag search_action_url, method: :get do %>
+      <div class="input-group input-group--icon mb-2">
+        <label class="sr-only" for="q"><%= t('shared.search.label') %></label>
+        <%= text_field_tag :q, params[:q], placeholder: t('shared.search.placeholder'), class: 'form-control' %>
+        <div class="input-group-append">
+          <button class="btn btn-primary" type="submit">
+            <i class="material-icons"><%= t('shared.search.submit') %></i>
+          </button>
+        </div>
+      </div>
+    <% end %>
+    <div class="keyline keyline--center">
+      <p><%= t('shared.search.subheading') %></p>
+    </div>
+    <div class="mt-2 text-center">
+      <%= link_to t('shared.search.browse'), search_catalog_path, class: 'btn btn-primary' %>
+    </div>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -53,5 +53,8 @@ module Scholarsphere
     config.view_component.default_preview_layout = 'component_preview'
 
     config.no_reply_email = ENV.fetch('NO_REPLY_EMAIL', 'no_reply@scholarsphere.psu.edu')
+
+    # Use our own custom exceptions
+    config.exceptions_app = routes
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,6 +78,16 @@ en:
   errors:
     messages:
       invalid_edtf: is not a valid date in EDTF format
+    not_found:
+      heading: Resource not found or unavailable
+      content: >
+        The page you are trying to access is either not available or not in ScholarSphere. Please contact us if you
+        believe this is a problem.
+    server_error:
+      heading: Unable to process request
+      content: >
+        We're sorry, something unexpected happened and we're unable to continue. We've been notified of the problem
+        and will work to resolve it.
   footer:
     heading: 'ScholarSphere'
     description: 'A service of the University Libraries.'
@@ -268,6 +278,8 @@ en:
     heading:
       home: 'Welcome to ScholarSphere'
       dashboard: 'Your Dashboard'
+      not_found: 'Page Not Found'
+      server_error: 'Server Error'
   resources:
     analytics: Analytics
     collections: Collections
@@ -287,3 +299,11 @@ en:
       valid: 'This is a valid DOI and can be used to reference this page'
       invalid: 'This DOI has formatting errors. Please contact us to have it fixed'
       unmanaged: 'This is a valid DOI, but we cannot manage nor update it. Please contact us if to have it fixed'
+  shared:
+    search:
+      heading: 'Browse and search for works'
+      placeholder: 'Search for titles, keywords, resource types, creators, etc.'
+      label: 'Search ScholarSphere'
+      submit: 'search' 
+      subheading: Or
+      browse: 'Browse & Filter All Works'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,6 +109,10 @@ Rails.application.routes.draw do
     end
   end
 
+  get '/404', to: 'errors#not_found'
+  get '/401', to: 'errors#not_found'
+  get '/500', to: 'errors#server_error'
+
   # Legacy URL support
   # Note that collections and works go to the same place. This works because the
   # legacy IDs are unique noids. It could lead to an extraordinarily unlikely

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ErrorsController, type: :controller do
+  subject { response }
+
+  context 'with a 404 error' do
+    before { get :not_found }
+
+    its(:status) { is_expected.to eq(404) }
+  end
+
+  context 'with a 500 error' do
+    before { get :server_error }
+
+    its(:status) { is_expected.to eq(500) }
+  end
+end

--- a/spec/routes/errors_spec.rb
+++ b/spec/routes/errors_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Errors routes', type: :routing do
+  describe '#not_found' do
+    specify do
+      expect(get('/404')).to route_to(controller: 'errors', action: 'not_found')
+    end
+
+    specify do
+      expect(get('/401')).to route_to(controller: 'errors', action: 'not_found')
+    end
+  end
+
+  describe '#server_error' do
+    specify do
+      expect(get('/500')).to route_to(controller: 'errors', action: 'server_error')
+    end
+  end
+end


### PR DESCRIPTION
Implements a custom ErrorsController for 404, 401, and 500 error messages that can be displayed within the application layout. This overrides the default Rack app's standard "red and black" pages, but keeps the logging information consistent with stack traces and status codes.

Fixes #426 

![Screen Shot 2020-09-01 at 10 45 23 AM](https://user-images.githubusercontent.com/312085/91866230-46510b80-ec40-11ea-848e-2e22880e30b9.png)
![Screen Shot 2020-09-01 at 10 43 43 AM](https://user-images.githubusercontent.com/312085/91866233-481acf00-ec40-11ea-99f4-abaf00bbac77.png)
