### PR TITLE
adds after_commit_everywhere gem to fix deprication / race condition

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.7.1'
 
 gem 'aasm'
+gem 'after_commit_everywhere', '~> 0.1', '>= 0.1.5'
 gem 'blacklight', '~> 7.10'
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'browser'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,8 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    after_commit_everywhere (0.1.5)
+      activerecord (>= 4.2)
     ast (2.4.1)
     aws-eventstream (1.1.0)
     aws-partitions (1.349.0)
@@ -492,6 +494,7 @@ PLATFORMS
 
 DEPENDENCIES
   aasm
+  after_commit_everywhere (~> 0.1, >= 0.1.5)
   better_errors
   binding_of_caller
   blacklight (~> 7.10)


### PR DESCRIPTION
"[DEPRECATION] :after_commit AASM callback is not safe in terms of race conditions and redundant calls."