### PR TITLE
Remove favicon links to avoid 404 errors

### DIFF
--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -10,7 +10,6 @@
 
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <title>Component Preview</title>
-    <%= favicon_link_tag %>
     <%= javascript_pack_tag 'frontend' %>
     <%= stylesheet_pack_tag 'frontend', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= csrf_meta_tags %>

--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -9,7 +9,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     <title><%= render_page_title %></title>
-    <%= favicon_link_tag %>
     <%= javascript_pack_tag 'frontend' %>
     <%= stylesheet_pack_tag 'frontend', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= csrf_meta_tags %>


### PR DESCRIPTION
This can be reverted later if we want actual favicons for the site.