### PR TITLE
Prompt user for unsaved changes when moving between tabs on work form

### DIFF
--- a/app/components/work_form_tabs_component.html.erb
+++ b/app/components/work_form_tabs_component.html.erb
@@ -1,7 +1,7 @@
 <nav>
   <div class="nav nav-tabs justify-content-between" role="tablist">
     <% tabs.each do |tab| %>
-      <%= link_to_unless (!links_enabled || tab.active), tab.label, tab.url, class: tab.classes do %>
+      <%= link_to_unless (!links_enabled || tab.active), tab.label, tab.url, class: tab.classes, data: { action: 'unsaved-changes#prompt' } do %>
         <span class="<%= tab.classes.join(' ') %>"><%= tab.label %></span>
       <% end %>
     <% end %>

--- a/app/javascript/controllers/unsaved_changes_controller.js
+++ b/app/javascript/controllers/unsaved_changes_controller.js
@@ -1,0 +1,23 @@
+import { Controller } from 'stimulus'
+import formChanges from '../vendor/formchanges.js'
+
+export default class extends Controller {
+  static targets = ['form']
+
+  connect () {
+    this.promptText = this.data.get('prompt')
+  }
+
+  prompt (event) {
+    const hasChanges = formChanges(this.formTarget).length > 0
+    if (!hasChanges) { return true }
+
+    const discard = confirm(this.promptText)
+
+    if (discard) {
+      return true
+    } else {
+      event.preventDefault()
+    }
+  }
+}

--- a/app/javascript/vendor/formchanges.js
+++ b/app/javascript/vendor/formchanges.js
@@ -1,0 +1,62 @@
+/*
+ * FormChanges(string FormID | DOMelement FormNode)
+ * Returns an array of changed form elements.
+ * An empty array indicates no changes have been made.
+ * NULL indicates that the form does not exist.
+ *
+ * By Craig Buckler,   http://twitter.com/craigbuckler
+ * of OptimalWorks.net http://optimalworks.net/
+ * for SitePoint.com   http://sitepoint.com/
+ *
+ * Refer to http://blogs.sitepoint.com/javascript-form-change-checker/
+ *
+ * This code can be used without restriction.
+ */
+function FormChanges (form) {
+  // get form
+  if (typeof form === 'string') form = document.getElementById(form)
+  if (!form || !form.nodeName || form.nodeName.toLowerCase() !== 'form') return null
+
+  // find changed elements
+  var changed = []; var n; var c; var def; var o; var ol; var opt
+  for (var e = 0, el = form.elements.length; e < el; e++) {
+    n = form.elements[e]
+    c = false
+
+    switch (n.nodeName.toLowerCase()) {
+      // select boxes
+      case 'select':
+        def = 0
+        for (o = 0, ol = n.options.length; o < ol; o++) {
+          opt = n.options[o]
+          c = c || (opt.selected !== opt.defaultSelected)
+          if (opt.defaultSelected) def = o
+        }
+        if (c && !n.multiple) c = (def !== n.selectedIndex)
+        break
+
+        // input / textarea
+      case 'textarea':
+      case 'input':
+
+        switch (n.type.toLowerCase()) {
+          case 'checkbox':
+          case 'radio':
+            // checkbox / radio
+            c = (n.checked !== n.defaultChecked)
+            break
+          default:
+            // standard values
+            c = (n.value !== n.defaultValue)
+            break
+        }
+        break
+    }
+
+    if (c) changed.push(n)
+  }
+
+  return changed
+}
+
+export default FormChanges

--- a/app/views/dashboard/work_form/contributors/edit.html.erb
+++ b/app/views/dashboard/work_form/contributors/edit.html.erb
@@ -1,13 +1,13 @@
 <div class="container">
   <div class="row">
-    <div class="col">
+    <div class="col" data-controller="unsaved-changes" data-unsaved-changes-prompt="<%= t 'dashboard.work_form.unsaved_changes_prompt' %>">
       <h4 class="text-center mb-4"><%= t 'dashboard.work_form.heading.edit' %></h4>
       <%= render WorkFormTabsComponent.new(work_version: @work_version, current_controller: controller_name) %>
 
       <div class="tab-content">
         <div class="tab-pane active show">
 
-          <%= form_with(model: @work_version, url: dashboard_work_form_contributors_path(@work_version), local: true) do |form| %>
+          <%= form_with(model: @work_version, url: dashboard_work_form_contributors_path(@work_version), local: true, data: { target: 'unsaved-changes.form' }) do |form| %>
             <%= render FormErrorMessageComponent.new(form: form) %>
 
             <%= render 'fields', form: form %>

--- a/app/views/dashboard/work_form/details/_form.html.erb
+++ b/app/views/dashboard/work_form/details/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: @work_version, url: url, local: true) do |form| %>
+<%= form_with(model: @work_version, url: url, local: true, data: { target: 'unsaved-changes.form' }) do |form| %>
 
   <%= render FormErrorMessageComponent.new(form: form) %>
 

--- a/app/views/dashboard/work_form/details/edit.html.erb
+++ b/app/views/dashboard/work_form/details/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <div class="row">
-    <div class="col">
+    <div class="col" data-controller="unsaved-changes" data-unsaved-changes-prompt="<%= t 'dashboard.work_form.unsaved_changes_prompt' %>">
       <h4 class="text-center mb-4"><%= t 'dashboard.work_form.heading.edit' %></h4>
       <%= render WorkFormTabsComponent.new(work_version: @work_version, current_controller: controller_name) %>
 

--- a/app/views/dashboard/work_form/files/edit.html.erb
+++ b/app/views/dashboard/work_form/files/edit.html.erb
@@ -1,13 +1,13 @@
 <div class="container">
   <div class="row">
-    <div class="col">
+    <div class="col" data-controller="unsaved-changes" data-unsaved-changes-prompt="<%= t 'dashboard.work_form.unsaved_changes_prompt' %>">
       <h4 class="text-center mb-4"><%= t 'dashboard.work_form.heading.edit' %></h4>
       <%= render WorkFormTabsComponent.new(work_version: @work_version, current_controller: controller_name) %>
 
       <div class="tab-content">
         <div class="tab-pane active show">
 
-          <%= form_with(model: @work_version, url: dashboard_work_form_files_path(@work_version), local: true, id: 'file-uploader') do |form| %>
+          <%= form_with(model: @work_version, url: dashboard_work_form_files_path(@work_version), local: true, id: 'file-uploader', data: { target: 'unsaved-changes.form' }) do |form| %>
             <%= render 'fields', form: form %>
 
             <% if form.object.file_version_memberships.any? %>

--- a/app/views/dashboard/work_form/publish/edit.html.erb
+++ b/app/views/dashboard/work_form/publish/edit.html.erb
@@ -1,13 +1,13 @@
 <div class="container">
   <div class="row">
-    <div class="col">
+    <div class="col" data-controller="unsaved-changes" data-unsaved-changes-prompt="<%= t 'dashboard.work_form.unsaved_changes_prompt' %>">
       <h4 class="text-center mb-4"><%= t 'dashboard.work_form.heading.edit' %></h4>
       <%= render WorkFormTabsComponent.new(work_version: @work_version, current_controller: controller_name) %>
 
       <div class="tab-content">
         <div class="tab-pane active show">
 
-          <%= form_with(model: @work_version, url: dashboard_work_form_publish_path(@work_version), local: true, id: 'file-uploader') do |form| %>
+          <%= form_with(model: @work_version, url: dashboard_work_form_publish_path(@work_version), local: true, id: 'file-uploader', data: { target: 'unsaved-changes.form' }) do |form| %>
 
             <%= render FormErrorMessageComponent.new(
                   form: form,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -194,6 +194,7 @@ en:
           contributors: Contributors
           files: Files
           publishing_details: Publishing Details
+      unsaved_changes_prompt: You have unsaved changes on this page. Are you sure you want to leave and discard these changes?
     work_versions:
       files:
         name: Name

--- a/spec/features/publish_new_work_spec.rb
+++ b/spec/features/publish_new_work_spec.rb
@@ -100,6 +100,26 @@ RSpec.describe 'Publishing a work', with_user: :user do
         expect(page).to have_current_path(dashboard_work_form_contributors_path(work_version))
       end
     end
+
+    context 'when navigating away from unsaved changes', js: true do
+      it 'warns the user' do
+        visit dashboard_work_form_details_path(work_version)
+
+        fill_in 'work_version_title', with: "Changed #{metadata[:title]}"
+
+        dismiss_confirm(I18n.t('dashboard.work_form.unsaved_changes_prompt')) do
+          click_on I18n.t('dashboard.work_form.tabs.contributors')
+        end
+
+        expect(page).to have_current_path(dashboard_work_form_details_path(work_version))
+
+        accept_confirm(I18n.t('dashboard.work_form.unsaved_changes_prompt')) do
+          click_on I18n.t('dashboard.work_form.tabs.contributors')
+        end
+
+        expect(page).to have_current_path(dashboard_work_form_contributors_path(work_version))
+      end
+    end
   end
 
   describe 'The Contributors tab', js: true do


### PR DESCRIPTION
There's a Javascript library I found online that can be used to detect changed values on any given html form. It's nice because the "change" javascript event does not account for the fact that I could change a field, then change it back. e.g If there's a field that says "title" and I change it to "titleee", that will fire one js change event, then if I change it _back_ to "title" that will fire a second change event. So listening for js change events is not enough to do this. The library I found actually compares the value of the field to its original value.

Anyways, long winded explanation to say, I found some off-the-shelf library and didn't know where to put it. I opted for `app/javascript/vendor` as the place to put it, because I couldn't find anything else already there. I'm open to suggestions

Closes #527 