### PR TITLE
Remove empty strings from Actor fields

### DIFF
--- a/app/models/actor.rb
+++ b/app/models/actor.rb
@@ -92,6 +92,19 @@ class Actor < ApplicationRecord
     Collection.reindex_all(created_collections)
   end
 
+  # Fields that contain single values automatically remove blank values
+  %i[
+    surname
+    given_name
+    email
+    orcid
+    psu_id
+  ].each do |field|
+    define_method "#{field}=" do |val|
+      super(val.presence)
+    end
+  end
+
   private
 
     def reindex_if_default_alias_changed

--- a/spec/models/actor_spec.rb
+++ b/spec/models/actor_spec.rb
@@ -132,4 +132,12 @@ RSpec.describe Actor, type: :model do
       expect(Collection).to have_received(:reindex_all).with(actor.created_collections)
     end
   end
+
+  describe 'singlevalued fields' do
+    it_behaves_like 'a singlevalued field', :surname
+    it_behaves_like 'a singlevalued field', :given_name
+    it_behaves_like 'a singlevalued field', :email
+    it_behaves_like 'a singlevalued field', :psu_id
+    it_behaves_like 'a singlevalued field', :orcid
+  end
 end

--- a/spec/support/shared/a_singlevalued_json_field.rb
+++ b/spec/support/shared/a_singlevalued_json_field.rb
@@ -12,3 +12,8 @@ RSpec.shared_examples 'a singlevalued json field' do |field|
     expect(record[field]).to be_nil
   end
 end
+
+# This effectively aliases the name of the shared example because the tests apply to json and non-json fields alike
+RSpec.shared_examples 'a singlevalued field' do |field|
+  it_behaves_like 'a singlevalued json field', field
+end


### PR DESCRIPTION
Ensures that any blank strings in an actor's record are converted to nil.

Fixes this error:
![Screen Shot 2020-10-02 at 12 10 45 PM](https://user-images.githubusercontent.com/312085/94945217-56ab0f00-04a8-11eb-8c7c-d527709ba407.png)
