### PR TITLE
Toggle admin privileges

### DIFF
--- a/app/controllers/dashboard/profiles_controller.rb
+++ b/app/controllers/dashboard/profiles_controller.rb
@@ -10,7 +10,7 @@ module Dashboard
       @actor = current_user.actor
 
       if @actor.update(creator_params)
-        redirect_to dashboard_works_path,
+        redirect_to dashboard_root_path,
                     notice: t('dashboard.profiles.update.success')
       else
         render :edit
@@ -27,8 +27,16 @@ module Dashboard
             :surname,
             :default_alias,
             :email,
-            :orcid
+            :orcid,
+            user_attributes: [
+              :id,
+              :admin_enabled
+            ]
           )
+      end
+
+      def determine_layout
+        'frontend'
       end
   end
 end

--- a/app/models/actor.rb
+++ b/app/models/actor.rb
@@ -45,6 +45,8 @@ class Actor < ApplicationRecord
            through: :collection_creations,
            inverse_of: :creators
 
+  accepts_nested_attributes_for :user
+
   validates :surname,
             presence: true,
             unless: -> { validation_context == :from_omniauth }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,6 +85,10 @@ class User < ApplicationRecord
   end
 
   def admin?
+    admin_available? && admin_enabled
+  end
+
+  def admin_available?
     groups.map(&:name).include? Scholarsphere::Application.config.admin_group
   end
 

--- a/app/validators/orcid_validator.rb
+++ b/app/validators/orcid_validator.rb
@@ -3,7 +3,7 @@
 # @abstract A wrapper to ActiveRecordize Orcid.valid?
 class OrcidValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    return if value.nil?
+    return if value.blank?
 
     record.errors.add(attribute, (options[:message] || :invalid_orcid)) unless Orcid.valid?(value)
   end

--- a/app/views/dashboard/profiles/_admin_fields.html.erb
+++ b/app/views/dashboard/profiles/_admin_fields.html.erb
@@ -1,0 +1,11 @@
+<%= form.fields_for :user do |user_fields| %>
+
+  <div class="form-group">
+    <div class="form-check">
+      <%= user_fields.check_box :admin_enabled, class: 'form-check-input' %>
+
+      <%= user_fields.label :admin_enabled, class: 'form-check-label' %>
+    </div>
+  </div>
+
+<% end %>

--- a/app/views/dashboard/profiles/edit.html.erb
+++ b/app/views/dashboard/profiles/edit.html.erb
@@ -1,34 +1,29 @@
-<h1><%= t 'dashboard.profiles.edit.heading' %></h1>
-
-<%= form_with(model: @actor, url: dashboard_profile_path, local: true) do |f| %>
-  <% if f.object.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= t('dashboard.profiles.edit.error_message', error: pluralize(f.object.errors.count, 'error')) %></h2>
-      <ul>
-      <% f.object.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-      </ul>
-    </div>
-  <% end %>
-
-  <div class="form-group">
-    <%= f.label :default_alias %>
-    <%= f.text_field :default_alias, class: 'form-control', 'aria-describedby': 'default_alias_help' %>
-    <small id="default_alias_help" class="form-text text-muted">
-      <%= t 'dashboard.profiles.edit.default_alias.help' %>
-    </small>
-  </div>
-
-  <div class="row">
-    <div class="col"><%= render 'form_fields/text', form: f, attribute: :given_name %></div>
-    <div class="col"><%= render 'form_fields/text', form: f, attribute: :surname %></div>
-  </div>
-  <%= render 'form_fields/text', form: f, attribute: :email %>
-  <%= render 'form_fields/text', form: f, attribute: :orcid %>
-
-  <div class="actions">
-    <%= f.submit 'Save', class: 'btn btn-primary' %>
-    <%= link_to 'Cancel', :back, class: 'btn btn-text' %>
-  </div>
+<% content_for :navbar_heading do %>
+  <h1 class="navbar-brand navbar-brand--center slab-font"><%= t('dashboard.profiles.edit.heading') %></h1>
 <% end %>
+
+<div class="container">
+  <div class="row">
+
+    <%= form_with(model: @actor, url: dashboard_profile_path, local: true) do |form| %>
+      <%= render FormErrorMessageComponent.new(
+            form: form,
+            heading: t('dashboard.profiles.edit.error_message', error: pluralize(@actor.errors.count, 'error'))
+          ) %>
+
+      <div class="form-wrapper">
+        <%= render 'form_fields/text', form: form, attribute: :default_alias, required: true %>
+        <%= render 'form_fields/text', form: form, attribute: :given_name %>
+        <%= render 'form_fields/text', form: form, attribute: :surname %>
+        <%= render 'form_fields/text', form: form, attribute: :email %>
+        <%= render 'form_fields/text', form: form, attribute: :orcid %>
+        <%= render 'admin_fields', form: form if @actor.user.admin_available? %>
+      </div>
+
+      <div class="actions">
+        <%= form.submit 'Save', class: 'btn btn-primary' %>
+        <%= link_to 'Cancel', :back, class: 'btn btn-text' %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,8 @@ en:
         display_work_type: Work Type
         display_doi: DOI
         file_resources: Files
+      user:
+        admin_enabled: Administrative privleges enabled
     errors:
       models:
         file_version_membership:
@@ -115,6 +117,9 @@ en:
         work_type: This is a hint for the work type
       actor:
         orcid: "This is a 16-digit identifier in the format ####-####-####-####"
+        default_alias: >
+          When you create new works, this will be used as the initial value for the Creator field. For example, if your
+          first and last name are Pat Researcher, you might wish to set this to "Dr. Pat Q. Researcher PhD."
     placeholder:
       work_version:
         version_name: x.y.z
@@ -164,9 +169,7 @@ en:
     profiles:
       edit:
         heading: "Edit Profile"
-        error_message: "%{error} prohibited this work from being saved:"
-        default_alias:
-          help: 'When you create new works, this will be used as the initial value for the Creator field. For example, if your first and last name are Pat Researcher, you might wish to set this to "Dr. Pat Q. Researcher PhD."'
+        error_message: "%{error} prohibited your profile from being saved:"
       update:
         success: 'Your profile was saved successfully.'
     works:

--- a/db/migrate/20201005132540_add_admin_option_to_user.rb
+++ b/db/migrate/20201005132540_add_admin_option_to_user.rb
@@ -1,0 +1,5 @@
+class AddAdminOptionToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :admin_enabled, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_30_174811) do
+ActiveRecord::Schema.define(version: 2020_10_05_132540) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -169,6 +169,7 @@ ActiveRecord::Schema.define(version: 2020_09_30_174811) do
     t.bigint "actor_id", null: false
     t.boolean "opt_out_stats_email", default: false
     t.boolean "active", default: true
+    t.boolean "admin_enabled", default: false
     t.index ["access_id"], name: "index_users_on_access_id", unique: true
     t.index ["actor_id"], name: "index_users_on_actor_id"
   end

--- a/spec/controllers/dashboard/profiles_controller_spec.rb
+++ b/spec/controllers/dashboard/profiles_controller_spec.rb
@@ -62,9 +62,9 @@ RSpec.describe Dashboard::ProfilesController, type: :controller do
           expect(actor.orcid).to eq '0000-1234-5678-9101'
         end
 
-        it 'redirects to the dashboard works page' do
+        it "redirects to the user's dashboard" do
           put :update, params: { actor: valid_attributes }
-          expect(response).to redirect_to(dashboard_works_path) # WIP
+          expect(response).to redirect_to(dashboard_root_path)
         end
       end
 

--- a/spec/factories/actors.rb
+++ b/spec/factories/actors.rb
@@ -17,5 +17,9 @@ FactoryBot.define do
     trait :with_user do
       user
     end
+
+    trait :without_an_orcid do
+      orcid { nil }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
   factory :user do
     trait :admin do
       groups { User.default_groups + [Group.new(name: Rails.application.config.admin_group)] }
+      admin_enabled { true }
     end
     groups { User.default_groups }
     email { "#{access_id}@psu.edu" }

--- a/spec/features/dashboard/profile_spec.rb
+++ b/spec/features/dashboard/profile_spec.rb
@@ -3,26 +3,59 @@
 require 'rails_helper'
 
 RSpec.describe 'Profile', type: :feature, with_user: :user do
-  let(:user) { create(:user) }
   let(:attributes) { attributes_for(:actor) }
   let(:updated_display_name) { "Dr. #{attributes[:default_alias]}" }
 
-  it 'displays and updates my profile information' do
-    visit edit_dashboard_profile_path
-    expect(page).to have_content('Edit Profile')
-    fill_in 'Display Name', with: updated_display_name
-    fill_in 'Given Name', with: attributes[:given_name]
-    fill_in 'Surname', with: attributes[:surname]
-    fill_in 'Email', with: attributes[:email]
-    fill_in 'ORCiD', with: attributes[:orcid]
-    click_button 'Save'
-    user.actor.reload
-    expect(user.actor.given_name).to eq(attributes[:given_name])
-    expect(user.actor.surname).to eq(attributes[:surname])
-    expect(user.actor.orcid).to eq(attributes[:orcid])
-    expect(user.actor.psu_id).to eq(user.access_id)
-    within('#navbarDropdown') do
-      expect(page).to have_content(updated_display_name)
+  context 'with a standard user' do
+    let(:user) { create(:user) }
+
+    it 'displays and updates my profile information' do
+      visit edit_dashboard_profile_path
+      expect(page).to have_content('Edit Profile')
+      fill_in 'Display Name', with: updated_display_name
+      fill_in 'Given Name', with: attributes[:given_name]
+      fill_in 'Surname', with: attributes[:surname]
+      fill_in 'Email', with: attributes[:email]
+      fill_in 'ORCiD', with: attributes[:orcid]
+      expect(page).not_to have_content('Administrative privleges enabled')
+      click_button 'Save'
+      user.actor.reload
+      expect(user.actor.given_name).to eq(attributes[:given_name])
+      expect(user.actor.surname).to eq(attributes[:surname])
+      expect(user.actor.orcid).to eq(attributes[:orcid])
+      expect(user.actor.psu_id).to eq(user.access_id)
+      expect(page).to have_content(I18n.t('navbar.heading.dashboard'))
+      expect(page).to have_content(I18n.t('dashboard.profiles.update.success'))
+    end
+  end
+
+  context 'when the user does not have an orcid' do
+    let(:actor) { create(:actor, :without_an_orcid) }
+    let(:user) { create(:user, actor: actor) }
+
+    it 'does not require them to enter one' do
+      visit edit_dashboard_profile_path
+      expect(page).to have_content('Edit Profile')
+      expect(page).to have_field('ORCiD', text: '')
+      click_button 'Save'
+      expect(page).to have_content(I18n.t('navbar.heading.dashboard'))
+      expect(page).to have_content(I18n.t('dashboard.profiles.update.success'))
+    end
+  end
+
+  context 'with an admin user' do
+    let(:user) { create(:user, :admin) }
+
+    it 'offers the option to enable admin privledges' do
+      visit edit_dashboard_profile_path
+      expect(page).to have_content('Edit Profile')
+      expect(page).to have_field('Administrative privleges enabled', checked: true)
+      uncheck('Administrative privleges enabled')
+      click_button 'Save'
+      user.reload
+      expect(user.admin_enabled).to be(false)
+      expect(page).to have_content(I18n.t('navbar.heading.dashboard'))
+      expect(page).to have_content(I18n.t('dashboard.profiles.update.success'))
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_db_column(:provider).of_type(:string) }
     it { is_expected.to have_db_column(:uid).of_type(:string) }
     it { is_expected.to have_db_column(:actor_id) }
+    it { is_expected.to have_db_column(:admin_enabled).of_type(:boolean) }
 
     it { is_expected.to have_db_index(:access_id).unique }
     it { is_expected.to have_db_index(:actor_id) }
@@ -241,15 +242,40 @@ RSpec.describe User, type: :model do
   end
 
   describe '#admin?' do
-    let(:user) { build_stubbed :user }
-    let(:admin_user) { create(:user, :admin) }
+    subject { user }
 
-    it 'is false when user is not an admin' do
-      expect(user.admin?).to be false
+    context 'when the user is not an admin' do
+      let(:user) { build_stubbed :user }
+
+      it { is_expected.not_to be_admin }
     end
 
-    it 'is true when user is an admin' do
-      expect(admin_user.admin?).to be true
+    context 'when the user is an admin and enabled' do
+      let(:user) { build(:user, :admin, admin_enabled: true) }
+
+      it { is_expected.to be_admin }
+    end
+
+    context 'when the user is an admin but not enabled' do
+      let(:user) { build(:user, :admin, admin_enabled: false) }
+
+      it { is_expected.not_to be_admin }
+    end
+  end
+
+  describe '#admin_available?' do
+    subject { user }
+
+    context 'when the user is not an admin' do
+      let(:user) { build_stubbed :user }
+
+      it { is_expected.not_to be_admin_available }
+    end
+
+    context 'when the user is an admin' do
+      let(:user) { build(:user, :admin) }
+
+      it { is_expected.to be_admin_available }
     end
   end
 


### PR DESCRIPTION
Allows a user, who has admin rights available to them, to disable/enable those rights via their profile page. This is useful if an administrator wants to use the application like a standard user, or to verify access controls to standard users are being observed properly.

This also updates the layout and formatting of the profile edit page to make it more consistent with the rest of the forms in the application, and ensure that the user does not have to enter an ORCiD id for their profile.