### PR TITLE
move Create New Work to new work form

### DIFF
--- a/app/views/dashboard/catalog/_home.html.erb
+++ b/app/views/dashboard/catalog/_home.html.erb
@@ -8,7 +8,7 @@
     <h4 class="mb-2"><%= t('dashboard.home.start.heading') %></h4>
     <div class="surface search">
       <div class="mt-2 text-center">
-        <%= link_to 'Create New Work', new_dashboard_work_path, class: 'btn btn-primary' %>
+        <%= link_to 'Create New Work', dashboard_work_form_new_path, class: 'btn btn-primary' %>
       </div>
       <div class="keyline keyline--center">
         <h4><%= t('dashboard.home.start.subheading') %></h4>


### PR DESCRIPTION
I noticed that the new work button on the dashboard went to the old path. I have mended that here.