### PR TITLE
Link dashboard work versions to their resources pages

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,3 +73,7 @@ Style/ClassVars:
 Style/EmptyMethod:
   Exclude:
     - 'app/jobs/metadata_listener/job.rb'
+
+Style/MethodMissingSuper:
+  Exclude:
+   - 'app/models/null_work_version.rb'

--- a/app/decorators/collection_decorator.rb
+++ b/app/decorators/collection_decorator.rb
@@ -5,7 +5,7 @@ class CollectionDecorator < ResourceDecorator
     works
       .includes(versions: :creator_aliases)
       .map(&:latest_published_version)
-      .compact
+      .reject(&:blank?)
       .map do |work_version|
         SolrDocumentAdapterDecorator.new(
           WorkVersionDecorator.new(work_version)

--- a/app/models/null_work_version.rb
+++ b/app/models/null_work_version.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class NullWorkVersion
+  def respond_to_missing?(_name, _include_private)
+    nil
+  end
+
+  def method_missing(_name, *_args)
+    nil
+  end
+
+  def nil?
+    true
+  end
+  alias :blank? :nil?
+  alias :empty? :nil?
+end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -116,7 +116,7 @@ class Work < ApplicationRecord
   end
 
   def latest_published_version
-    versions.published.last
+    versions.published.last || NullWorkVersion.new
   end
 
   def draft_version

--- a/app/views/dashboard/catalog/_index_work_version.html.erb
+++ b/app/views/dashboard/catalog/_index_work_version.html.erb
@@ -4,7 +4,7 @@
   <%= render ThumbnailComponent.new(resource: index_work_version) %>
   <div class="card-body">
     <h3 class="card-title">
-      <%= link_to index_work_version.title, dashboard_work_version_path(index_work_version) %>
+      <%= link_to index_work_version.title, resource_path(index_work_version.uuid) %>
     </h3>
 
     <p class="meta">

--- a/spec/components/work_versions/version_navigation_dropdown_component_spec.rb
+++ b/spec/components/work_versions/version_navigation_dropdown_component_spec.rb
@@ -7,35 +7,53 @@ RSpec.describe WorkVersions::VersionNavigationDropdownComponent, type: :componen
 
   let(:result) { render_inline(described_class.new(work: work, current_version: current_version)) }
 
-  let(:work) { WorkDecorator.new(build(:work, versions_count: 2, has_draft: false)) }
-  let(:current_version) { v2 }
+  context 'when the work has no draft' do
+    let(:work) { WorkDecorator.new(build(:work, versions_count: 2, has_draft: false)) }
+    let(:current_version) { v2 }
 
-  let(:v1) { work.decorated_versions.first }
-  let(:v2) { work.decorated_versions.last }
+    let(:v1) { work.decorated_versions.first }
+    let(:v2) { work.decorated_versions.last }
 
-  before do
-    allow(work).to receive(:latest_published_version)
-      .and_return(v2)
+    before do
+      allow(work).to receive(:latest_published_version)
+        .and_return(v2)
+    end
+
+    it 'renders the current version as the dropdown toggle button' do
+      expect(result.css('.btn.dropdown-toggle').text)
+        .to include('V2')
+        .and include('published')
+    end
+
+    it 'renders the current version as a disabled menu item' do
+      expect(result.css('.dropdown-item.disabled').length).to eq 1
+      expect(result.css('.dropdown-item.disabled').text).to include('V2')
+    end
+
+    it 'links the latest published version to the *Work* resource page' do
+      expect(result.at_css('.dropdown-item:contains("V2")')[:href])
+        .to eq resource_path(work.uuid)
+    end
+
+    it 'links all other versions to their WorkVersion resource page' do
+      expect(result.at_css('.dropdown-item:contains("V1")')[:href])
+        .to eq resource_path(v1.uuid)
+    end
   end
 
-  it 'renders the current version as the dropdown toggle button' do
-    expect(result.css('.btn.dropdown-toggle').text)
-      .to include('V2')
-      .and include('published')
-  end
+  context 'when the work is a draft' do
+    let(:work) { WorkDecorator.new(build(:work, has_draft: true)) }
+    let(:current_version) { work.decorated_versions.first }
 
-  it 'renders the current version as a disabled menu item' do
-    expect(result.css('.dropdown-item.disabled').length).to eq 1
-    expect(result.css('.dropdown-item.disabled').text).to include('V2')
-  end
+    before do
+      allow(work).to receive(:latest_published_version)
+        .and_return(NullWorkVersion.new)
+    end
 
-  it 'links the latest published version to the *Work* resource page' do
-    expect(result.at_css('.dropdown-item:contains("V2")')[:href])
-      .to eq resource_path(work.uuid)
-  end
-
-  it 'links all other versions to their WorkVersion resource page' do
-    expect(result.at_css('.dropdown-item:contains("V1")')[:href])
-      .to eq resource_path(v1.uuid)
+    it 'renders the draft version as the dropdown toggle button' do
+      expect(result.css('.btn.dropdown-toggle').text)
+        .to include('V1')
+        .and include('draft')
+    end
   end
 end

--- a/spec/features/catalog/catalog_spec.rb
+++ b/spec/features/catalog/catalog_spec.rb
@@ -5,10 +5,14 @@ require 'rails_helper'
 RSpec.describe 'Blacklight catalog page', :inline_jobs do
   let(:user) { create(:user) }
 
-  # Create an array of all the latest published work versions. Some works may only have a draft, so we want to exclude
-  # those. Using `compact` removes them because `latest_published_version` returns nil.
+  # Creates an array of all the published work versions.
+  # those.
   let(:published_work_versions) do
-    Work.all.includes(versions: :creator_aliases).map(&:latest_published_version).compact
+    Work
+      .all
+      .includes(versions: :creator_aliases)
+      .map(&:latest_published_version)
+      .reject(&:blank?)
   end
 
   let(:collections) do

--- a/spec/features/dashboard/catalog_spec.rb
+++ b/spec/features/dashboard/catalog_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe 'Dashboard catalog page', :inline_jobs do
       click_link('100 per page')
 
       expect(page).to have_content("1 - #{work_versions.count} of #{work_versions.count}")
+      click_link(work_versions.first.title)
+      expect(page).to have_content(work_versions.first.title)
     end
   end
 end

--- a/spec/models/null_work_version_spec.rb
+++ b/spec/models/null_work_version_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe NullWorkVersion do
+  it { is_expected.to be_nil }
+  it { is_expected.to be_empty }
+  it { is_expected.to be_blank }
+  it { is_expected.not_to be_present }
+
+  its(:anything) { is_expected.to be_nil }
+end

--- a/spec/schemas/latest_published_version_schema_spec.rb
+++ b/spec/schemas/latest_published_version_schema_spec.rb
@@ -49,5 +49,11 @@ RSpec.describe LatestPublishedVersionSchema do
 
       its(:document) { is_expected.to be_empty }
     end
+
+    context 'when the resource is a NullWorkVersion' do
+      let(:resource) { NullWorkVersion.new }
+
+      its(:document) { is_expected.to be_empty }
+    end
   end
 end


### PR DESCRIPTION
Updates the dashboard search results to link work versions to their resource pages. Includes a new NullWorkVersion object as a stand-in for works that do have a published versions. This follows the "null object pattern" and will help us in the future when dealing with works that have no published version.

Fixes #560