### PR TITLE
Strict enforcement of EDTF on date fields

### DIFF
--- a/app/services/edtf_date.rb
+++ b/app/services/edtf_date.rb
@@ -2,15 +2,7 @@
 
 module EdtfDate
   def self.valid?(str)
-    regular_date = begin
-                     Date.parse(str)
-                   rescue ArgumentError, TypeError
-                     nil
-                   end
-
-    edtf_date = Date.edtf(str)
-
-    (regular_date || edtf_date).present?
+    Date.edtf(str).present?
   end
 
   def self.humanize(str)

--- a/spec/services/edtf_date_spec.rb
+++ b/spec/services/edtf_date_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe EdtfDate do
   describe '::valid?' do
@@ -9,8 +9,10 @@ RSpec.describe EdtfDate do
       '1999-uu-uu' => true,
       '1984?-01~' => true,
 
-      # Valid Ruby dates
-      'January 21, 2019' => true,
+      # Valid Ruby dates, but invalid EDTF dates
+      'January 21, 2019' => false,
+      'January' => false,
+      '17th Century' => false,
 
       # Invalid values
       'asdf' => false,


### PR DESCRIPTION
The EDTF validation code came from CHO. In CHO it was a feature that the fields should accept either valid Ruby dates, or valid EDTF dates, therefore things like "17th Century" were considered valid. This behavior is a bug in Scholarsphere, so I've updated the validator to require strict compliance to EDTF.

Closes #548 