### PR TITLE
Switch sidebar with main content

### DIFF
--- a/app/views/layouts/_with_sidebar.html.erb
+++ b/app/views/layouts/_with_sidebar.html.erb
@@ -1,12 +1,12 @@
 <div class="container-fluid">
   <div class="row">
-    <div class="col-lg-3">
+    <div class="col-lg-9 order-last">
+      <%= yield %>
+    </div>
+    <div class="col-lg-3 order-first">
       <aside class="sidebar">
          <%= content_for(:sidebar) %>
       </aside>
-    </div>
-    <div class="col-lg-9">
-      <%= yield %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
For accessibility reasons, it's preferred to have a screen reader present the main content first, before it presents any sidebar content. Because of layout reasons, this content was appearing *after* the sidebar. Using Bootstrap's reordering classes, we can present the main content fist in the page structure, but have it display second, after the sidebar.

Fixes #480 