### PR TITLE
Mint a DOI via background job

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -66,6 +66,11 @@ RSpec/AnyInstance:
 RSpec/NestedGroups:
   Enabled: false
 
+RSpec/MessageSpies:
+  Exclude:
+    - 'spec/jobs/doi_minting_job_spec.rb'
+    - 'spec/lib/scholarsphere/solr_admin_spec.rb'
+
 Style/ClassVars:
   Exclude:
     - 'spec/system/active_job_system_spec.rb'

--- a/app/jobs/doi_minting_job.rb
+++ b/app/jobs/doi_minting_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class DoiMintingJob < ApplicationJob
+  queue_as :doi
+
+  def perform(resource)
+    status = DoiStatus.new(resource)
+
+    status.minting!
+    DoiService.call(resource)
+    status.delete!
+  rescue DoiService::Error => e
+    status.error!
+    # @todo more error handling here?
+    raise e
+  end
+end

--- a/app/services/doi_status.rb
+++ b/app/services/doi_status.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class DoiStatus
+  STATUSES = %i(
+    waiting
+    minting
+    error
+  ).freeze
+
+  STATUSES.each do |status|
+    define_method "#{status}!" do
+      set status.to_s
+    end
+
+    define_method "#{status}?" do
+      current_status.to_s == status.to_s
+    end
+  end
+
+  def initialize(resource)
+    @resource = resource
+  end
+
+  def present?
+    current_status.present?
+  end
+
+  def delete!
+    redis.del(key)
+  end
+
+  private
+
+    attr_reader :resource
+
+    def current_status
+      redis.get(key)
+    end
+
+    def key
+      "doi:status:#{resource.uuid}"
+    end
+
+    def set(new_status)
+      redis.set(key, new_status)
+    end
+
+    def redis
+      @redis ||= Redis.new(Rails.configuration.redis)
+    end
+end

--- a/app/services/mint_doi_async.rb
+++ b/app/services/mint_doi_async.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class MintDoiAsync
+  def self.call(resource)
+    status = DoiStatus.new(resource)
+
+    status.waiting!
+    DoiMintingJob.perform_later(resource)
+  end
+end

--- a/spec/jobs/doi_minting_job_spec.rb
+++ b/spec/jobs/doi_minting_job_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DoiMintingJob, type: :job do
+  let(:resource) { instance_spy('Work') }
+  let(:mock_doi_status) { instance_spy('DoiStatus') }
+
+  describe '#perform' do
+    before do
+      allow(DoiService).to receive(:call)
+      allow(DoiStatus).to receive(:new).and_return(mock_doi_status)
+    end
+
+    it 'calls DoiService while reporting status' do
+      expect(DoiStatus).to receive(:new).with(resource)
+
+      # Order of these calls matters
+      expect(mock_doi_status).to receive(:minting!).ordered
+      expect(DoiService).to receive(:call).with(resource).ordered
+      expect(mock_doi_status).to receive(:delete!).ordered
+
+      described_class.perform_now(resource)
+    end
+
+    context 'when an error occurrs' do
+      before do
+        allow(DoiService).to receive(:call).with(resource).and_raise(DoiService::Error)
+      end
+
+      it 'reports the error to the status, then raises' do
+        expect {
+          described_class.perform_now(resource)
+        }.to raise_error(DoiService::Error)
+
+        expect(mock_doi_status).to have_received(:error!)
+      end
+    end
+  end
+end

--- a/spec/services/doi_status_spec.rb
+++ b/spec/services/doi_status_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe DoiStatus do
+  subject(:status) { described_class.new(resource) }
+
+  let(:resource) { build_stubbed :work }
+
+  describe '::STATUSES' do
+    subject { described_class::STATUSES }
+
+    it { is_expected.to match_array(%i(waiting minting error)) }
+  end
+
+  describe 'status-based methods' do
+    described_class::STATUSES.each do |status|
+      it { is_expected.to respond_to("#{status}!") }
+      it { is_expected.to respond_to("#{status}?") }
+    end
+  end
+
+  # All of these status-based predicate methods are metaprogrammed,
+  # so I'm only going to test one
+  describe '#waiting?' do
+    subject { status.waiting? }
+
+    context 'when the current status is not "waiting"' do
+      before { status.delete! }
+
+      it { is_expected.to eq false }
+    end
+
+    context 'when the current status is "waiting"' do
+      before { status.waiting! }
+
+      it { is_expected.to eq true }
+    end
+  end
+
+  describe '#waiting!' do
+    before { status.delete! }
+
+    it 'sets the current status to waiting' do
+      expect(status).not_to be_waiting # Sanity
+      status.waiting!
+      expect(status).to be_waiting
+    end
+  end
+
+  describe '#delete!' do
+    before { status.waiting! }
+
+    it 'deletes the key from redis' do
+      expect(status).to be_waiting # Sanity
+      status.delete!
+      expect(status).not_to be_present
+    end
+  end
+
+  describe '#present?' do
+    subject { status.present? }
+
+    context 'when the key is present in redis' do
+      before { status.waiting! }
+
+      it { is_expected.to eq true }
+    end
+
+    context 'when the key is not present in redis' do
+      before { status.delete! }
+
+      it { is_expected.to eq false }
+    end
+  end
+end

--- a/spec/services/mint_doi_async_spec.rb
+++ b/spec/services/mint_doi_async_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe MintDoiAsync do
+  let(:resource) { instance_spy('Work') }
+  let(:mock_doi_status) { instance_spy('DoiStatus') }
+
+  describe '.call' do
+    before do
+      allow(DoiStatus).to receive(:new).with(resource).and_return(mock_doi_status)
+      allow(DoiMintingJob).to receive(:perform_later)
+    end
+
+    it 'fires off a background job after setting appropriate status' do
+      described_class.call(resource)
+
+      expect(DoiStatus).to have_received(:new).with(resource)
+      expect(mock_doi_status).to have_received(:waiting!)
+      expect(DoiMintingJob).to have_received(:perform_later).with(resource)
+    end
+  end
+end


### PR DESCRIPTION
The entrypoint for this (aka, what the controller(s) will use) is `MintDoiAsync.call`. That method sets the status of the doi to `waiting` and fires off a background job. From there, the DoiMintingJob will eventually take over, and mint the DOI using our existing service while keeping the status updated accordingly

Closes #105 