### PR TITLE
Adds remaining fields to work form

### DIFF
--- a/app/controllers/dashboard/work_form/contributors_controller.rb
+++ b/app/controllers/dashboard/work_form/contributors_controller.rb
@@ -35,6 +35,7 @@ module Dashboard
           params
             .require(:work_version)
             .permit(
+              contributor: [],
               creator_aliases_attributes: [
                 :id,
                 :actor_id,

--- a/app/views/dashboard/work_form/contributors/_contributors.html.erb
+++ b/app/views/dashboard/work_form/contributors/_contributors.html.erb
@@ -1,0 +1,9 @@
+<div class="form-wrapper form-wrapper--wide">
+  <div class="keyline keyline--left mb-3">
+    <h4><%= t('dashboard.work_form.contributors.edit.contributors_heading') %></h4>
+  </div>
+</div>
+
+<div class="form-wrapper">
+  <%= render 'form_fields/multi_text', form: form, attribute: :contributor %>
+</div>

--- a/app/views/dashboard/work_form/contributors/_creator_alias_fields.html.erb
+++ b/app/views/dashboard/work_form/contributors/_creator_alias_fields.html.erb
@@ -1,46 +1,38 @@
 <%# @note Builds a form object when the partial is called async, such as appending new creators to the work form %>
-<% f ||= ActionView::Helpers::FormBuilder.new("work_version[creator_aliases_attributes][#{Time.zone.now.to_i}]", creator_alias, self, {}) %>
-<% index = f.try(:index) || 0 %>
+<%- form ||= ActionView::Helpers::FormBuilder.new("work_version[creator_aliases_attributes][#{Time.zone.now.to_i}]", creator_alias, self, {}) %>
+<%- index = form.try(:index) || 0 %>
 
 <div class="nested-fields">
-  <% if index > 0 || f.try(:index).blank? %>
+  <% if index > 0 || form.try(:index).blank? %>
     <hr>
   <% end %>
 
-  <div class="row row--md-reduce">
+  <div class="row">
     <div class="col-2">
       <span class="badge badge-dark badge--outline">
         <%= t('dashboard.work_form.contributors.edit.badge') %>
         <span class="badge--index"><%= index + 1 %></span>
       </span>
-
     </div>
 
-    <div class="col-7">
-      <div class="form-wrapper">
-        <%= f.hidden_field :actor_id %>
-        <%= render 'form_fields/text', form: f, attribute: :alias, required: true %>
+    <div class="col-8 pr-2">
+      <%= form.hidden_field :actor_id %>
+      <div class="form-group has-float-label">
+        <%= form.text_field :alias, class: 'form-control', placeholder: true, required: true %>
+        <%= form.label :alias %>
       </div>
     </div>
 
-    <div class="col-3">
-      <%= link_to_remove_association f, class: 'btn btn-outline-danger btn-sm float-sm-right' do %>
-        <span class="sr-only"><%= t('dashboard.work_form.contributors.edit.remove', name: f.object.alias) %></span>
+    <div class="col-2 pl-0">
+      <%= link_to_remove_association form, class: 'remove' do %>
+        <span class="sr-only"><%= t('dashboard.work_form.contributors.edit.remove', name: form.object.alias) %></span>
         <i class="material-icons" aria-hidden="true">highlight_off</i>
-      <% end %>
-
-      <%= link_to '#', class: 'btn btn-outline-info btn-sm float-sm-right' do %>
-        <i class="material-icons" aria-hidden="true">arrow_circle_down</i>
-      <% end %>
-
-      <%= link_to '#', class: 'btn btn-outline-info btn-sm float-sm-right' do %>
-        <i class="material-icons" aria-hidden="true">arrow_circle_up</i>
       <% end %>
     </div>
   </div>
 
-  <div class="row row--md-reduce">
-    <div class="col-12 offset-2">
+  <div class="row">
+    <div class="col-10 offset-2">
       <table class="table table-sm">
         <thead>
           <tr>
@@ -52,15 +44,15 @@
         </thead>
         <tbody>
           <tr>
-            <td><%= f.object.actor.given_name %></td>
-            <td><%= f.object.actor.surname %></td>
-            <td><%= f.object.actor.email %></td>
-            <td><%= f.object.actor.psu_id %></td>
+            <td><%= form.object.actor.given_name %></td>
+            <td><%= form.object.actor.surname %></td>
+            <td><%= form.object.actor.email %></td>
+            <td><%= form.object.actor.psu_id %></td>
           </tr>
         </tbody>
       </table>
 
-      <%= f.fields_for :actor do |actor_fields| %>
+      <%= form.fields_for :actor do |actor_fields| %>
         <%= actor_fields.hidden_field :email %>
         <%= actor_fields.hidden_field :given_name %>
         <%= actor_fields.hidden_field :surname %>

--- a/app/views/dashboard/work_form/contributors/_creators.html.erb
+++ b/app/views/dashboard/work_form/contributors/_creators.html.erb
@@ -1,16 +1,15 @@
 <div class="form-wrapper form-wrapper--wide">
   <div class="keyline keyline--left mb-3">
-    <h4><%= t('dashboard.work_form.contributors.edit.fields_heading') %></h4>
+    <h4><%= t('dashboard.work_form.contributors.edit.creators_heading') %></h4>
   </div>
 </div>
 
 <div id="creator_aliases"
-     class="mb-3"
      data-controller="contributors"
      data-contributors-new="<%= new_dashboard_actor_path %>"
      data-contributors-post="<%= dashboard_work_form_aliases_new_path %>"
      data-contributors-badge-class="badge--index">
   <%= form.fields_for :creator_aliases do |creator_alias| %>
-    <%= render 'dashboard/work_form/contributors/creator_alias_fields', f: creator_alias %>
+    <%= render 'dashboard/work_form/contributors/creator_alias_fields', form: creator_alias %>
   <% end %>
 </div>

--- a/app/views/dashboard/work_form/contributors/_search.html.erb
+++ b/app/views/dashboard/work_form/contributors/_search.html.erb
@@ -1,44 +1,50 @@
-<div class="form-wrapper form-wrapper--wide">
-  <div class="keyline keyline--left mb-3">
-    <h4><%= t('dashboard.work_form.contributors.edit.search_heading') %></h4>
+<div class="row row--md-reduce">
+  <div class="col-10 offset-2">
+    <div class="form-wrapper form-wrapper--wide">
+      <div class="keyline keyline--left mb-3">
+        <h4><%= t('dashboard.work_form.contributors.edit.search_heading') %></h4>
+      </div>
+    </div>
   </div>
 </div>
 
-<div class="form-wrapper">
-  <div class="form-group"
-     data-controller="autocomplete"
-     data-autocomplete-search="/authorities/search/persons">
+<div class="row row--md-reduce">
+  <div class="col-10 offset-2">
+    <div class="form-group"
+         data-controller="autocomplete"
+         data-autocomplete-search="/authorities/search/persons">
 
-     <template data-target="autocomplete.emptyResultTemplate">
-       <%= t('dashboard.work_form.contributors.edit.empty_result') %>
-     </template>
+      <template data-target="autocomplete.emptyResultTemplate">
+        <%= t('dashboard.work_form.contributors.edit.empty_result') %>
+      </template>
 
-     <template data-target="autocomplete.lastOptionTemplate">
-       <%= t('dashboard.work_form.contributors.edit.last_option') %>
-     </template>
+      <template data-target="autocomplete.lastOptionTemplate">
+        <%= t('dashboard.work_form.contributors.edit.last_option') %>
+      </template>
 
-     <template data-target="autocomplete.suggestionTemplate">
-       {{default_alias}}
-       <span class="sr-only">
-         Search result {{result_number}} of {{total_results}}. Press enter to add this creator to the form.
-       </span>
-     </template>
-
-     <input type="text"
-            class="form-control"
-            id="search-creators"
-            aria-describedby="search-creators-description"
-            data-target="autocomplete.field"
-            placeholder="<%= t('dashboard.work_form.contributors.edit.placeholder') %>">
-
-      <label for="search-creators" class="sr-only">
-        <%= t('dashboard.work_form.contributors.edit.search_label') %>
-      </label>
-      <small id="search-creators-description" class="form-text text-muted">
-        <%= t('dashboard.work_form.contributors.edit.search') %>
+      <template data-target="autocomplete.suggestionTemplate">
+        {{default_alias}}
         <span class="sr-only">
-          <%= t('dashboard.work_form.contributors.edit.reader_hint') %>
+          Search result {{result_number}} of {{total_results}}. Press enter to add this creator to the form.
         </span>
-      </small>
+      </template>
+
+      <input type="text"
+             class="form-control"
+             id="search-creators"
+             aria-describedby="search-creators-description"
+             data-target="autocomplete.field"
+             placeholder="<%= t('dashboard.work_form.contributors.edit.placeholder') %>">
+
+             <label for="search-creators" class="sr-only">
+               <%= t('dashboard.work_form.contributors.edit.search_label') %>
+             </label>
+             <small id="search-creators-description" class="form-text text-muted">
+               <%= t('dashboard.work_form.contributors.edit.search') %>
+               <span class="sr-only">
+                 <%= t('dashboard.work_form.contributors.edit.reader_hint') %>
+               </span>
+             </small>
+    </div>
   </div>
 </div>

--- a/app/views/dashboard/work_form/contributors/edit.html.erb
+++ b/app/views/dashboard/work_form/contributors/edit.html.erb
@@ -19,9 +19,11 @@
 
             <%= render FormErrorMessageComponent.new(form: form) %>
 
-            <%= render 'fields', form: form %>
+            <%= render 'creators', form: form %>
 
             <%= render 'search' %>
+
+            <%= render 'contributors', form: form %>
 
             <%= render 'dashboard/work_form/shared/action_footer', form: form, publish: false %>
           <% end %>

--- a/app/views/dashboard/work_form/details/_fields.html.erb
+++ b/app/views/dashboard/work_form/details/_fields.html.erb
@@ -31,8 +31,13 @@
 </div>
 
 <div class="form-wrapper">
+  <%= render 'form_fields/text', form: form, attribute: :subtitle %>
+  <%= render 'form_fields/text', form: form, attribute: :version_name %>
   <%= render 'form_fields/multi_text', form: form, attribute: :publisher %>
   <%= render 'form_fields/multi_text', form: form, attribute: :subject %>
   <%= render 'form_fields/multi_text', form: form, attribute: :language %>
   <%= render 'form_fields/multi_text', form: form, attribute: :related_url %>
+  <%= render 'form_fields/multi_text', form: form, attribute: :identifier %>
+  <%= render 'form_fields/multi_text', form: form, attribute: :based_near %>
+  <%= render 'form_fields/multi_text', form: form, attribute: :source %>
 </div>

--- a/app/views/dashboard/work_form/publish/edit.html.erb
+++ b/app/views/dashboard/work_form/publish/edit.html.erb
@@ -16,12 +16,8 @@
 
             <%= render 'dashboard/work_form/details/fields', form: form %>
 
-            <div class="form-wrapper form-wrapper--wide">
-              <div class="keyline keyline--left mb-3">
-                <h4><%= t '.contributors' %></h4>
-              </div>
-            </div>
-            <%= render 'dashboard/work_form/contributors/fields', form: form %>
+            <%= render 'dashboard/work_form/contributors/creators', form: form %>
+            <%= render 'dashboard/work_form/contributors/contributors', form: form %>
 
             <div class="form-wrapper form-wrapper--wide">
               <div class="keyline keyline--left mb-3">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,7 +14,7 @@ en:
         keyword: Keyword
         description: Description
         creator_aliases: Creator
-        contributor: Contributor
+        contributor: Acknowledgments
         publisher: Publisher
         published_date: &collection_published_date Publication Date
         display_published_date: *collection_published_date
@@ -41,7 +41,7 @@ en:
         description: Description
         creator_aliases: Creators
         resource_type: Resource Type
-        contributor: Contributor
+        contributor: Acknowledgments
         publisher: Publisher
         published_date: &work_version_published_date Publication Date
         display_published_date: *work_version_published_date
@@ -207,16 +207,18 @@ en:
         edit:
           badge: Creator
           empty_result: No results found. Choose this option to create a new creator.
-          fields_heading: Creators
+          creators_heading: Creators
+          contributors_heading: Additional Acknowledgments
           last_option: Not finding what you're looking for? Choose this option to create your own...
           new: Create New Contributor
           no_results: No results
-          placeholder: "Search for an existing creator"
+          placeholder: "Search..."
           reader_hint: >
             When autocomplete results are available use up and down arrows to review and enter to select.
             Touch device users, explore by touch or with swipe gestures.
           remove: "Remove creator %{name}"
-          search: "You can search for creators by Access Account ID (abc123 or abc1234) or by name"
+          search: >
+            You can search for creators using their Penn State Access Account, email, or name
           search_heading: Add another creator
           search_label: Search creators
           search_results: Search Results

--- a/spec/features/publish_new_work_spec.rb
+++ b/spec/features/publish_new_work_spec.rb
@@ -50,10 +50,15 @@ RSpec.describe 'Publishing a work', with_user: :user do
         expect(new_work_version.description).to eq metadata[:description]
         expect(new_work_version.published_date).to eq metadata[:published_date]
         expect(new_work_version.keyword).to eq [metadata[:keyword]]
+        expect(new_work_version.subtitle).to eq metadata[:subtitle]
+        expect(new_work_version.version_name).to eq metadata[:version_name]
         expect(new_work_version.publisher).to eq [metadata[:publisher]]
         expect(new_work_version.subject).to eq [metadata[:subject]]
         expect(new_work_version.language).to eq [metadata[:language]]
         expect(new_work_version.related_url).to eq [metadata[:related_url]]
+        expect(new_work_version.identifier).to eq [metadata[:identifier]]
+        expect(new_work_version.based_near).to eq [metadata[:based_near]]
+        expect(new_work_version.source).to eq [metadata[:source]]
 
         expect(page).to have_current_path(dashboard_work_form_contributors_path(new_work_version))
       end
@@ -89,14 +94,20 @@ RSpec.describe 'Publishing a work', with_user: :user do
         FeatureHelpers::WorkForm.save_and_continue
 
         work_version.reload
+        expect(work_version.version_number).to eq 2
         expect(work_version.title).to eq metadata[:title]
         expect(work_version.description).to eq metadata[:description]
         expect(work_version.published_date).to eq metadata[:published_date]
         expect(work_version.keyword).to eq [metadata[:keyword]]
+        expect(work_version.subtitle).to eq metadata[:subtitle]
+        expect(work_version.version_name).to eq metadata[:version_name]
         expect(work_version.publisher).to eq [metadata[:publisher]]
         expect(work_version.subject).to eq [metadata[:subject]]
         expect(work_version.language).to eq [metadata[:language]]
         expect(work_version.related_url).to eq [metadata[:related_url]]
+        expect(work_version.identifier).to eq [metadata[:identifier]]
+        expect(work_version.based_near).to eq [metadata[:based_near]]
+        expect(work_version.source).to eq [metadata[:source]]
 
         expect(page).to have_current_path(dashboard_work_form_contributors_path(work_version))
       end
@@ -129,7 +140,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
     let(:actor) { work_version.work.depositor }
 
     context 'with an initial draft version' do
-      it 'includes the current user as a creator' do
+      it 'includes the current user as a creator and adds additional contributors' do
         visit dashboard_work_form_contributors_path(work_version)
 
         expect(work_version.creators).to be_empty
@@ -147,9 +158,13 @@ RSpec.describe 'Publishing a work', with_user: :user do
           expect(page).to have_content(actor.psu_id)
         end
 
+        fill_in 'work_version_contributor', with: metadata[:contributor]
+
         FeatureHelpers::WorkForm.save_and_continue
 
+        work_version.reload
         expect(work_version.creators).to contain_exactly(actor)
+        expect(work_version.contributor).to eq [metadata[:contributor]]
 
         expect(page).to have_current_path(dashboard_work_form_files_path(work_version))
       end

--- a/spec/support/feature_helpers/work_form.rb
+++ b/spec/support/feature_helpers/work_form.rb
@@ -16,10 +16,15 @@ module FeatureHelpers
       fill_in 'work_version_published_date', with: work_version_metadata[:published_date]
       fill_in 'work_version_keyword', with: work_version_metadata[:keyword]
 
+      fill_in 'work_version_subtitle', with: work_version_metadata[:subtitle]
+      fill_in 'work_version_version_name', with: work_version_metadata[:version_name]
       fill_in 'work_version_publisher', with: work_version_metadata[:publisher]
       fill_in 'work_version_subject', with: work_version_metadata[:subject]
       fill_in 'work_version_language', with: work_version_metadata[:language]
       fill_in 'work_version_related_url', with: work_version_metadata[:related_url]
+      fill_in 'work_version_identifier', with: work_version_metadata[:identifier]
+      fill_in 'work_version_based_near', with: work_version_metadata[:based_near]
+      fill_in 'work_version_source', with: work_version_metadata[:source]
     end
 
     def self.fill_in_contributors(metadata)


### PR DESCRIPTION
Additional fields are added to the details tab of the work form. Additional contributors can be added via the contributors tab.

Fixes #549 

This alters the flow of the UI a bit and we should probably discuss. Here are the changes:

Additional fields are added to the details tab:
<img width="923" alt="Screen Shot 2020-10-06 at 4 19 10 PM" src="https://user-images.githubusercontent.com/312085/95255666-bb8b9f80-07ef-11eb-92d9-b57b506f3166.png">

The contributors field in original Scholarsphere is here now, but labeled as _Additional Contributors_. This might be confusing to the user since the contributors field wasn't initially visible in SS3.

**UPDATED**
![Screen Shot 2020-10-08 at 2 27 04 PM](https://user-images.githubusercontent.com/312085/95498852-6c21ac80-0972-11eb-9af0-1d3e673ec833.png)



