### PR TITLE
Operations in the user's dashboard

### DIFF
--- a/app/controllers/dashboard/work_versions_controller.rb
+++ b/app/controllers/dashboard/work_versions_controller.rb
@@ -12,7 +12,7 @@ module Dashboard
       respond_to do |format|
         if @work_version.save
           format.html do
-            redirect_to dashboard_work_version_file_list_path(@work_version),
+            redirect_to dashboard_work_form_details_path(@work_version),
                         notice: 'Work version was successfully created.'
           end
           format.json { render :show, status: :created, location: @work_version }
@@ -59,7 +59,7 @@ module Dashboard
       DestroyWorkVersion.call(@work_version)
 
       respond_to do |format|
-        format.html { redirect_to dashboard_works_path, notice: 'Work version was successfully destroyed.' }
+        format.html { redirect_to dashboard_root_path, notice: 'Work version was successfully destroyed.' }
         format.json { head :no_content }
       end
     end

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -98,8 +98,6 @@ class WorkVersion < ApplicationRecord
 
   after_save :update_index_async
 
-  after_destroy { SolrDeleteJob.perform_later(uuid) }
-
   aasm do
     state :draft, intial: true
     state :published, :withdrawn, :removed

--- a/app/services/destroy_work_version.rb
+++ b/app/services/destroy_work_version.rb
@@ -6,8 +6,12 @@ class DestroyWorkVersion
 
     if parent_work.versions.count == 1
       parent_work.destroy!
+      IndexingService.delete_document(work_version.uuid, commit: true)
     else
       work_version.destroy!
+      parent_work.reload
+      IndexingService.delete_document(work_version.uuid, commit: false)
+      WorkIndexer.call(parent_work, commit: true)
     end
   end
 end

--- a/app/views/dashboard/catalog/_index_work_version.html.erb
+++ b/app/views/dashboard/catalog/_index_work_version.html.erb
@@ -35,7 +35,7 @@
       <% end %>
 
       <% if policy(index_work_version).new?(index_work_version) %>
-        <%= link_to dashboard_work_work_versions_path(index_work_version),
+        <%= link_to dashboard_work_work_versions_path(index_work_version.work),
                     method: :post,
                     class: 'btn btn-primary btn--icon' do %>
           <i class="material-icons">create_new_folder</i>

--- a/spec/controllers/dashboard/work_versions_controller_spec.rb
+++ b/spec/controllers/dashboard/work_versions_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Dashboard::WorkVersionsController, type: :controller do
           perform_request
           new_version = work.reload.draft_version
 
-          expect(response).to redirect_to dashboard_work_version_file_list_path(new_version)
+          expect(response).to redirect_to dashboard_work_form_details_path(new_version)
         end
       end
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -3,9 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Collection, type: :model do
-  it_behaves_like 'an indexable resource' do
-    let(:resource) { create(:collection) }
-  end
+  it_behaves_like 'an indexable resource'
 
   it_behaves_like 'a resource with permissions' do
     let(:factory_name) { :collection }
@@ -275,6 +273,17 @@ RSpec.describe Collection, type: :model do
         expect(collection).not_to have_received(:reload)
         expect(CollectionIndexer).to have_received(:call)
       end
+    end
+  end
+
+  describe 'after destroy' do
+    let(:collection) { create(:collection) }
+
+    before { allow(SolrDeleteJob).to receive(:perform_later) }
+
+    it 'removes the collection from the index' do
+      collection.destroy
+      expect(SolrDeleteJob).to have_received(:perform_later).with(collection.uuid)
     end
   end
 end

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -3,9 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe WorkVersion, type: :model do
-  it_behaves_like 'an indexable resource' do
-    let(:resource) { build(:work_version) }
-  end
+  it_behaves_like 'an indexable resource'
 
   it_behaves_like 'a resource with view statistics' do
     let(:resource) { create(:work_version) }

--- a/spec/support/shared/an_indexable_resource.rb
+++ b/spec/support/shared/an_indexable_resource.rb
@@ -3,13 +3,4 @@
 RSpec.shared_examples 'an indexable resource' do
   it { is_expected.to respond_to(:update_index) }
   it { is_expected.to respond_to(:update_index_async) }
-
-  describe 'after destroy' do
-    before { allow(SolrDeleteJob).to receive(:perform_later) }
-
-    it 'removes the resource from the index' do
-      resource.destroy
-      expect(SolrDeleteJob).to have_received(:perform_later).with(resource.uuid)
-    end
-  end
 end


### PR DESCRIPTION
This tests for and corrects a couple of problems with the user's dashboard:

* creating a new work version directs to the revised work form
* deleting a work version redirects back to the dashboard
* deleted versions are properly removed from the index and their parent works updated
* saving in the work form redirects back to the dashboard

Because most of the activities redirect back to the user's dashboard, all Solr operations are performed *synchronously* so the changes can be seen immediately.

At this point, we aren't making any provisions for asynchronous Solr operations with regards to deleting work versions because there isn't a clear use case at the moment.