### PR TITLE
Wait for the modal to close

### DIFF
--- a/spec/features/publish_new_work_spec.rb
+++ b/spec/features/publish_new_work_spec.rb
@@ -218,14 +218,14 @@ RSpec.describe 'Publishing a work', with_user: :user do
           click_button('Save')
         end
 
-        wait_until(Capybara.default_max_wait_time * 4) do
-          within('#creator_aliases') do
-            expect(page).to have_content('CREATOR 1')
-            expect(page).to have_content('CREATOR 2')
-            expect(page).to have_content(metadata[:surname])
-            expect(page).to have_content(metadata[:given_name])
-            expect(page).to have_field('Display Name', count: 2)
-          end
+        wait_for_modal(5)
+
+        within('#creator_aliases') do
+          expect(page).to have_content('CREATOR 1')
+          expect(page).to have_content('CREATOR 2')
+          expect(page).to have_content(metadata[:surname])
+          expect(page).to have_content(metadata[:given_name])
+          expect(page).to have_field('Display Name', count: 2)
         end
         FeatureHelpers::WorkForm.save_and_continue
 

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -33,8 +33,13 @@ module FeatureHelpers
     puts ''
   end
 
-  def wait_until(timeout = Capybara.default_max_wait_time)
-    Capybara.send(:timeout, timeout, Capybara.current_driver) { yield }
+  def wait_for_modal(limit = Capybara.default_max_wait_time)
+    count = 1
+    while page.has_selector?('body.modal-open')
+      sleep 1
+      count = count + 1
+      raise StandardError, "modal failed to close after #{limit} seconds" if count == limit
+    end
   end
 
   private


### PR DESCRIPTION
Avoids the intermittent failures in CI.

At first I thought the failures were due to async calls, but it turns out we just need to wait for the modal to fully close. Hopefully this should fix the problems.