### PR TITLE
Add actor_id to QA authority response

### DIFF
--- a/lib/qa/authorities/persons.rb
+++ b/lib/qa/authorities/persons.rb
@@ -61,6 +61,7 @@ module Qa
             email: result.email,
             orcid: result.orcid,
             default_alias: result.default_alias,
+            actor_id: result.id,
             source: 'scholarsphere'
           }
         end

--- a/spec/features/publish_new_work_spec.rb
+++ b/spec/features/publish_new_work_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
     end
 
     context 'when adding additional users from Penn State' do
-      it 'inserts the creator into the form' do
+      it 'inserts the Penn State person as a creator into the form' do
         visit dashboard_work_form_contributors_path(work_version)
 
         expect(work_version.creators).to be_empty
@@ -184,6 +184,39 @@ RSpec.describe 'Publishing a work', with_user: :user do
         FeatureHelpers::WorkForm.save_and_continue
 
         expect(work_version.creators.map(&:surname)).to include('Wead')
+        expect(page).to have_current_path(dashboard_work_form_files_path(work_version))
+      end
+    end
+
+    context 'when add existing actors from Scholarsphere' do
+      let!(:actor) { create(:actor) }
+
+      it 'inserts the local Scholarsphere actor as a creator into the form' do
+        visit dashboard_work_form_contributors_path(work_version)
+
+        expect(work_version.creators).to be_empty
+        within('#creator_aliases') do
+          expect(page).to have_content('CREATOR 1')
+          expect(page).to have_field('Display Name', count: 1)
+        end
+
+        FeatureHelpers::WorkForm.search_creators(actor.surname)
+
+        within('.algolia-autocomplete') do
+          expect(page).to have_content(actor.default_alias)
+        end
+
+        find_all('.aa-suggestion').first.click
+
+        within('#creator_aliases') do
+          expect(page).to have_content('CREATOR 1')
+          expect(page).to have_content('CREATOR 2')
+          expect(page).to have_field('Display Name', count: 2)
+        end
+
+        FeatureHelpers::WorkForm.save_and_continue
+
+        expect(work_version.creators.map(&:surname)).to include(actor.surname)
         expect(page).to have_current_path(dashboard_work_form_files_path(work_version))
       end
     end

--- a/spec/lib/qa/authorities/persons_spec.rb
+++ b/spec/lib/qa/authorities/persons_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Qa::Authorities::Persons, type: :authority do
           email: creator.email,
           orcid: creator.orcid,
           source: 'scholarsphere',
+          actor_id: creator.id,
           result_number: 1,
           total_results: 1
         }


### PR DESCRIPTION
This corrects a bug that was preventing adding existing actors to the creators form. Because the actor ID wasn't being added to the form, the application was trying to create a *new* actor using the existing actor's metadata, which was causing validation errors.

Fixes #573 