### PR TITLE
Add autosave option to access controls

### DIFF
--- a/app/models/concerns/permissions.rb
+++ b/app/models/concerns/permissions.rb
@@ -29,7 +29,8 @@ module Permissions
   included do
     has_many :access_controls,
              as: :resource,
-             dependent: :destroy
+             dependent: :destroy,
+             autosave: true
   end
 
   # @note This is to exclude agents from the []= assigning process, and avoids the problem of removing visibility

--- a/spec/features/dashboard/visibility_spec.rb
+++ b/spec/features/dashboard/visibility_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Setting visibility in the dashboard', with_user: :user do
+  let(:user) { work_version.work.depositor.user }
+
+  context 'when changing from public to Penn State' do
+    let(:work_version) { create :work_version, :able_to_be_published }
+
+    it 'sets the visibility to Penn State' do
+      visit dashboard_work_form_publish_path(work_version)
+
+      expect(find_field('Public')).to be_checked
+
+      choose "work_version_work_attributes_visibility_#{Permissions::Visibility::AUTHORIZED}"
+      check 'work_version_depositor_agreement'
+      FeatureHelpers::WorkForm.publish
+
+      work = Work.last
+      expect(work).to be_authorized_access
+    end
+  end
+
+  context 'when changing from Penn State to public' do
+    let(:work_version) { create :work_version, :able_to_be_published, work: create(:work, :with_authorized_access) }
+
+    it 'sets the visibility to public' do
+      visit dashboard_work_form_publish_path(work_version)
+
+      expect(find_field('Penn State Only')).to be_checked
+
+      choose "work_version_work_attributes_visibility_#{Permissions::Visibility::OPEN}"
+      check 'work_version_depositor_agreement'
+      FeatureHelpers::WorkForm.publish
+
+      work = Work.last
+      expect(work).to be_open_access
+    end
+  end
+
+  context 'when changing from restricted to Penn State' do
+    let(:work_version) { create :work_version, :able_to_be_published, work: create(:work, :with_no_access) }
+
+    it 'sets the visibility to public' do
+      visit dashboard_work_form_publish_path(work_version)
+
+      expect(find_field('Penn State Only')).not_to be_checked
+      expect(find_field('Public')).not_to be_checked
+
+      choose "work_version_work_attributes_visibility_#{Permissions::Visibility::AUTHORIZED}"
+      check 'work_version_depositor_agreement'
+      FeatureHelpers::WorkForm.publish
+
+      work = Work.last
+      expect(work).to be_authorized_access
+    end
+  end
+
+  context 'when changing from restricted to public' do
+    let(:work_version) { create :work_version, :able_to_be_published, work: create(:work, :with_no_access) }
+
+    it 'sets the visibility to public' do
+      visit dashboard_work_form_publish_path(work_version)
+
+      expect(find_field('Penn State Only')).not_to be_checked
+      expect(find_field('Public')).not_to be_checked
+
+      choose "work_version_work_attributes_visibility_#{Permissions::Visibility::OPEN}"
+      check 'work_version_depositor_agreement'
+      FeatureHelpers::WorkForm.publish
+
+      work = Work.last
+      expect(work).to be_open_access
+    end
+  end
+
+  context 'when NOT changing from restricted' do
+    let(:work_version) { create :work_version, :able_to_be_published, work: create(:work, :with_no_access) }
+
+    it 'sets the visibility to public' do
+      visit dashboard_work_form_publish_path(work_version)
+
+      expect(find_field('Penn State Only')).not_to be_checked
+      expect(find_field('Public')).not_to be_checked
+
+      check 'work_version_depositor_agreement'
+      FeatureHelpers::WorkForm.publish
+
+      within('#error_explanation') do
+        expect(page).to have_content('Visibility cannot be private')
+      end
+    end
+  end
+end

--- a/spec/services/doi_service_spec.rb
+++ b/spec/services/doi_service_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe DoiService do
     end
 
     context 'when the metadata mapper cannot build valid metadata' do
-      let(:resource) { FactoryBot.build_stubbed :work_version, doi: nil }
+      let(:resource) { FactoryBot.create :work_version, doi: nil }
 
       before do
         allow(resource).to receive(:draft?).and_return(false)
@@ -237,7 +237,7 @@ RSpec.describe DoiService do
     end
 
     context 'when the doi client raises an error' do
-      let(:resource) { FactoryBot.build_stubbed :work_version, doi: nil }
+      let(:resource) { FactoryBot.create :work_version, doi: nil }
 
       before do
         allow(resource).to receive(:draft?).and_return(true)


### PR DESCRIPTION
This gets around the problem of new or changed access controls not triggering a save operation. This is due to the fact that methods like .visibility are actual ActiveModel attributes and changing them doesn't mark the resource changed.

Fixes #575 