### PR TITLE
Track changes to works done via the API

### DIFF
--- a/app/components/work_histories/work_history_component.rb
+++ b/app/components/work_histories/work_history_component.rb
@@ -108,12 +108,13 @@ module WorkHistories
           end
       end
 
-      def lookup_user(user_id)
-        user_lookup_cache[user_id] ||= find_user(user_id)
+      def lookup_user(global_id)
+        user_lookup_cache[global_id] ||= find_user_or_app(global_id)
       end
 
-      def find_user(user_id)
-        User.find(user_id)
+      # @return [User, ExternalApp]
+      def find_user_or_app(global_id)
+        GlobalID::Locator.locate(global_id) || null_user
       rescue ActiveRecord::RecordNotFound
         null_user
       end

--- a/app/controllers/api/v1/rest_controller.rb
+++ b/app/controllers/api/v1/rest_controller.rb
@@ -3,6 +3,8 @@
 module Api
   module V1
     class RestController < ActionController::API
+      include WithAuditing
+
       before_action :authenticate_request!
 
       rescue_from StandardError do |exception|
@@ -16,6 +18,10 @@ module Api
           render json: { message: "We're sorry, but something went wrong", errors: [exception.class.to_s, exception] },
                  status: :internal_server_error
         end
+      end
+
+      def current_user
+        api_token.application
       end
 
       private

--- a/app/controllers/concerns/with_auditing.rb
+++ b/app/controllers/concerns/with_auditing.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# @abstract Adds support for auditing controller actions with PaperTrail.
+
+module WithAuditing
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_paper_trail_whodunnit
+  end
+
+  # @note Overrides PaperTrail::Rails::Controller to return a global id because our current users are either a User or
+  # an ExternalApp.
+  def user_for_paper_trail
+    return unless defined?(current_user)
+
+    current_user.to_gid
+  end
+end

--- a/app/controllers/dashboard/base_controller.rb
+++ b/app/controllers/dashboard/base_controller.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class Dashboard::BaseController < ApplicationController
+  include WithAuditing
+
   before_action :authenticate_user!
-  before_action :set_paper_trail_whodunnit
 
   private
 

--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -1,32 +1,12 @@
 # frozen_string_literal: true
 
 class ApiToken < ApplicationRecord
+  belongs_to :application,
+             class_name: 'ExternalApp',
+             foreign_key: 'application_id',
+             inverse_of: 'api_tokens'
+
   before_create :set_token
-
-  validates :app_name,
-            :admin_email,
-            presence: true
-
-  class << self
-    # @note Database cleaner and transactional fixtures are causing caching problems so we re-find/create each time but
-    # only in test.
-    def metadata_listener
-      if Rails.env.test?
-        find_or_create_metadata_listener
-      else
-        @metadata_listener ||= find_or_create_metadata_listener
-      end
-    end
-
-    private
-
-      def find_or_create_metadata_listener
-        find_or_create_by(
-          app_name: 'Metadata Listener',
-          admin_email: 'no-reply@scholarsphere.psu.edu'
-        )
-      end
-  end
 
   def record_usage
     update_column(:last_used_at, Time.zone.now)

--- a/app/models/external_app.rb
+++ b/app/models/external_app.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class ExternalApp < ApplicationRecord
+  has_many :api_tokens,
+           dependent: :destroy,
+           foreign_key: 'application_id',
+           inverse_of: 'application'
+
+  validates :name,
+            presence: true,
+            uniqueness: true
+
+  validates :contact_email,
+            presence: true
+
+  class MetadataListener
+    NAME = 'Metadata Listener'
+
+    def self.build
+      ExternalApp.find_or_create_by(name: NAME) do |app|
+        app.api_tokens.build
+        app.contact_email = Rails.configuration.no_reply_email
+      end
+    end
+  end
+
+  def self.metadata_listener
+    MetadataListener.build
+  end
+
+  def token
+    api_tokens.first.token
+  end
+end

--- a/app/models/external_app.rb
+++ b/app/models/external_app.rb
@@ -31,4 +31,10 @@ class ExternalApp < ApplicationRecord
   def token
     api_tokens.first.token
   end
+
+  # @note This is used in work histories, which (typically) display the names of users who have made changes to a work.
+  # If this pattern goes beyond here, it would be a good idea to refactor it into a decorator.
+  def access_id
+    name
+  end
 end

--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -34,7 +34,7 @@ class FileUploader < Shrine
     MetadataListener::Job.perform_later(
       path: [file_data['storage'], file_data['id']].join('/'),
       endpoint: FileUploader.api_endpoint(record),
-      api_token: ApiToken.metadata_listener.token
+      api_token: ExternalApp.metadata_listener.token
     )
   end
 

--- a/db/migrate/20201009164619_create_external_apps.rb
+++ b/db/migrate/20201009164619_create_external_apps.rb
@@ -1,0 +1,12 @@
+class CreateExternalApps < ActiveRecord::Migration[6.0]
+  def change
+    create_table :external_apps do |t|
+      t.string :name
+      t.string :contact_email
+
+      t.timestamps
+    end
+
+    add_index :external_apps, :name, unique: true
+  end
+end

--- a/db/migrate/20201009170334_add_external_apps_to_api_tokens.rb
+++ b/db/migrate/20201009170334_add_external_apps_to_api_tokens.rb
@@ -1,0 +1,7 @@
+class AddExternalAppsToApiTokens < ActiveRecord::Migration[6.0]
+  def change
+    add_column :api_tokens, :application_id, :integer
+    add_index :api_tokens, :application_id
+    add_foreign_key :api_tokens, :external_apps, column: :application_id
+  end
+end

--- a/db/migrate/20201009190932_remove_app_name_and_email_from_api_tokens.rb
+++ b/db/migrate/20201009190932_remove_app_name_and_email_from_api_tokens.rb
@@ -1,0 +1,6 @@
+class RemoveAppNameAndEmailFromApiTokens < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :api_tokens, :app_name
+    remove_column :api_tokens, :admin_email
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_05_132540) do
+ActiveRecord::Schema.define(version: 2020_10_09_190932) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,11 +44,11 @@ ActiveRecord::Schema.define(version: 2020_10_05_132540) do
 
   create_table "api_tokens", force: :cascade do |t|
     t.string "token"
-    t.string "app_name"
-    t.string "admin_email"
     t.datetime "last_used_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "application_id"
+    t.index ["application_id"], name: "index_api_tokens_on_application_id"
     t.index ["token"], name: "index_api_tokens_on_token", unique: true
   end
 
@@ -93,6 +93,14 @@ ActiveRecord::Schema.define(version: 2020_10_05_132540) do
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "deposited_at"
     t.index ["depositor_id"], name: "index_collections_on_depositor_id"
+  end
+
+  create_table "external_apps", force: :cascade do |t|
+    t.string "name"
+    t.string "contact_email"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_external_apps_on_name", unique: true
   end
 
   create_table "featured_resources", force: :cascade do |t|
@@ -237,6 +245,7 @@ ActiveRecord::Schema.define(version: 2020_10_05_132540) do
     t.index ["proxy_id"], name: "index_works_on_proxy_id"
   end
 
+  add_foreign_key "api_tokens", "external_apps", column: "application_id"
   add_foreign_key "collection_creations", "actors"
   add_foreign_key "collection_creations", "collections"
   add_foreign_key "collection_work_memberships", "collections"

--- a/db/seeds/development/api_tokens.seeds.rb
+++ b/db/seeds/development/api_tokens.seeds.rb
@@ -1,5 +1,4 @@
-ApiToken.find_or_create_by(
-  token: 'db9c21583ea98d16e42a73d9f78897c1ffc1dffcae781eb17f841cf421bd22b7a1a1228226437c5fdf6b6c9a8f537b17',
-  app_name: 'Client Testing',
-  admin_email: 'testing@psu.edu'
-)
+ExternalApp.find_or_create_by(name: 'Client Testing') do |app|
+  app.api_tokens.build(token: 'db9c21583ea98d16e42a73d9f78897c1ffc1dffcae781eb17f841cf421bd22b7a1a1228226437c5fdf6b6c9a8f537b17')
+  app.contact_email = 'testing@psu.edu'
+end

--- a/spec/controllers/api/v1/files_controller_spec.rb
+++ b/spec/controllers/api/v1/files_controller_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe Api::V1::FilesController, type: :controller do
       before do
         patch :update, params: {
           id: file.id,
-          metadata: { virus: { status: false, scanned_at: scan_time } },
-          key: ApiToken.metadata_listener
+          metadata: { virus: { status: false, scanned_at: scan_time } }
         }
       end
 
@@ -35,8 +34,7 @@ RSpec.describe Api::V1::FilesController, type: :controller do
         allow(file).to receive(:save).and_return(false)
         patch :update, params: {
           id: file.id,
-          metadata: { virus: { status: false, scanned_at: scan_time } },
-          key: ApiToken.metadata_listener
+          metadata: { virus: { status: false, scanned_at: scan_time } }
         }
       end
 

--- a/spec/controllers/api/v1/rest_controller_spec.rb
+++ b/spec/controllers/api/v1/rest_controller_spec.rb
@@ -85,4 +85,22 @@ RSpec.describe Api::V1::RestController, type: :controller do
       )
     end
   end
+
+  describe '#current_user' do
+    subject { controller.current_user }
+
+    let(:api_key) { create :api_token }
+
+    before { request.headers[:'X-API-Key'] = api_key.token }
+
+    it { is_expected.to be_an(ExternalApp) }
+  end
+
+  describe '#user_for_paper_trail' do
+    let(:api_key) { create :api_token }
+
+    before { request.headers[:'X-API-Key'] = api_key.token }
+
+    its(:user_for_paper_trail) { is_expected.to eq(api_key.application.to_gid) }
+  end
 end

--- a/spec/controllers/dashboard/base_controller_spec.rb
+++ b/spec/controllers/dashboard/base_controller_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Dashboard::BaseController, type: :controller do
+  describe '#user_for_paper_trail' do
+    let(:user) { create(:user) }
+
+    before { log_in user }
+
+    its(:user_for_paper_trail) { is_expected.to eq(user.to_gid) }
+  end
+end

--- a/spec/factories/api_tokens.rb
+++ b/spec/factories/api_tokens.rb
@@ -2,8 +2,7 @@
 
 FactoryBot.define do
   factory :api_token do
+    association :application
     token { nil } # Typically generated in an after_initialize
-    app_name { 'My Client Application' }
-    admin_email { 'admin@client.app' }
   end
 end

--- a/spec/factories/external_apps.rb
+++ b/spec/factories/external_apps.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :external_app, aliases: [:application] do
+    name { Faker::App.name }
+    contact_email { Faker::Internet.email }
+  end
+end

--- a/spec/features/dashboard/work_history_spec.rb
+++ b/spec/features/dashboard/work_history_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Dashboard Work History', with_user: :user, versioning: true do
   before do
     # This is usually done in the controller, but we need to do it here to get
     # our user on the changes both made in the factory and below
-    PaperTrail.request.whodunnit = user.id
+    PaperTrail.request.whodunnit = user.to_gid
 
     # Create a new draft version
     draft_version = BuildNewWorkVersion.call(work.latest_published_version)

--- a/spec/models/api_token_spec.rb
+++ b/spec/models/api_token_spec.rb
@@ -5,22 +5,21 @@ require 'rails_helper'
 RSpec.describe ApiToken, type: :model do
   describe 'table' do
     it { is_expected.to have_db_column(:token).of_type(:string) }
-    it { is_expected.to have_db_column(:app_name).of_type(:string) }
-    it { is_expected.to have_db_column(:admin_email).of_type(:string) }
     it { is_expected.to have_db_column(:last_used_at).of_type(:datetime) }
     it { is_expected.to have_db_column(:created_at).of_type(:datetime) }
     it { is_expected.to have_db_column(:updated_at).of_type(:datetime) }
+    it { is_expected.to have_db_column(:application_id).of_type(:integer) }
 
     it { is_expected.to have_db_index(:token).unique(true) }
+    it { is_expected.to have_db_index(:application_id) }
   end
 
   describe 'factory' do
     it { is_expected.to have_valid_factory(:api_token) }
   end
 
-  describe 'validations' do
-    it { is_expected.to validate_presence_of(:app_name) }
-    it { is_expected.to validate_presence_of(:admin_email) }
+  describe 'associations' do
+    it { is_expected.to belong_to(:application).class_name('ExternalApp').with_foreign_key(:application_id) }
   end
 
   describe 'creating a new token' do

--- a/spec/models/external_app_spec.rb
+++ b/spec/models/external_app_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ExternalApp, type: :model do
+  describe 'table' do
+    it { is_expected.to have_db_column(:name).of_type(:string) }
+    it { is_expected.to have_db_column(:contact_email).of_type(:string) }
+
+    it { is_expected.to have_db_index(:name) }
+  end
+
+  describe 'factories' do
+    it { is_expected.to have_valid_factory(:external_app) }
+  end
+
+  describe 'associations' do
+    it { is_expected.to have_many(:api_tokens) }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_uniqueness_of(:name) }
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:contact_email) }
+  end
+
+  describe '::metadata_listener' do
+    subject(:app) { described_class.metadata_listener }
+
+    it { is_expected.to be_a(described_class) }
+    its(:token) { is_expected.to eq(app.api_tokens.first.token) }
+    its(:contact_email) { is_expected.to eq(Rails.configuration.no_reply_email) }
+  end
+end

--- a/spec/models/file_resource_spec.rb
+++ b/spec/models/file_resource_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe FileResource, type: :model do
       expect(MetadataListener::Job).to have_received(:perform_later).with(
         path: "#{file_data['storage']}/#{file_data['id']}",
         endpoint: "http://#{Rails.application.routes.default_url_options[:host]}/api/v1/files/#{file_resource.id}",
-        api_token: ApiToken.metadata_listener.token
+        api_token: ExternalApp.metadata_listener.token
       )
     end
   end


### PR DESCRIPTION
This creates an ExternalApp class that can be used to name applications or other processes that make changes to a work. Now, when a work is migrated or updated via the API, the name of the application that made the changes will be reflected in the work history.

Fixes #500 

![Screen Shot 2020-10-12 at 4 48 58 PM](https://user-images.githubusercontent.com/312085/95789272-3a2e8400-0cab-11eb-82c1-526e79fda536.png)
