### PR TITLE
Add license options to work form

### DIFF
--- a/app/services/publish_new_work.rb
+++ b/app/services/publish_new_work.rb
@@ -19,6 +19,7 @@ class PublishNewWork
   def self.call(metadata:, depositor:, content:, permissions: {})
     noid = metadata.delete(:noid)
     deposited_at = metadata.delete(:deposited_at)
+    metadata[:rights] ||= WorkVersion::Licenses::DEFAULT
 
     # @todo start a transaction here in case we need to rollback and remove any Actors we've created
 

--- a/app/views/dashboard/work_form/publish/_fields.html.erb
+++ b/app/views/dashboard/work_form/publish/_fields.html.erb
@@ -1,3 +1,11 @@
+<div class="form-wrapper">
+  <%= render 'form_fields/select',
+             form: form,
+             attribute: :rights,
+             options_for_select: WorkVersion::Licenses.options_for_select_box,
+             include_blank: true %>
+</div>
+
 <%= form.fields_for :work do |work_form| %>
   <div class="form-wrapper">
 

--- a/app/views/form_fields/_select.html.erb
+++ b/app/views/form_fields/_select.html.erb
@@ -6,7 +6,7 @@
 <div class="form-group has-float-label mb-3">
   <%= form.select attribute,
                   options_for_select,
-                  { include_blank: false },
+                  { include_blank: local_assigns.fetch(:include_blank, false) },
                   {
                     class: 'form-control custom-select',
                     required: local_assigns[:required].presence,

--- a/config/authorities/licenses.yml
+++ b/config/authorities/licenses.yml
@@ -1,0 +1,58 @@
+terms:
+  - id: http://creativecommons.org/licenses/by/3.0/us/
+    term: Attribution 3.0 United States
+    active: false
+  - id: http://creativecommons.org/licenses/by-sa/3.0/us/
+    term: Attribution-ShareAlike 3.0 United States
+    active: false
+  - id: http://creativecommons.org/licenses/by-nc/3.0/us/
+    term: Attribution-NonCommercial 3.0 United States
+    active: false
+  - id: http://creativecommons.org/licenses/by-nd/3.0/us/
+    term: Attribution-NoDerivs 3.0 United States
+    active: false
+  - id: http://creativecommons.org/licenses/by-nc-nd/3.0/us/
+    term: Attribution-NonCommercial-NoDerivs 3.0 United States
+    active: false
+  - id: http://creativecommons.org/licenses/by-nc-sa/3.0/us/
+    term: Attribution-NonCommercial-ShareAlike 3.0 United States
+    active: false
+  - id: https://creativecommons.org/licenses/by/4.0/
+    term: Attribution 4.0 International
+    active: true
+  - id: https://creativecommons.org/licenses/by-sa/4.0/
+    term: Attribution-ShareAlike 4.0 International
+    active: true
+  - id: https://creativecommons.org/licenses/by-nc/4.0/
+    term: Attribution-NonCommercial 4.0 International
+    active: true
+  - id: https://creativecommons.org/licenses/by-nd/4.0/
+    term: Attribution-NoDerivatives 4.0 International
+    active: true
+  - id: https://creativecommons.org/licenses/by-nc-nd/4.0/
+    term: Attribution-NonCommercial-NoDerivatives 4.0 International
+    active: true
+  - id: https://creativecommons.org/licenses/by-nc-sa/4.0/
+    term: Attribution-NonCommercial-ShareAlike 4.0 International
+    active: true
+  - id: http://creativecommons.org/publicdomain/mark/1.0/
+    term: Public Domain Mark 1.0
+    active: true
+  - id: http://creativecommons.org/publicdomain/zero/1.0/
+    term: CC0 1.0 Universal
+    active: true
+  - id: http://www.europeana.eu/portal/rights/rr-r.html
+    term: All rights reserved
+    active: true
+  - id: http://www.apache.org/licenses/LICENSE-2.0
+    term: Apache 2.0
+    active: true
+  - id: https://www.gnu.org/licenses/gpl.html
+    term: GNU General Public License
+    active: true
+  - id: https://opensource.org/licenses/MIT
+    term: MIT License
+    active: true
+  - id: https://opensource.org/licenses/BSD-3-Clause
+    term: BSD License
+    active: true

--- a/spec/factories/work_versions.rb
+++ b/spec/factories/work_versions.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     aasm_state { WorkVersion::STATE_DRAFT }
     title { generate(:work_title) }
     sequence(:version_number) { |n| work.present? ? work.versions.length + 1 : n }
+    rights { WorkVersion::Licenses.active.sample[:id] }
 
     # Postgres does this for us, but for testing, we can do it here to save having to call create/reload.
     uuid { SecureRandom.uuid }
@@ -63,7 +64,6 @@ FactoryBot.define do
       title { generate(:work_title) }
       subtitle { FactoryBotHelpers.work_title }
       keyword { Faker::Science.element }
-      rights { Faker::Lorem.sentence }
       description { Faker::Lorem.paragraph }
       resource_type { Faker::House.furniture }
       contributor { Faker::Artist.name }

--- a/spec/features/publish_new_work_spec.rb
+++ b/spec/features/publish_new_work_spec.rb
@@ -432,6 +432,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
       expect(version.subject).to eq [different_metadata[:subject]]
       expect(version.language).to eq [different_metadata[:language]]
       expect(version.related_url).to eq [different_metadata[:related_url]]
+      expect(version.rights).to eq metadata[:rights]
 
       expect(version.creator_aliases.length).to eq 1
       expect(version.creator_aliases.first.alias).to eq user.actor.default_alias

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -371,4 +371,70 @@ RSpec.describe WorkVersion, type: :model do
       expect(work.deposit_agreed_at).to be_within(1.minute).of(Time.zone.now)
     end
   end
+
+  describe WorkVersion::Licenses do
+    let(:active_license) do
+      {
+        id: 'https://creativecommons.org/licenses/by/4.0/',
+        label: 'Attribution 4.0 International',
+        active: true
+      }
+    end
+
+    let(:inactive_license) do
+      {
+        id: 'http://creativecommons.org/licenses/by/3.0/us/',
+        label: 'Attribution 3.0 United States',
+        active: false
+      }
+    end
+
+    describe '::DEFAULT' do
+      subject { described_class::DEFAULT }
+
+      it { is_expected.to eq('http://www.europeana.eu/portal/rights/rr-r.html') }
+    end
+
+    describe '::all' do
+      subject { described_class.all }
+
+      it { is_expected.to include(inactive_license) }
+      it { is_expected.to include(active_license) }
+    end
+
+    describe '::active' do
+      subject { described_class.active }
+
+      it { is_expected.not_to include(inactive_license) }
+      it { is_expected.to include(active_license) }
+    end
+
+    describe '::options_for_select_box' do
+      subject(:options) { described_class.options_for_select_box }
+
+      specify do
+        expect(options).to contain_exactly(
+          ['Attribution 4.0 International', 'https://creativecommons.org/licenses/by/4.0/'],
+          ['Attribution-ShareAlike 4.0 International', 'https://creativecommons.org/licenses/by-sa/4.0/'],
+          ['Attribution-NonCommercial 4.0 International', 'https://creativecommons.org/licenses/by-nc/4.0/'],
+          ['Attribution-NoDerivatives 4.0 International', 'https://creativecommons.org/licenses/by-nd/4.0/'],
+          [
+            'Attribution-NonCommercial-NoDerivatives 4.0 International',
+            'https://creativecommons.org/licenses/by-nc-nd/4.0/'
+          ],
+          [
+            'Attribution-NonCommercial-ShareAlike 4.0 International',
+            'https://creativecommons.org/licenses/by-nc-sa/4.0/'
+          ],
+          ['Public Domain Mark 1.0', 'http://creativecommons.org/publicdomain/mark/1.0/'],
+          ['CC0 1.0 Universal', 'http://creativecommons.org/publicdomain/zero/1.0/'],
+          ['All rights reserved', 'http://www.europeana.eu/portal/rights/rr-r.html'],
+          ['Apache 2.0', 'http://www.apache.org/licenses/LICENSE-2.0'],
+          ['GNU General Public License', 'https://www.gnu.org/licenses/gpl.html'],
+          ['MIT License', 'https://opensource.org/licenses/MIT'],
+          ['BSD License', 'https://opensource.org/licenses/BSD-3-Clause']
+        )
+      end
+    end
+  end
 end

--- a/spec/presenters/diff_presenter_spec.rb
+++ b/spec/presenters/diff_presenter_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe DiffPresenter do
   let(:second) { build(:work_version) }
 
   describe '#terms' do
-    its(:terms) { is_expected.to contain_exactly('title') }
+    its(:terms) { is_expected.to include('title') }
   end
 
   describe '#hash' do

--- a/spec/services/metadata_diff_spec.rb
+++ b/spec/services/metadata_diff_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe MetadataDiff do
   it { is_expected.to be_a(HashWithIndifferentAccess) }
 
   context 'when the titles are different' do
-    its(:keys) { is_expected.to contain_exactly('title') }
+    its(:keys) { is_expected.to include('title') }
 
     it 'returns a diff of the titles' do
       expect(diff[:title]).to eq([first.title, second.title])
@@ -22,7 +22,7 @@ RSpec.describe MetadataDiff do
     let(:first) { build(:work_version, title: 'The Same Title', keyword: ['foo', 'bar']) }
     let(:second) { build(:work_version, title: 'The Same Title', keyword: ['foo', 'baz']) }
 
-    its(:keys) { is_expected.to contain_exactly('keyword') }
+    its(:keys) { is_expected.to include('keyword') }
 
     it 'returns only the terms that are different' do
       expect(diff[:title]).to be_nil
@@ -34,7 +34,7 @@ RSpec.describe MetadataDiff do
     let(:first) { build(:work_version, title: 'The Same Title', keyword: ['foo', 'bar']) }
     let(:second) { build(:work_version, title: 'The Same Title', keyword: ['baz']) }
 
-    its(:keys) { is_expected.to contain_exactly('keyword') }
+    its(:keys) { is_expected.to include('keyword') }
 
     it 'returns diffs that include the deleted term' do
       expect(diff[:title]).to be_nil

--- a/spec/support/feature_helpers/work_form.rb
+++ b/spec/support/feature_helpers/work_form.rb
@@ -51,9 +51,10 @@ module FeatureHelpers
       end
     end
 
-    def self.fill_in_publishing_details(_metadata)
+    def self.fill_in_publishing_details(metadata)
       choose "work_version_work_attributes_visibility_#{Permissions::Visibility::OPEN}"
       check 'work_version_depositor_agreement'
+      select WorkVersion::Licenses.label(metadata[:rights]), from: 'work_version_rights'
     end
 
     def self.save_as_draft_and_exit


### PR DESCRIPTION
Using our existing Questioning Authority framework, we can build license options from a yaml file.

Fixes #514 