### PR TITLE
Subclass WorkVersion to index immidately in the dashboard

### DIFF
--- a/app/models/dashboard/work_version.rb
+++ b/app/models/dashboard/work_version.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# @abstract Subclasses WorkVersion to allow for synchronus indexing. A Dashboard::WorkVersion is identical to a
+# WorkVersion in every way, _except_ with respect to indexing. A WorkVersion is indexed async via ActiveJob, whereas
+# the Dashboard::WorkVersion will update its index immediately. This is so any changes made by the user will appear in
+# the dashboard as soon as a resource is created or update.
+module Dashboard
+  class WorkVersion < ::WorkVersion
+    self.table_name = ::WorkVersion.table_name
+
+    def self.model_name
+      ::WorkVersion.model_name
+    end
+
+    private
+
+      def update_index_with_callback
+        update_index
+      end
+  end
+end

--- a/app/schemas/work_version_schema.rb
+++ b/app/schemas/work_version_schema.rb
@@ -9,7 +9,8 @@ class WorkVersionSchema < BaseSchema
         latest_version_bsi: resource.latest_version?,
         embargoed_until_dtsi: work.embargoed_until,
         depositor_id_isi: work.depositor.id,
-        proxy_id_isi: work.proxy_id
+        proxy_id_isi: work.proxy_id,
+        model_ssi: 'WorkVersion'
       )
   end
 

--- a/spec/controllers/dashboard/work_versions_controller_spec.rb
+++ b/spec/controllers/dashboard/work_versions_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Dashboard::WorkVersionsController, type: :controller do
   let(:user) { work_version.depositor.user }
-  let(:work_version) { create :work_version, :draft }
+  let(:work_version) { create :dashboard_work_version, :draft }
 
   describe 'POST #create' do
     let(:user) { work.depositor.user }

--- a/spec/factories/work_versions.rb
+++ b/spec/factories/work_versions.rb
@@ -29,6 +29,9 @@ FactoryBot.define do
       end
     end
 
+    # @note A Dashboard::WorkVersion is the same as a WorkVersion so there are no changes to attributes at this time.
+    factory :dashboard_work_version, class: 'Dashboard::WorkVersion' do; end
+
     trait :with_files do
       transient do
         file_count { 1 }

--- a/spec/features/publish_new_work_spec.rb
+++ b/spec/features/publish_new_work_spec.rb
@@ -421,6 +421,10 @@ RSpec.describe 'Publishing a work', with_user: :user do
       work = Work.last
       version = work.versions.first
 
+      within('.work-list__work') do
+        expect(page).to have_content(version.title)
+      end
+
       expect(version).to be_published
 
       expect(version.version_number).to eq 1

--- a/spec/models/dashboard/work_version_spec.rb
+++ b/spec/models/dashboard/work_version_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Dashboard::WorkVersion, type: :model do
+  describe '::table_name' do
+    subject { described_class.table_name }
+
+    it { is_expected.to eq(::WorkVersion.table_name) }
+  end
+
+  describe '::model_name' do
+    subject { described_class.model_name }
+
+    it { is_expected.to eq(::WorkVersion.model_name) }
+  end
+
+  describe '.to_solr' do
+    subject { dashboard_work_version.to_solr }
+
+    let(:dashboard_work_version) { create(:dashboard_work_version, :published, :with_complete_metadata) }
+
+    it { is_expected.to include('model_ssi' => 'WorkVersion') }
+  end
+end

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -3,8 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe WorkVersion, type: :model do
-  it_behaves_like 'an indexable resource'
-
   it_behaves_like 'a resource with view statistics' do
     let(:resource) { create(:work_version) }
   end
@@ -167,10 +165,10 @@ RSpec.describe WorkVersion, type: :model do
     # think of a better way to do this without testing the contents of
     # update_index_async twice.
 
-    it 'calls #update_index_async' do
-      allow(work_version).to receive(:update_index_async)
+    it 'calls #update_index_with_callback' do
+      allow(work_version).to receive(:update_index_with_callback)
       work_version.save!
-      expect(work_version).to have_received(:update_index_async)
+      expect(work_version).to have_received(:update_index_with_callback)
     end
   end
 
@@ -318,13 +316,13 @@ RSpec.describe WorkVersion, type: :model do
     end
   end
 
-  describe '#update_index_async' do
+  describe '#update_index_with_callback' do
     let(:work_version) { described_class.new }
 
     before { allow(SolrIndexingJob).to receive(:perform_later) }
 
     it 'provides itself to SolrIndexingJob.perform_later' do
-      work_version.update_index_async
+      work_version.send(:update_index_with_callback)
       expect(SolrIndexingJob).to have_received(:perform_later).with(work_version)
     end
   end


### PR DESCRIPTION
Dashboard::WorkVersion serves as an identical stand-in to WorkVersion within the user's dashboard. This allows for synchronus updating of the work version in Solr, so any changes will appear immediately to the user. Outside of the dashboard, such as API calls, in the console, or elsewhere, the updates are performed async via ActiveJob.

Fixes #501 