### PR TITLE
Sorting order

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -195,10 +195,8 @@ class CatalogController < ApplicationController
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
-    config.add_sort_field 'score desc, pub_date_si desc, title_si asc', label: 'relevance'
-    config.add_sort_field 'pub_date_si desc, title_si asc', label: 'year'
-    config.add_sort_field 'author_si asc, title_si asc', label: 'author'
-    config.add_sort_field 'title_si asc, pub_date_si desc', label: 'title'
+    config.add_sort_field 'score desc, deposited_at_dtsi desc', label: 'relevance'
+    config.add_sort_field 'title_tesim asc', label: 'title'
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/app/models/dashboard/postgres_response.rb
+++ b/app/models/dashboard/postgres_response.rb
@@ -13,6 +13,7 @@ module Dashboard
 
       def work_versions
         WorkVersion.where(uuid: work_version_uuids)
+          .order(updated_at: :desc)
           .compact
           .map { |work_version| WorkVersionDecorator.new(work_version) }
       end


### PR DESCRIPTION
Sorts public searches according to date deposited and user dashboard searches according to date updated.

Fixes #555 
Fixes #556 