### PR TITLE
Index work versions synchronously in the dashboard

### DIFF
--- a/app/controllers/dashboard/work_form/base_controller.rb
+++ b/app/controllers/dashboard/work_form/base_controller.rb
@@ -29,6 +29,16 @@ module Dashboard
         def next_page_path
           raise NotImplementedError, 'You must implement this method in your controller subclass'
         end
+
+        def update_or_save_work_version(attributes: nil)
+          @work_version.indexing_source = SolrIndexingJob.public_method(:perform_now)
+
+          if attributes
+            @work_version.update(attributes)
+          else
+            @work_version.save
+          end
+        end
     end
   end
 end

--- a/app/controllers/dashboard/work_form/contributors_controller.rb
+++ b/app/controllers/dashboard/work_form/contributors_controller.rb
@@ -17,7 +17,7 @@ module Dashboard
         @work_version.attributes = work_version_params
 
         respond_to do |format|
-          if @work_version.save
+          if update_or_save_work_version
             format.html do
               redirect_upon_success
             end

--- a/app/controllers/dashboard/work_form/details_controller.rb
+++ b/app/controllers/dashboard/work_form/details_controller.rb
@@ -11,7 +11,7 @@ module Dashboard
         @work_version = WorkVersion.build_with_empty_work(work_version_params, depositor: current_user.actor)
 
         respond_to do |format|
-          if @work_version.save
+          if update_or_save_work_version
             format.html do
               redirect_upon_success
             end
@@ -35,7 +35,7 @@ module Dashboard
         @work_version.attributes = work_version_params
 
         respond_to do |format|
-          if @work_version.save
+          if update_or_save_work_version
             format.html do
               redirect_upon_success
             end

--- a/app/controllers/dashboard/work_form/files_controller.rb
+++ b/app/controllers/dashboard/work_form/files_controller.rb
@@ -13,7 +13,7 @@ module Dashboard
       def update
         @work_version = policy_scope(WorkVersion).find(params[:work_version_id])
         authorize(@work_version)
-        if @work_version.update(work_version_params)
+        if update_or_save_work_version(attributes: work_version_params)
           redirect_upon_success
         else
           render :edit

--- a/app/controllers/dashboard/work_form/publish_controller.rb
+++ b/app/controllers/dashboard/work_form/publish_controller.rb
@@ -22,7 +22,7 @@ module Dashboard
         @work_version.publish if publish_work?
 
         respond_to do |format|
-          if @work_version.save
+          if update_or_save_work_version
             format.html do
               notice = if publish_work?
                          'Successfully published work!'

--- a/spec/features/publish_new_work_spec.rb
+++ b/spec/features/publish_new_work_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
         expect(new_work.versions.length).to eq 1
 
         new_work_version = new_work.versions.last
+        expect(page).to have_content(metadata[:title])
         expect(new_work_version.title).to eq metadata[:title]
         expect(new_work_version.version_number).to eq 1
       end
@@ -420,6 +421,10 @@ RSpec.describe 'Publishing a work', with_user: :user do
       #
       work = Work.last
       version = work.versions.first
+
+      within('.work-list__work') do
+        expect(page).to have_content(version.title)
+      end
 
       expect(version).to be_published
 

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -3,8 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe WorkVersion, type: :model do
-  it_behaves_like 'an indexable resource'
-
   it_behaves_like 'a resource with view statistics' do
     let(:resource) { create(:work_version) }
   end
@@ -165,12 +163,12 @@ RSpec.describe WorkVersion, type: :model do
 
     # I've heard it's bad practice to mock the object under test, but I can't
     # think of a better way to do this without testing the contents of
-    # update_index_async twice.
+    # perform_update_index twice.
 
-    it 'calls #update_index_async' do
-      allow(work_version).to receive(:update_index_async)
+    it 'calls #perform_update_index' do
+      allow(work_version).to receive(:perform_update_index)
       work_version.save!
-      expect(work_version).to have_received(:update_index_async)
+      expect(work_version).to have_received(:perform_update_index)
     end
   end
 
@@ -318,13 +316,13 @@ RSpec.describe WorkVersion, type: :model do
     end
   end
 
-  describe '#update_index_async' do
+  describe '#perform_update_index' do
     let(:work_version) { described_class.new }
 
     before { allow(SolrIndexingJob).to receive(:perform_later) }
 
     it 'provides itself to SolrIndexingJob.perform_later' do
-      work_version.update_index_async
+      work_version.send(:perform_update_index)
       expect(SolrIndexingJob).to have_received(:perform_later).with(work_version)
     end
   end


### PR DESCRIPTION
When updating or creating work versions via the user's dashboard, changes should be made to Solr immediately to avoid any lags in displaying search results. This way, when a user creates or updates a work version and then navigates back to the dashboard search page, they'll see the changes instead of having to wait for the indexing job to finish.

Fixes #501 