### PR TITLE
Render zero results page in the dashboard

### DIFF
--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -1,0 +1,25 @@
+<h2 class="sr-only"><%= t('blacklight.search.search_results') %></h2>
+
+<div class="action-bar mb-3">
+  <%= render_search_bar %>
+</div>
+
+<div class="action-bar mb-3">
+  <%= render 'constraints' %>
+</div>
+
+<div class="action-bar mb-3">
+  <%= render 'did_you_mean' %>
+  <%= render partial: 'paginate_compact', object: @response if show_pagination? %>
+  <%= render_results_collection_tools wrapping_class: 'search-widgets' %>
+</div>
+
+<%- if @response.empty? %>
+  <%= render 'zero_results' %>
+<%- else %>
+  <%= render_document_index %>
+<%- end %>
+
+<div class="action-bar mb-3">
+  <%= render 'results_pagination' %>
+</div>

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -22,34 +22,5 @@
 <div class="container-fluid">
   <h1 class="sr-only top-content-title"><%= t('blacklight.search.header') %></h1>
 
-  <div class="action-bar mb-3">
-    <%= render_search_bar %>
-  </div>
-
-  <div class="action-bar mb-3">
-    <%= render 'constraints' %>
-  </div>
-
-  <div class="action-bar mb-3">
-    <%= render 'did_you_mean' %>
-    <% if show_pagination? and @response.present? %>
-      <%= render partial: 'paginate_compact', object: @response %>
-    <% end %>
-    <%= render_results_collection_tools wrapping_class: 'search-widgets' %>
-  </div>
-
-  <h2 class="sr-only"><%= t('blacklight.search.search_results') %></h2>
-
-  <%- if @response.empty? %>
-    <%= render 'zero_results' %>
-  <%- elsif render_grouped_response? %>
-    <%= render_grouped_document_index %>
-  <%- else %>
-    <%= render_document_index %>
-  <%- end %>
-
-  <div class="action-bar mb-3">
-    <%= render 'results_pagination' %>
-  </div>
-
+  <%= render 'search_results' %>
 </div>

--- a/app/views/dashboard/catalog/_zero_results.html.erb
+++ b/app/views/dashboard/catalog/_zero_results.html.erb
@@ -1,0 +1,17 @@
+<div class="row row--md-mb-3">
+  <div class="col-md">
+    <h4 class="mb-2"><%= t('dashboard.catalog.zero_results.info.heading') %></h4>
+    <div class="surface"><%= t('dashboard.catalog.zero_results.info.content') %></div>
+  </div>
+
+  <div class="col-md">
+    <h4 class="mb-2"><%= t('dashboard.catalog.zero_results.options.heading') %></h4>
+    <div class="surface search">
+        <div class="mt-2 text-center">
+          <%= link_to t('dashboard.catalog.zero_results.options.browse'),
+                      dashboard_root_path,
+                      class: 'btn btn-primary' %>
+        </div>
+    </div>
+  </div>
+</div>

--- a/app/views/dashboard/catalog/index.html.erb
+++ b/app/views/dashboard/catalog/index.html.erb
@@ -14,33 +14,11 @@
 <% end %>
 
 <div class="container-fluid">
-
   <h1 class="sr-only"><%= t('blacklight.search.header') %></h1>
 
-  <h2 class="sr-only"><%= t('blacklight.search.search_results') %></h2>
-
-  <%- if @response.empty? %>
-
+  <%- if current_user.works.empty? %>
     <%= render 'home' %>
-
   <%- else %>
-
-    <div class="action-bar mb-3">
-      <%= render_search_bar %>
-    </div>
-    <div class="action-bar mb-3">
-      <%= render 'constraints' %>
-    </div>
-    <div class="action-bar mb-3">
-      <%= render 'did_you_mean' %>
-      <%= render partial: 'paginate_compact', object: @response if show_pagination? %>
-      <%= render_results_collection_tools wrapping_class: 'search-widgets' %>
-    </div>
-
-    <%= render_document_index %>
-
-    <div class="action-bar mb-3">
-      <%= render 'results_pagination' %>
-    </div>
+    <%= render 'search_results' %>
   <%- end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -133,7 +133,16 @@ en:
         additional_metadata: 'Additional Metadata'
         actions:
           save: 'Save'
-
+    catalog:
+      zero_results:
+        info:
+          heading: 'No Works Found'
+          content: >
+            None of your works match the search. You can change your search terms or browse all of your works using
+            facets.
+        options:
+          heading: 'Dashboard Search Alternatives'
+          browse: "Browse & Filter All Your Works"
     collections:
       index:
         heading: "Your Collections"

--- a/spec/features/catalog/catalog_spec.rb
+++ b/spec/features/catalog/catalog_spec.rb
@@ -83,6 +83,15 @@ RSpec.describe 'Blacklight catalog page', :inline_jobs do
     expect(page).to have_css('td.work-version-subtitle', text: work_version.subtitle)
   end
 
+  context 'when the search returns no results' do
+    it 'displays no search results', with_user: :user do
+      visit(search_catalog_path(q: 'asdfasdfasdfasdfasdfasdfasdf'))
+
+      expect(page).to have_selector('h4', text: I18n.t('catalog.zero_results.info.heading'))
+      expect(page).to have_content(I18n.t('catalog.zero_results.info.content'))
+    end
+  end
+
   def document_id(resource)
     if resource.is_a? WorkVersion
       "document-#{resource.work.uuid}"

--- a/spec/features/dashboard/catalog_spec.rb
+++ b/spec/features/dashboard/catalog_spec.rb
@@ -44,6 +44,17 @@ RSpec.describe 'Dashboard catalog page', :inline_jobs do
     end
   end
 
+  context "when the user's search returns no results" do
+    before { create(:work, depositor: user.actor, has_draft: true) }
+
+    it 'displays no search results', with_user: :user do
+      visit(dashboard_root_path(q: 'asdfasdfasdfasdfasdfasdfasdf'))
+
+      expect(page).to have_selector('h4', text: I18n.t('dashboard.catalog.zero_results.info.heading'))
+      expect(page).to have_content(I18n.t('dashboard.catalog.zero_results.info.content'))
+    end
+  end
+
   context 'when the user has a published work' do
     let!(:work) { create(:work, depositor: user.actor, versions_count: 3, has_draft: false) }
 


### PR DESCRIPTION
If the user has works, but their search returns no results, it should look similar to the public "no search results" page. This refactors the view code to make them identical in layout and features, except with changes in text to indicate the differences.

Fixes #545 