### PR TITLE
Make License validations more user-friendly on Work Form

### DIFF
--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -117,7 +117,10 @@ class WorkVersion < ApplicationRecord
 
   validates :rights,
             presence: true,
-            inclusion: { in: WorkVersion::Licenses.ids },
+            inclusion: {
+              in: WorkVersion::Licenses.ids,
+              allow_nil: true # Avoid duplicating the above presence validation
+            },
             if: :published?
 
   validates :published_date,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,7 +37,7 @@ en:
         version_name: Semantic Version (optional)
         subtitle: Subtitle
         keyword: Keyword
-        rights: Rights
+        rights: License
         description: Description
         creator_aliases: Creators
         resource_type: Resource Type
@@ -67,6 +67,8 @@ en:
             description:
               blank: is required to publish the work
             published_date:
+              blank: is required to publish the work
+            rights:
               blank: is required to publish the work
   api:
     errors:


### PR DESCRIPTION
Our field is called "rights" but I felt like "License" was a more self-explanatory label.

I also tweaked the inclusion validation, because if the rights field was blank, you would get two error messages, one from the presence validator telling you it couldn't be blank, and another one from the inclusion validator telling you that nil wasn't in the list. I changed it so the inclusion validation allows a nil value, thereby bypassing the inclusion validation when we know the presence validator will pick up those errors.