### PR TITLE
Configured Datacite handle should be managed

### DIFF
--- a/app/models/doi.rb
+++ b/app/models/doi.rb
@@ -13,7 +13,7 @@ class Doi
   end
 
   def managed?
-    MANAGED_PREFIXES.include?(prefix)
+    MANAGED_PREFIXES.include?(prefix) || prefix == ENV['DATACITE_PREFIX']
   end
 
   def prefix

--- a/spec/models/doi_spec.rb
+++ b/spec/models/doi_spec.rb
@@ -25,6 +25,15 @@ RSpec.describe Doi do
     it { is_expected.to be_managed }
   end
 
+  context 'with a configured prefix' do
+    let(:doi) { "doi:#{ENV['DATACITE_PREFIX']}/fvr2-yw38" }
+
+    before { ENV['DATACITE_PREFIX'] = "10.#{Faker::Number.number(digits: 5)}" }
+
+    it { is_expected.to be_valid }
+    it { is_expected.to be_managed }
+  end
+
   context 'with https://doi.org/10.1515/pol-2020-2011' do
     let(:doi) { 'https://doi.org/10.1515/pol-2020-2011' }
 


### PR DESCRIPTION
Any handle that is configured in our environment should count as a managed DOI. This is different than the hardcoded managed handles which are technically more "legacy" handles and should never be removed. The configured handle can be more flexible in nature, and vary between environments.

Fixes #593 