### PR TITLE
Fix overflowing x-axis labels in analytics chart

### DIFF
--- a/app/javascript/frontend/scripts/view_statistics_chart.js
+++ b/app/javascript/frontend/scripts/view_statistics_chart.js
@@ -22,7 +22,7 @@ function parseData (data) {
 }
 
 function drawChart (selection, data) {
-  const margin = { top: 2, right: 10, bottom: 20, left: 10 }
+  const margin = { top: 2, right: 25, bottom: 20, left: 25 }
   const width = 350
   const height = 80
 
@@ -73,6 +73,7 @@ function drawChart (selection, data) {
     .attr('class', 'axis axis--x')
     .attr('transform', `translate(0,${height - margin.bottom + 2})`)
     .call(xAxis)
+    .call(g => hideOverflowingTickLabels(svg, g.selectAll('.tick text')))
 
   const chartGroup = svg.append('g')
     .attr('class', 'chart')
@@ -131,4 +132,21 @@ function findNearestDataPoint (bisector, data, date) {
   const a = data[i - 1]
   const b = data[i]
   return date - a[0] > b[0] - date ? b : a
+}
+
+function hideOverflowingTickLabels (svg, tickTextSelection) {
+  const svgBounds = svg.node().getBoundingClientRect()
+  const svgLeft = svgBounds.x
+  const svgRight = svgBounds.x + svgBounds.width
+
+  tickTextSelection
+    .filter(function () {
+      // Note in d3, `this` is set to the element that we're filtering
+      const tickBounds = this.getBoundingClientRect()
+      const tickLeft = tickBounds.x
+      const tickRight = tickBounds.x + tickBounds.width
+
+      return (tickLeft < svgLeft || svgRight < tickRight)
+    })
+    .style('visibility', 'hidden')
 }


### PR DESCRIPTION
In #466 we saw that the x-axis labels on the view analytics chart could be clipped off in confusing ways, if they were positioned too close to the edge and overflowed beyond the parent SVG element.

I fixed this in two ways: 
- Increased the horizontal padding on the chart quite a bit, which will prevent the issue from happening the vast majority of the time.
- Added a backup function, executed after the x-axis labels are drawn, that hides any labels whose left or right edge extends beyond the bounds of the parent SVG element and thus are clipped.

Closes #466 