### PR TITLE
Allows DOIs on Collections to be migrated

### DIFF
--- a/app/components/collection_metadata_component.rb
+++ b/app/components/collection_metadata_component.rb
@@ -17,6 +17,7 @@ class CollectionMetadataComponent < ApplicationComponent
     :display_published_date,
     :subject,
     :language,
+    :display_doi,
     :identifier,
     :based_near,
     :related_url,
@@ -62,6 +63,8 @@ class CollectionMetadataComponent < ApplicationComponent
         value.to_formatted_s(:long)
       elsif value.is_a? CollectionCreation
         value.alias
+      elsif value.is_a? ApplicationComponent
+        render value
       else
         value.to_s
       end

--- a/app/controllers/api/v1/collections_controller.rb
+++ b/app/controllers/api/v1/collections_controller.rb
@@ -63,6 +63,7 @@ module Api::V1
             :published_date,
             :deposited_at,
             :description,
+            :doi,
             work_ids: [],
             keyword: [],
             contributor: [],

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -45,5 +45,9 @@ FactoryBot.define do
       related_url { [Faker::Internet.url] }
       source { [Faker::SlackEmoji.emoji] }
     end
+
+    trait :with_a_doi do
+      doi { FactoryBotHelpers.valid_doi }
+    end
   end
 end

--- a/spec/features/resources_spec.rb
+++ b/spec/features/resources_spec.rb
@@ -22,15 +22,37 @@ RSpec.describe 'Public Resources', type: :feature do
     end
   end
 
-  describe 'given a collection' do
-    let(:collection) { create :collection, works: [work] }
+  describe 'given a collection without a DOI' do
+    let(:collection) { create :collection, :with_complete_metadata, works: [work] }
     let(:work) { build :work, has_draft: false, versions_count: 1 }
 
     it 'displays the public resource page for the collection' do
       visit resource_path(collection.uuid)
 
+      expect(page).to have_selector('h1', text: collection.title)
       expect(page).to have_content collection.description
       expect(page).to have_content work.latest_published_version.title
+
+      within('.meta-table') do
+        expect(page).to have_content(collection.title)
+      end
+    end
+  end
+
+  describe 'given a collection with a DOI' do
+    let(:collection) { create :collection, :with_complete_metadata, :with_a_doi, works: [work] }
+    let(:work) { build :work, has_draft: false, versions_count: 1 }
+
+    it 'displays the public resource page for the collection' do
+      visit resource_path(collection.uuid)
+
+      expect(page).to have_selector('h1', text: collection.title)
+      expect(page).to have_content collection.description
+      expect(page).to have_content work.latest_published_version.title
+
+      within('.meta-table') do
+        expect(page).to have_content(collection.doi)
+      end
     end
   end
 end


### PR DESCRIPTION
This has the additional side-effect of enabling minting DOIs on collections that don't have them.

Related to #332 