### PR TITLE
Return nil when counting draft versions

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -138,7 +138,7 @@ class Work < ApplicationRecord
   end
 
   def count_view!
-    raise ArgumentError, 'work must have a published version' if latest_published_version.nil?
+    return if latest_published_version.nil?
 
     latest_published_version.count_view!
   end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -401,13 +401,11 @@ RSpec.describe Work, type: :model do
     end
 
     context 'when the work does NOT have a published version' do
+      subject { work.count_view! }
+
       let(:work) { build(:work) }
 
-      it 'raises an error' do
-        expect {
-          work.count_view!
-        }.to raise_error(ArgumentError, 'work must have a published version')
-      end
+      it { is_expected.to be_nil }
     end
   end
 


### PR DESCRIPTION
Don't raise an ArgumentError if the controller tries to count a draft version. There's isn't any need for an exception here, just move on...

Fixes #591 

I didn't address the redirect issue because we probably want to think about it a bit more and it might be moot after all, if we adopt a more ajax response process.