### PR TITLE
Move user menu up to the white top navbar

### DIFF
--- a/app/javascript/frontend/styles/_common.scss
+++ b/app/javascript/frontend/styles/_common.scss
@@ -329,6 +329,11 @@ h4,
       align-items: center;
     }
   }
+
+  .navbar-filler {
+    display: inline-block;
+    padding: ($spacer * 1.5) 0;
+  }
 }
 
 

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -14,36 +14,16 @@
   <div class="collapse navbar-collapse" id="navbar-toggle">
     <ul class="navbar-nav">
 
-      <%= yield :navbar_items %>
-
-      <% if current_user.guest? %>
-
-        <li class="nav-item">
-          <%= link_to t('blacklight.header_links.login'), new_user_session_path,
-                      class: 'btn btn-primary btn--collapse-normal btn--square btn--expand' %>
-        </li>
-
+      <% if content_for? :navbar_items %>
+        <%= yield :navbar_items %>
       <% else %>
 
-        <li class="nav-item dropdown dropdown--navbar-action">
-          <button class="btn btn-primary dropdown-toggle btn--square btn--expand btn--settings"
-                  type="button"
-                  id="settings"
-                  data-toggle="dropdown"
-                  aria-haspopup="true"
-                  aria-expanded="false">
-            <%= current_user.display_name %>
-          </button>
-          <div class="dropdown-menu dropdown-menu-right" aria-labelledby="settings">
-            <%= link_to_dropdown_item('Profile', edit_dashboard_profile_path) %>
-            <%= link_to_dropdown_item('Dashboard', dashboard_root_path) %>
-            <%= link_to_dropdown_item('Create New Work', dashboard_work_form_new_path) %>
-            <div class="dropdown-divider"></div>
-            <%= link_to_dropdown_item('Logout', destroy_user_session_path) %>
-          </div>
+        <%# Fill-out the navbar with empty space so that the headings will appear %>
+        <li class="nav-item">
+          <span class='navbar-filler' />
         </li>
-
       <% end %>
+
     </ul>
   </div>
 </nav>

--- a/app/views/layouts/_user_menu.html.erb
+++ b/app/views/layouts/_user_menu.html.erb
@@ -1,0 +1,28 @@
+<% if current_user.guest? %>
+
+  <li class="nav-item">
+    <%= link_to t('blacklight.header_links.login'), new_user_session_path, class: 'nav-link' %>
+  </li>
+
+<% else %>
+
+  <li class="nav-item dropdown">
+    <a class="nav-link dropdown-toggle"
+       href="#"
+       id="topbarUsername"
+       role="button"
+       data-toggle="dropdown"
+       aria-haspopup="true"
+       aria-expanded="false">
+      <%= current_user.display_name %>
+    </a>
+    <div class="dropdown-menu dropdown-menu-right" aria-labelledby="topbarUsername">
+      <%= link_to_dropdown_item('Profile', edit_dashboard_profile_path) %>
+      <%= link_to_dropdown_item('Dashboard', dashboard_root_path) %>
+      <%= link_to_dropdown_item('Create New Work', dashboard_work_form_new_path) %>
+      <div class="dropdown-divider"></div>
+      <%= link_to_dropdown_item('Logout', destroy_user_session_path) %>
+    </div>
+  </li>
+
+<% end %>

--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -60,6 +60,7 @@
             <li class="nav-item">
               <%= link_to 'Contact', '#', class: 'nav-link' %>
             </li>
+            <%= render '/layouts/user_menu' %>
           </ul>
         </div>
       </nav>


### PR DESCRIPTION
Takes the existing user drop-down menu and moves it up to the white navbar above. Because the blue navbar will now have no menu items in it on certain pages, there needs to be a "spacer" to ensure headings will display.

Fixes #490 

![Screen Shot 2020-10-22 at 11 59 04 AM](https://user-images.githubusercontent.com/312085/96898706-0b0fd380-145e-11eb-99c3-9380ee399653.png)

## Caveats

We're trying to use the navbar in a way that it wasn't intended for: as a heading. To do this, we have to "fake" some space, which has some consequences because the page still renders it like a navbar in some cases:

![Screen Shot 2020-10-22 at 11 59 17 AM](https://user-images.githubusercontent.com/312085/96898866-3a264500-145e-11eb-880a-d8ace49434b0.png)

