### PR TITLE
Edit, Create New Version buttons on resource page

### DIFF
--- a/app/components/link_disabled_by_tooltip_component.html.erb
+++ b/app/components/link_disabled_by_tooltip_component.html.erb
@@ -1,3 +1,3 @@
-<%= link_to_if enabled?, text, path, html_options do %>
-  <%= content_tag(:span, text, html_options) %>
+<%= link_to_if enabled?, text, path, html_options_enabled do %>
+  <%= content_tag(:span, text, html_options_disabled) %>
 <% end %>

--- a/app/components/link_disabled_by_tooltip_component.html.erb
+++ b/app/components/link_disabled_by_tooltip_component.html.erb
@@ -1,0 +1,3 @@
+<%= link_to_if enabled?, text, path, html_options do %>
+  <%= content_tag(:span, text, html_options) %>
+<% end %>

--- a/app/components/link_disabled_by_tooltip_component.rb
+++ b/app/components/link_disabled_by_tooltip_component.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+class LinkDisabledByTooltipComponent < ApplicationComponent
+  def initialize(enabled:, text:, path:, tooltip:, method: :get, class_list: nil)
+    @enabled = !!enabled
+    @text = text
+    @path = path
+    @tooltip = tooltip
+    @method = method
+    @class_list = class_list || default_classes
+  end
+
+  private
+
+    attr_reader :enabled,
+                :text,
+                :path,
+                :tooltip,
+                :method,
+                :class_list
+
+    def enabled?
+      enabled
+    end
+
+    def disabled?
+      !enabled?
+    end
+
+    def html_options
+      { class: classes }
+        .deep_merge(tooltip_options)
+        .deep_merge(link_options)
+    end
+
+    def classes
+      klasses = Array.wrap(class_list).dup
+      klasses << 'disabled' if disabled?
+      klasses
+    end
+
+    def tooltip_options
+      return {} if enabled?
+
+      {
+        data: {
+          toggle: 'tooltip',
+          placement: 'bottom'
+        },
+        title: tooltip
+      }
+    end
+
+    def link_options
+      return {} if disabled?
+
+      { method: method }
+    end
+
+    def default_classes
+      %w(btn btn-outline-light btn--squish mr-lg-2)
+    end
+end

--- a/app/components/link_disabled_by_tooltip_component.rb
+++ b/app/components/link_disabled_by_tooltip_component.rb
@@ -23,38 +23,24 @@ class LinkDisabledByTooltipComponent < ApplicationComponent
       enabled
     end
 
-    def disabled?
-      !enabled?
+    def html_options_enabled
+      {
+        class: class_list,
+        method: method
+      }
     end
 
-    def html_options
-      { class: classes }
-        .deep_merge(tooltip_options)
-        .deep_merge(link_options)
-    end
-
-    def classes
-      klasses = Array.wrap(class_list).dup
-      klasses << 'disabled' if disabled?
-      klasses
-    end
-
-    def tooltip_options
-      return {} if enabled?
+    def html_options_disabled
+      classes = Array.wrap(class_list) + ['disabled']
 
       {
+        class: classes,
         data: {
           toggle: 'tooltip',
           placement: 'bottom'
         },
         title: tooltip
       }
-    end
-
-    def link_options
-      return {} if disabled?
-
-      { method: method }
     end
 
     def default_classes

--- a/app/controllers/dashboard/work_form/base_controller.rb
+++ b/app/controllers/dashboard/work_form/base_controller.rb
@@ -19,7 +19,7 @@ module Dashboard
 
         def redirect_upon_success
           if save_and_exit?
-            redirect_to dashboard_root_path,
+            redirect_to resource_path(@work_version&.uuid),
                         notice: 'Work version was successfully updated.'
           else
             redirect_to next_page_path
@@ -28,6 +28,15 @@ module Dashboard
 
         def next_page_path
           raise NotImplementedError, 'You must implement this method in your controller subclass'
+        end
+
+        helper_method :cancel_path
+        def cancel_path
+          if @work_version.present? && @work_version.persisted?
+            resource_path(@work_version&.uuid)
+          else
+            dashboard_root_path
+          end
         end
 
         def update_or_save_work_version(attributes: nil)

--- a/app/controllers/dashboard/work_form/base_controller.rb
+++ b/app/controllers/dashboard/work_form/base_controller.rb
@@ -19,7 +19,7 @@ module Dashboard
 
         def redirect_upon_success
           if save_and_exit?
-            redirect_to resource_path(@work_version&.uuid),
+            redirect_to resource_path(@work_version.uuid),
                         notice: 'Work version was successfully updated.'
           else
             redirect_to next_page_path
@@ -33,7 +33,7 @@ module Dashboard
         helper_method :cancel_path
         def cancel_path
           if @work_version.present? && @work_version.persisted?
-            resource_path(@work_version&.uuid)
+            resource_path(@work_version.uuid)
           else
             dashboard_root_path
           end

--- a/app/views/dashboard/work_form/shared/_action_footer.html.erb
+++ b/app/views/dashboard/work_form/shared/_action_footer.html.erb
@@ -3,7 +3,7 @@
 <footer class="footer footer--actions footer--fixed d-flex justify-content-center">
   <%= form.button t('dashboard.work_form.actions.save_and_exit'), name: 'save_and_exit', class: 'btn btn-outline-primary btn--rounded' %>
   <div>
-    <%= link_to t('dashboard.work_form.actions.cancel'), dashboard_root_path, class: 'btn btn-outline-dark btn--rounded' %>
+    <%= link_to t('dashboard.work_form.actions.cancel'), cancel_path, class: 'btn btn-outline-dark btn--rounded' %>
     <%= form.submit primary_text, class: 'btn btn-primary btn--rounded ml-2' %>
   </div>
 </footer>

--- a/app/views/resources/_work_version.html.erb
+++ b/app/views/resources/_work_version.html.erb
@@ -3,11 +3,35 @@
         current_version: work_version,
         work: work_version.decorated_work
       ) %>
+
+  <% if policy(work_version.work).edit? %>
+    <li class="nav-item">
+      <%= render LinkDisabledByTooltipComponent.new(
+            enabled: policy(work_version).edit?,
+            text: I18n.t('resources.edit_button.text', version: work_version.display_version_short),
+            path: dashboard_work_form_details_path(work_version),
+            tooltip: I18n.t('resources.edit_button.tooltip'),
+            class_list: 'btn btn-outline-light btn--squish mr-lg-2 qa-edit-version'
+          ) %>
+    </li>
+
+    <li class="nav-item">
+      <%= render LinkDisabledByTooltipComponent.new(
+            enabled: policy(work_version).new?(work_version.work.latest_version),
+            text: I18n.t('resources.create_button.text', version: work_version.display_version_short),
+            path: dashboard_work_work_versions_path(work_version.work),
+            method: :post,
+            tooltip: I18n.t('resources.create_button.tooltip'),
+            class_list: 'btn btn-outline-light btn--squish mr-lg-4 qa-create-draft'
+          ) %>
+    </li>
+
+  <% end %>
 <% end %>
 
 <div class="container-fluid">
 
-  <% unless work_version.latest_published_version? %>
+  <% unless (work_version.latest_published_version? || work_version.draft?) %>
     <div class="alert alert-warning" role="alert">
       <%= t 'resources.old_version.message' %>
       <%= link_to t('resources.old_version.link'),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -365,6 +365,12 @@ en:
       create: 'Create a DOI for this work'
       confirm: 'Do you want to create a DOI? This DOI will always resolve to the most recently published version of this work.'
       disable_with: 'Creating...'
+    edit_button:
+      text: 'Edit %{version}'
+      tooltip: 'Only a draft can be edited. Create a new version to add changes to the published work.'
+    create_button:
+      text: 'Create New Version From %{version}'
+      tooltip: 'A new draft version can only be created from the latest published version. Only one draft version may exist at any time.'
   shared:
     search:
       heading: 'Browse and search for works'

--- a/spec/components/link_disabled_by_tooltip_component_spec.rb
+++ b/spec/components/link_disabled_by_tooltip_component_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LinkDisabledByTooltipComponent, type: :component do
+  let(:result) { render_inline(described_class.new(enabled: enabled, text: text, path: path, tooltip: tooltip)) }
+
+  let(:text) { 'My Link Text' }
+  let(:path) { '/path/for/link' }
+  let(:tooltip) { 'The tooltip' }
+
+  let(:default_classes) { %w(btn btn-outline-light btn--squish mr-lg-2) }
+
+  context 'when enabled' do
+    let(:enabled) { true }
+    let(:element) { result.css('a').first }
+
+    it 'renders a link to the work form' do
+      expect(element).to be_present
+      expect(element[:href]).to eq path
+    end
+
+    it 'does not render a tooltip' do
+      expect(element['data-toggle']).to be_blank
+    end
+
+    it 'renders the text' do
+      expect(element.text).to eq text
+    end
+
+    it 'renders the default classes' do
+      expect(element.classes).to eq default_classes
+    end
+  end
+
+  context 'when disabled' do
+    let(:enabled) { false }
+    let(:element) { result.css('span').first }
+
+    it 'renders a span tag' do
+      expect(element).to be_present
+      expect(element[:href]).to be_blank
+    end
+
+    it 'renders a tooltip' do
+      expect(element['data-toggle']).to eq 'tooltip'
+      expect(element['title']).to eq tooltip
+    end
+
+    it 'renders the text' do
+      expect(element.text).to eq text
+    end
+
+    it 'renders the default classes + disabled ones' do
+      expect(element.classes).to contain_exactly(
+        *default_classes,
+        'disabled'
+      )
+    end
+  end
+
+  context 'when providing your own html classes' do
+    subject(:classes) { element.classes }
+
+    let(:result) { render_inline(described_class.new(
+                                   enabled: enabled,
+                                   text: text,
+                                   path: path,
+                                   tooltip: tooltip,
+                                   class_list: 'my custom classes'
+                                 )) }
+    let(:element) { result.css('*').first }
+
+    context 'when enabled' do
+      let(:enabled) {  true }
+
+      it { is_expected.to match_array(%w(my custom classes)) }
+    end
+
+    context 'when disabled' do
+      let(:enabled) { false }
+
+      it { is_expected.to match_array(%w(my custom classes disabled)) }
+    end
+  end
+
+  context 'when providing your own http method' do
+    let(:result) { render_inline(described_class.new(
+                                   enabled: enabled,
+                                   text: text,
+                                   path: path,
+                                   tooltip: tooltip,
+                                   method: :post
+                                 )) }
+    let(:element) { result.css('a').first }
+    let(:enabled) { true }
+
+    it "triggers Rails' special behavior for post links" do
+      expect(element['data-method']).to eq 'post'
+    end
+  end
+end

--- a/spec/features/publish_new_work_spec.rb
+++ b/spec/features/publish_new_work_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe 'Publishing a work', with_user: :user do
         FeatureHelpers::WorkForm.fill_in_minimal_work_details_for_draft(metadata)
         FeatureHelpers::WorkForm.save_as_draft_and_exit
 
-        expect(page).to have_current_path(dashboard_root_path)
         expect(Work.count).to eq(initial_work_count + 1)
 
         new_work = Work.last
@@ -28,6 +27,8 @@ RSpec.describe 'Publishing a work', with_user: :user do
         expect(page).to have_content(metadata[:title])
         expect(new_work_version.title).to eq metadata[:title]
         expect(new_work_version.version_number).to eq 1
+
+        expect(page).to have_current_path(resource_path(new_work_version.uuid))
       end
     end
 
@@ -79,7 +80,7 @@ RSpec.describe 'Publishing a work', with_user: :user do
         FeatureHelpers::WorkForm.fill_in_minimal_work_details_for_draft(metadata)
         FeatureHelpers::WorkForm.save_as_draft_and_exit
 
-        expect(page).to have_current_path(dashboard_root_path)
+        expect(page).to have_current_path(resource_path(work_version.uuid))
         expect(Work.count).to eq(initial_work_count)
 
         work_version.reload

--- a/spec/features/resources_spec.rb
+++ b/spec/features/resources_spec.rb
@@ -6,19 +6,82 @@ RSpec.describe 'Public Resources', type: :feature do
   describe 'given a work' do
     let(:work) { create :work, has_draft: false, versions_count: 2 }
 
-    let(:v1) { work.versions.first }
-    let(:v2) { work.versions.last }
+    let(:v1) { work.versions[0] }
+    let(:v2) { work.versions[1] }
 
-    it 'displays the public resource page for the work' do
-      visit resource_path(work.uuid)
+    context 'when I am not logged in (i.e. as a public user)' do
+      it 'displays the public resource page for the work' do
+        visit resource_path(work.uuid)
 
-      expect(page).to have_content(v2.title)
+        expect(page).to have_content(v2.title)
 
-      ## Navigate to an old version
-      within('.navbar .dropdown--versions') { click_on 'V1' }
+        ## Does not have edit controls
+        within('header') do
+          expect(page).not_to have_content(I18n.t('resources.edit_button.text', version: 'V2'))
+        end
 
-      expect(page).to have_content(v1.title)
-      expect(page).to have_content(I18n.t('resources.old_version.message'))
+        ## Navigate to an old version
+        within('.navbar .dropdown--versions') { click_on 'V1' }
+
+        expect(page).to have_content(v1.title)
+        expect(page).to have_content(I18n.t('resources.old_version.message'))
+      end
+    end
+
+    context 'when logged in as the resource owner', with_user: :user do
+      let(:user) { work.depositor.user }
+
+      before { visit resource_path(work.uuid) }
+
+      context 'when no draft exists' do
+        it 'displays edit controls on the resource page' do
+          expect(page).to have_content(v2.title) # Sanity
+
+          within('header') do
+            ## Edit controls are visible
+            expect(page).to have_content(I18n.t('resources.edit_button.text', version: 'V2'))
+              .and have_content(I18n.t('resources.create_button.text', version: 'V2'))
+
+            ## Edit button is disabled, create draft button is enabled
+            expect(page).to have_selector('.qa-edit-version.disabled')
+            expect(page).to have_selector('.qa-create-draft')
+            expect(page).not_to have_selector('.qa-create-draft.disabled')
+          end
+
+          ## Navigate to an old version
+          within('.navbar .dropdown--versions') { click_on 'V1' }
+
+          within('header') do
+            ## Edit and create draft buttons are now both disabled
+            expect(page).to have_selector('.qa-edit-version.disabled')
+            expect(page).to have_selector('.qa-create-draft.disabled')
+          end
+        end
+      end
+
+      context 'when a draft exists' do
+        let(:work) { create :work, has_draft: true, versions_count: 3 }
+
+        it 'displays edit controls on the resource page' do
+          expect(page).to have_content(v2.title) # Sanity
+
+          within('header') do
+            ## Edit and create buttons are disabled
+            expect(page).to have_selector('.qa-edit-version.disabled')
+            expect(page).to have_selector('.qa-create-draft.disabled')
+          end
+
+          ## Navigate to draft version
+          within('.navbar .dropdown--versions') { click_on 'V3' }
+
+          within('header') do
+            ## Edit button enabled, create button disabled
+            expect(page).to have_selector('.qa-edit-version')
+            expect(page).not_to have_selector('.qa-edit-version.disabled')
+            expect(page).to have_selector('.qa-create-draft.disabled')
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
If the user is logged in and has the permissions, they can now edit a draft, or create a new draft from the resource page. 

Eventually we would like to remove those buttons from the Dashboard "search results" view and have them only on the resource page. To further this goal, I added a second commit that changes the paths of the work form's Cancel and Save Draft & Exit buttons to go to the resource page rather than back to the dashboard root—this was Seth's suggestion (which I agree with) when we were going through the UX last week.

Closes #491 