### PR TITLE
Add error handling to Bugsnag for 'ok_computer' actions

### DIFF
--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -5,4 +5,10 @@ Bugsnag.configure do |config|
   config.release_stage = ENV.fetch('BUGSNAG_RELEASE_STAGE', 'development')
 
   config.discard_classes << 'ActionController::UnknownFormat'
+
+  config.add_on_error(proc do |event|
+    action = event.request&.dig(:railsAction)
+
+    event.ignore! if action&.start_with?('ok_computer')
+  end)
 end


### PR DESCRIPTION
This pull request introduces an improvement to error reporting by refining which errors are sent to Bugsnag. Specifically, it adds logic to ignore errors triggered by certain health check actions, reducing noise in error monitoring.

Error reporting refinement:

* Updated the Bugsnag configuration in `bugsnag.rb` to ignore errors for requests where the Rails action starts with `ok_computer`, preventing health check endpoints from generating unnecessary error reports.